### PR TITLE
Make `serialize_workflow` private to overwrite the public one in `semantikon`

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -565,6 +565,8 @@ def _get_nodes(
     result = {}
     for label, function in data.items():
         if isinstance(function["function"], FunctionWithWorkflow):
+            # To do: Not to use the private function (currently needed because
+            # it is replaced in semantikon)
             result[label] = function["function"]._serialize_workflow(with_outputs=True)
             result[label]["label"] = label
             if with_function:


### PR DESCRIPTION
The behaviour should differ depending on whether `flowrep.workflow` is used or `semantikon.workflow`. This is more like a temporary solution that I'm not yet perfectly convinced of, since I needed to use the private function outside of the class (which is required basically because I don't want to expose too many methods to the user)