### PR TITLE
Make it possible to append original functions to the macro nodes

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -790,6 +790,8 @@ def get_workflow_dict(func: Callable, with_function: bool = False) -> dict[str, 
     Returns:
         dict: A dictionary representation of the workflow, including inputs,
             outputs, nodes, edges, and label.
+        with_function (bool): Whether to include the function object in the
+            workflow dictionary.
     """
     graph, f_dict, inputs = analyze_function(func)
     nodes = _get_nodes(f_dict, _get_output_counts(graph), with_function=with_function)


### PR DESCRIPTION
Since the new `flowrep` representation does not have inputs and outputs, the original function for the macro node is required, which can now be exported in the dictionary via `with_function = True`