### PR TITLE
Add semantikon as dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy==2.3.1",
-    "semanticon==0.0.21" 
+    "semantikon==0.0.21" 
 ]
 dynamic = [ "version",]
 authors = [


### PR DESCRIPTION
I just wanted to understand the dependencies and did not find semantikon in the toml. I do understand it correctly, that semantikon is a required dependency?!