### PR TITLE
Get and assign values directly from the dot notation

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -1379,7 +1379,7 @@ def _get_entry(data: dict[str, Any], key: str) -> Any:
 
     Returns:
         Any: The value at the specified key path.
-    
+
     Raises:
         KeyError: If the key path does not exist in the dictionary.
     """

--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -1359,6 +1359,8 @@ def separate_data(
     data_dict = {}
     for key, hash_data in hash_dict.items():
         try:
+            if not key.startswith("outputs") or not key.startswith("inputs"):
+                key = "nodes." + key
             value = _get_entry(workflow_dict, key + ".value")
             _set_entry(workflow_dict, key + ".value", hash_data)
             data_dict[hash_data] = value

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -939,9 +939,7 @@ class TestWorkflow(unittest.TestCase):
 
         workflow_dict = fwf.get_workflow_dict(yet_another_workflow)
         self.assertEqual(fwf._get_entry(workflow_dict, "inputs.a.default"), 10)
-        self.assertRaises(
-            KeyError, fwf._get_entry, workflow_dict, "inputs.x.default"
-        )
+        self.assertRaises(KeyError, fwf._get_entry, workflow_dict, "inputs.x.default")
         fwf._set_entry(workflow_dict, "inputs.a.value", 42)
         self.assertEqual(fwf._get_entry(workflow_dict, "inputs.a.value"), 42)
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -930,6 +930,21 @@ class TestWorkflow(unittest.TestCase):
             workflow_dict["nodes"]["add_0"]["outputs"]["output"]["value"], data
         )
 
+    def test_get_and_set_entry(self):
+
+        def yet_another_workflow(a=10, b=20):
+            x = add(a, b)
+            y = multiply(x, b)
+            return x, y
+
+        workflow_dict = fwf.get_workflow_dict(yet_another_workflow)
+        self.assertEqual(fwf._get_entry(workflow_dict, "inputs.a.default"), 10)
+        self.assertRaises(
+            KeyError, fwf._get_entry, workflow_dict, "inputs.x.default"
+        )
+        fwf._set_entry(workflow_dict, "inputs.a.value", 42)
+        self.assertEqual(fwf._get_entry(workflow_dict, "inputs.a.value"), 42)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The implementation in #8 looped over all the nodes in the workflow dictionary, which was inefficient and dangerous, because global outputs had to be accessed separately. I introduced get and set entry, in order to facilitate data exchange.