### PR TITLE
Specify recipe element names

### DIFF
--- a/flowrep/model.py
+++ b/flowrep/model.py
@@ -1,3 +1,3 @@
 from typing import Literal
 
-RecipeElementType = Literal["function", "workflow", "for", "while", "try", "if"]
+RecipeElementType = Literal["atomic", "workflow", "for", "while", "try", "if"]


### PR DESCRIPTION
Source code is trivial here. I just want to lock down the string values for what we're naming these things. I.e. when we have a recipe entry in some JSON file or whatever and it says `type: ...` what appears on the other side?

For the logical elements, I'm super comfortable just labelling them based on their operative name **for**, **while**-do, **try**-except[0-n]-finally, and **if**-elif[0-n]-then[+0-n]-else.

The main sticking points then are the atomic nodes and the subgraph nodes. I'm trying to avoid the term "node" here, because IMO _all_ these are representable as a "node" -- including subgraphs! That's the whole point of allowing nestable and hierarchical graphs.

I don't want to spend ages agonizing over this, but I at least want to spend a hot second getting something several of us can live with.

Alternatives I'm fine with and can think of:
- function: atomic, step
- workflow: macro, graph