### PR TITLE
Do not use nested names in the child nodes

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -663,7 +663,7 @@ def _get_edges(
             edges.append([f"{edge[0]}.outputs.{tag}", edge[1]])
             nodes_to_remove.append(edge[1])
     new_graph = _remove_and_reconnect_nodes(nx.DiGraph(edges), nodes_to_remove)
-    return list(new_graph.edges)
+    return [tuple(e.split("/")[-1] for e in edge) for edge in new_graph.edges]
 
 
 def get_node_dict(
@@ -750,19 +750,20 @@ def _nest_nodes(
         current_nodes = {}
         output_mapping = {}
         for key in _extract_functions_from_graph(subgraphs[cf_key]):
+            dict_key = key.split("/")[-1]
             if key in test_dict:
                 current_nodes[test_dict[key]] = nodes[key]
             elif key in nodes:
-                current_nodes[key] = nodes[key]
-                if "outputs" in current_nodes[key]:
+                current_nodes[dict_key] = nodes[key]
+                if "outputs" in current_nodes[dict_key]:
                     output_mapping[key] = list(current_nodes[key]["outputs"].keys())
-                    current_nodes[key].pop("outputs")
+                    current_nodes[dict_key].pop("outputs")
             else:
-                current_nodes[key] = injected_nodes.pop(key)
+                current_nodes[dict_key] = injected_nodes.pop(key)
         injected_nodes[new_key] = {
             "nodes": current_nodes,
             "edges": _get_edges(graph=subgraph, output_mapping=output_mapping),
-            "label": new_key,
+            "label": new_key.split("/")[-1],
             "type": cf_key.split("/")[-1].split("_")[0] if cf_key != "" else "Workflow",
         }
         for tag in ["test", "iter"]:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -501,10 +501,10 @@ class TestWorkflow(unittest.TestCase):
     def test_multiple_nested_workflow(self):
         data = fwf.get_workflow_dict(multiple_nested_workflow)
         self.assertIn("while_0", data["nodes"])
-        self.assertIn("while_0_while_0", data["nodes"]["while_0"]["nodes"])
-        self.assertIn("while_0_for_0", data["nodes"]["while_0"]["nodes"])
+        self.assertIn("while_0", data["nodes"]["while_0"]["nodes"])
+        self.assertIn("for_0", data["nodes"]["while_0"]["nodes"])
         self.assertEqual(
-            data["nodes"]["while_0"]["nodes"]["while_0_for_0"]["type"],
+            data["nodes"]["while_0"]["nodes"]["for_0"]["type"],
             "for",
         )
 


### PR DESCRIPTION
Example:

```python
def add(x: float = 2.0, y: float = 1) -> float:
    return x + y


def multiply(x: float, y: float = 5) -> float:
    return x * y

def my_condition(X, Y):
    return X + Y < 100


def my_for_loop(a=10, b=20):
    return range(int(a), int(b))


@fwf.workflow
def multiple_nested_workflow(a=1, b=2, c=3):
    d = add(a, b)
    e = multiply(b, c)
    f = add(c, d)

    while my_condition(d, e):
        d = add(d, b)
        e = multiply(e, c)

        for ii in my_for_loop(a, d):
            a = add(a, ii)
            d = multiply(b, e)
    return d
```

Before:

```python
print(print(wf["nodes"]["while_0"]["nodes"].keys()))
```

Output: `dict_keys(['multiply_1', 'while_0_for_0', 'add_2'])`

After this PR:

Output `dict_keys(['multiply_1', 'for_0', 'add_2'])`

Basically the nodes inside the nested nodes were carrying names of the parents nodes (such as the `while_0` before `for_0`), even though the child node should not have to care about the parent nodes.