### PR TITLE
[patch] Use argument names for the inputs instead of labels

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -1115,7 +1115,7 @@ def get_hashed_node_dict(workflow_dict: dict[str, dict]) -> dict[str, Any]:
         hash_dict_tmp["node"]["connected_inputs"] = []
         for inp in G.predecessors(node):
             data = G.nodes[inp]
-            inp_name = data.get("label", inp.split("-")[-1])
+            inp_name = inp.split("-")[-1]
             if "hash" in data:
                 hash_dict_tmp["inputs"][inp_name] = data["hash"]
                 hash_dict_tmp["node"]["connected_inputs"].append(inp_name)


### PR DESCRIPTION
I haven't talked about it with the other people, but it doesn't appear particularly useful to have user-defined labels for the inputs since they don't mean anything in python, so I use the argument names for the hashing algorithm instead. This creates a sort of asymmetry with the output, but I guess it's fine?