### PR TITLE
Use the control flow name instead of injected_ABC

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -477,7 +477,7 @@ def _get_subgraphs(graph: nx.DiGraph, cf_graph: nx.DiGraph) -> dict[str, nx.DiGr
     subgraphs = _split_graphs_into_subgraphs(graph)
     for key in list(topological_sort(cf_graph))[::-1]:
         subgraph = subgraphs[key]
-        node_name = key.replace("/", "_")
+        node_name = key
         io_ = _detect_io_variables_from_control_flow(graph, subgraph)
         for parent_graph_name in cf_graph.predecessors(key):
             parent_graph = subgraphs[parent_graph_name]
@@ -663,7 +663,7 @@ def _get_edges(
             edges.append([f"{edge[0]}.outputs.{tag}", edge[1]])
             nodes_to_remove.append(edge[1])
     new_graph = _remove_and_reconnect_nodes(nx.DiGraph(edges), nodes_to_remove)
-    return list(new_graph.edges)
+    return [tuple(e.split("/")[-1] for e in edge) for edge in new_graph.edges]
 
 
 def get_node_dict(
@@ -746,23 +746,24 @@ def _nest_nodes(
     injected_nodes: dict[str, Any] = {}
     for cf_key in list(topological_sort(cf_graph))[::-1]:
         subgraph = nx.relabel_nodes(subgraphs[cf_key], test_dict)
-        new_key = cf_key.replace("/", "_") if len(cf_key) > 0 else cf_key
+        new_key = cf_key if len(cf_key) > 0 else cf_key
         current_nodes = {}
         output_mapping = {}
         for key in _extract_functions_from_graph(subgraphs[cf_key]):
+            dict_key = key.split("/")[-1]
             if key in test_dict:
                 current_nodes[test_dict[key]] = nodes[key]
             elif key in nodes:
-                current_nodes[key] = nodes[key]
-                if "outputs" in current_nodes[key]:
+                current_nodes[dict_key] = nodes[key]
+                if "outputs" in current_nodes[dict_key]:
                     output_mapping[key] = list(current_nodes[key]["outputs"].keys())
-                    current_nodes[key].pop("outputs")
+                    current_nodes[dict_key].pop("outputs")
             else:
-                current_nodes[key] = injected_nodes.pop(key)
+                current_nodes[dict_key] = injected_nodes.pop(key)
         injected_nodes[new_key] = {
             "nodes": current_nodes,
             "edges": _get_edges(graph=subgraph, output_mapping=output_mapping),
-            "label": new_key,
+            "label": new_key.split("/")[-1],
             "type": cf_key.split("/")[-1].split("_")[0] if cf_key != "" else "Workflow",
         }
         for tag in ["test", "iter"]:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -501,10 +501,10 @@ class TestWorkflow(unittest.TestCase):
     def test_multiple_nested_workflow(self):
         data = fwf.get_workflow_dict(multiple_nested_workflow)
         self.assertIn("while_0", data["nodes"])
-        self.assertIn("while_0_while_0", data["nodes"]["while_0"]["nodes"])
-        self.assertIn("while_0_for_0", data["nodes"]["while_0"]["nodes"])
+        self.assertIn("while_0", data["nodes"]["while_0"]["nodes"])
+        self.assertIn("for_0", data["nodes"]["while_0"]["nodes"])
         self.assertEqual(
-            data["nodes"]["while_0"]["nodes"]["while_0_for_0"]["type"],
+            data["nodes"]["while_0"]["nodes"]["for_0"]["type"],
             "for",
         )
 


### PR DESCRIPTION
Currently, the control flows get node names like `injected_If_0`, `injected_While_1` etc., but it makes more sense to use `if_0`, `while_1` etc., because the underlying python function cannot be called `def if` or `def while`, while `def injected_If` or `def injected_While` might potentially appear.