### PR TITLE
Remove label from the workflow graphs

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -1076,7 +1076,9 @@ def get_workflow_graph(workflow_dict: dict[str, Any]) -> nx.DiGraph:
     for key, node in workflow_dict["nodes"].items():
         assert node["type"] in ["Function", "Workflow"]
         if node["type"] == "Workflow":
-            G = nx.union(get_workflow_graph(node), G)
+            child_G = get_workflow_graph(node)
+            mapping = {n: key + "." + n for n in child_G.nodes()}
+            G = nx.union(nx.relabel_nodes(child_G, mapping), G)
             nodes_to_delete.append(key)
         else:
             G.add_node(key, step="node", function=node["function"])
@@ -1095,8 +1097,7 @@ def get_workflow_graph(workflow_dict: dict[str, Any]) -> nx.DiGraph:
             G.nodes[node]["step"] = "input"
         elif node.split(".")[-2] == "outputs":
             G.nodes[node]["step"] = "output"
-    mapping = {n: workflow_dict["label"] + "." + n for n in G.nodes()}
-    return nx.relabel_nodes(G, mapping, copy=True)
+    return G
 
 
 def get_hashed_node_dict(workflow_dict: dict[str, dict]) -> dict[str, Any]:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -638,8 +638,8 @@ class TestWorkflow(unittest.TestCase):
             self.assertIsInstance(node["hash"], str)
             self.assertEqual(len(node["hash"]), 64)
         self.assertTrue(
-            hashed_dict["workflow_with_data.multiply_0"]["inputs"]["x"].endswith(
-                hashed_dict["workflow_with_data.add_0"]["hash"] + "@output"
+            hashed_dict["multiply_0"]["inputs"]["x"].endswith(
+                hashed_dict["add_0"]["hash"] + "@output"
             )
         )
         workflow_dict = workflow_with_data.serialize_workflow()
@@ -653,7 +653,7 @@ class TestWorkflow(unittest.TestCase):
         )
         workflow_dict = example_workflow.run(a=10, b=20)
         hashed_dict = fwf.get_hashed_node_dict(workflow_dict)
-        self.assertIn("example_workflow.example_macro_0.operation_0", hashed_dict)
+        self.assertIn("example_macro_0.operation_0", hashed_dict)
 
         @fwf.workflow
         def workflow_with_class(test: TestClass):


### PR DESCRIPTION
@liamhuber and I agreed to remove `label` from the workflow representation in `flowrep` (while in `semantikon` it's gonna stay). I removed it from the workflow graphs because it anyway annoys me when I plot the graph.