### PR TITLE
Replace uniqueness test

### DIFF
--- a/flowrep/models/nodes/for_model.py
+++ b/flowrep/models/nodes/for_model.py
@@ -72,20 +72,15 @@ class ForNode(base_models.NodeModel):
     body_node: helper_models.LabeledNode
     input_edges: dict[edge_models.TargetHandle, edge_models.InputSource]
     output_edges: dict[edge_models.OutputTarget, edge_models.SourceHandle]
-    nested_ports: list[base_models.Label] = pydantic.Field(default_factory=list)
-    zipped_ports: list[base_models.Label] = pydantic.Field(default_factory=list)
+    nested_ports: base_models.UniqueList[base_models.Label] = pydantic.Field(
+        default_factory=list
+    )
+    zipped_ports: base_models.UniqueList[base_models.Label] = pydantic.Field(
+        default_factory=list
+    )
     transfer_edges: dict[edge_models.OutputTarget, edge_models.InputSource] = (
         pydantic.Field(default_factory=dict)
     )
-
-    @pydantic.field_validator("nested_ports", "zipped_ports")
-    @classmethod
-    def validate_single_appearance(cls, v, info):
-        if not base_models._has_unique_elements(v):
-            raise ValueError(
-                f"'{info.field_name}' must contain unique values, but got {v}."
-            )
-        return v
 
     @pydantic.model_validator(mode="after")
     def validate_some_loop(self):

--- a/flowrep/models/nodes/try_model.py
+++ b/flowrep/models/nodes/try_model.py
@@ -77,8 +77,7 @@ class TryNode(base_models.NodeModel):
     @pydantic.model_validator(mode="after")
     def validate_unique_labels(self):
         labels = [self.try_node.label] + [c.body.label for c in self.exception_cases]
-        if not base_models._has_unique_elements(labels):
-            raise ValueError(f"All node labels must be unique. Got: {labels}")
+        base_models.validate_unique(labels)
         return self
 
     @pydantic.model_validator(mode="after")
@@ -126,11 +125,7 @@ class TryNode(base_models.NodeModel):
                     f"output_edges_matrix['{target.port}'] sources must be from "
                     f"{expected_nodes}, got invalid: {invalid_nodes}"
                 )
-            if not base_models._has_unique_elements(source_nodes):
-                raise ValueError(
-                    f"output_edges_matrix['{target.port}'] must have at most one "
-                    f"source from each other node. Got duplicates in: {source_nodes}"
-                )
+            base_models.validate_unique(source_nodes)
             for source in sources:
                 node = self.prospective_nodes[source.node]
                 if source.port not in node.outputs:

--- a/flowrep/models/nodes/workflow_model.py
+++ b/flowrep/models/nodes/workflow_model.py
@@ -26,12 +26,6 @@ class WorkflowNode(base_models.NodeModel):
     edges: dict[edge_models.TargetHandle, edge_models.SourceHandle]
     output_edges: dict[edge_models.OutputTarget, edge_models.SourceHandle]
 
-    @pydantic.field_validator("nodes")
-    @classmethod
-    def validate_node_labels(cls, v, info):
-        cls.validate_io_labels(list(v.keys()), info)
-        return v
-
     @pydantic.model_validator(mode="after")
     def validate_edge_references(self):
         """Validate that edges reference existing nodes and valid ports."""


### PR DESCRIPTION
And use it in a new unique type for lists to offload some of the explicit validation to pydantic's type matching