### PR TITLE
Allow inputs to pass through

### DIFF
--- a/flowrep/models/edge_models.py
+++ b/flowrep/models/edge_models.py
@@ -52,4 +52,5 @@ class OutputTarget(HandleModel):
 
 Edges = dict[TargetHandle, SourceHandle]  # Communicate between siblings
 InputEdges = dict[TargetHandle, InputSource]  # Pass data into a subgraph
-OutputEdges = dict[OutputTarget, SourceHandle]  # Extract data from a subgraph
+OutputEdges = dict[OutputTarget, SourceHandle | InputSource]
+# Extract data from a subgraph, or allow it to pass through

--- a/flowrep/models/nodes/for_model.py
+++ b/flowrep/models/nodes/for_model.py
@@ -99,6 +99,7 @@ class ForNode(base_models.NodeModel):
         subgraph_validation.validate_output_edge_sources(
             self.output_edges.values(),
             self.prospective_nodes,
+            self.inputs,
         )
         return self
 

--- a/flowrep/models/nodes/if_model.py
+++ b/flowrep/models/nodes/if_model.py
@@ -96,6 +96,7 @@ class IfNode(base_models.NodeModel):
             subgraph_validation.validate_output_edge_sources(
                 prospective_sources,
                 self.prospective_nodes,
+                self.inputs,
             )
         subgraph_validation.validate_output_edge_targets(
             self.prospective_output_edges, self.outputs

--- a/flowrep/models/nodes/try_model.py
+++ b/flowrep/models/nodes/try_model.py
@@ -90,6 +90,7 @@ class TryNode(base_models.NodeModel):
             subgraph_validation.validate_output_edge_sources(
                 prospective_sources,
                 self.prospective_nodes,
+                self.inputs,
             )
         subgraph_validation.validate_output_edge_targets(
             self.prospective_output_edges, self.outputs

--- a/flowrep/models/nodes/while_model.py
+++ b/flowrep/models/nodes/while_model.py
@@ -89,6 +89,7 @@ class WhileNode(base_models.NodeModel):
         subgraph_validation.validate_output_edge_sources(
             self.output_edges.values(),
             self.prospective_nodes,
+            self.inputs,
         )
         return self
 

--- a/flowrep/models/nodes/workflow_model.py
+++ b/flowrep/models/nodes/workflow_model.py
@@ -44,7 +44,7 @@ class WorkflowNode(base_models.NodeModel):
         subgraph_validation.validate_input_edge_sources(self.input_edges, self.inputs)
         subgraph_validation.validate_input_edge_targets(self.input_edges, self.nodes)
         subgraph_validation.validate_output_edge_sources(
-            self.output_edges.values(), self.nodes
+            self.output_edges.values(), self.nodes, self.inputs
         )
         subgraph_validation.validate_output_edge_targets(
             self.output_edges, self.outputs

--- a/flowrep/models/subgraph_validation.py
+++ b/flowrep/models/subgraph_validation.py
@@ -94,13 +94,23 @@ def validate_output_edge_targets(
 
 
 def validate_output_edge_sources(
-    sources: Collection[edge_models.SourceHandle],
+    sources: Collection[edge_models.SourceHandle | edge_models.InputSource],
     source_nodes: NodesAlias,
+    inputs: base_models.Labels,
 ) -> None:
-    if invalid_nodes := {s.serialize() for s in sources if s.node not in source_nodes}:
+    if invalid_nodes := {
+        s.serialize()
+        for s in sources
+        if s.node is not None and s.node not in source_nodes
+    }:
         raise ValueError(f"Invalid output source nodes: {invalid_nodes}")
     if invalid_ports := {
-        s.serialize() for s in sources if s.port not in source_nodes[s.node].outputs
+        s.serialize()
+        for s in sources
+        if (
+            (s.node is None and s.port not in inputs)
+            or (s.node is not None and s.port not in source_nodes[s.node].outputs)
+        )
     }:
         raise ValueError(f"Invalid output source ports: {invalid_ports}")
 

--- a/tests/unit/models/nodes/test_workflow_model.py
+++ b/tests/unit/models/nodes/test_workflow_model.py
@@ -155,6 +155,20 @@ class TestWorkflowNodeOutputEdges(unittest.TestCase):
         )
         self.assertEqual(len(wf.output_edges), 1)
 
+    def test_pass_through_output_edge(self):
+        """Output edge from input directly to output."""
+        wf = workflow_model.WorkflowNode(
+            inputs=["x"],
+            outputs=["y"],
+            nodes={},
+            input_edges={},
+            edges={},
+            output_edges={
+                edge_models.OutputTarget(port="y"): edge_models.InputSource(port="x"),
+            },
+        )
+        self.assertEqual(len(wf.output_edges), 1)
+
     def test_output_edge_invalid_workflow_output(self):
         """Output edge referencing nonexistent workflow output."""
         with self.assertRaises(pydantic.ValidationError) as ctx:

--- a/tests/unit/models/test_subgraph_validation.py
+++ b/tests/unit/models/test_subgraph_validation.py
@@ -114,20 +114,34 @@ class TestValidateOutputEdgeSources(unittest.TestCase):
     def test_valid_output_sources(self):
         nodes = {"a": MockNode(inputs=["inp"], outputs=["out"])}
         sources = [edge_models.SourceHandle(node="a", port="out")]
-        subgraph_validation.validate_output_edge_sources(sources, nodes)
+        subgraph_validation.validate_output_edge_sources(sources, nodes, [])
+
+    def test_valid_pass_through_output_source(self):
+        nodes = {"a": MockNode(inputs=["inp"], outputs=["out"])}
+        inputs = ["wf_inp"]
+        sources = [edge_models.InputSource(port="wf_inp")]
+        subgraph_validation.validate_output_edge_sources(sources, nodes, inputs)
 
     def test_invalid_source_node(self):
         nodes = {"a": MockNode(inputs=["inp"], outputs=["out"])}
         sources = [edge_models.SourceHandle(node="nonexistent", port="out")]
         with self.assertRaises(ValueError) as ctx:
-            subgraph_validation.validate_output_edge_sources(sources, nodes)
+            subgraph_validation.validate_output_edge_sources(sources, nodes, [])
         self.assertIn("nonexistent", str(ctx.exception))
+
+    def test_invalid_pass_through_output_source(self):
+        nodes = {"a": MockNode(inputs=["inp"], outputs=["out"])}
+        inputs = ["wf_inp"]
+        sources = [edge_models.InputSource(port="not_an_input")]
+        with self.assertRaises(ValueError) as ctx:
+            subgraph_validation.validate_output_edge_sources(sources, nodes, inputs)
+        self.assertIn("not_an_input", str(ctx.exception))
 
     def test_invalid_source_port(self):
         nodes = {"a": MockNode(inputs=["inp"], outputs=["out"])}
         sources = [edge_models.SourceHandle(node="a", port="wrong_port")]
         with self.assertRaises(ValueError) as ctx:
-            subgraph_validation.validate_output_edge_sources(sources, nodes)
+            subgraph_validation.validate_output_edge_sources(sources, nodes, [])
         self.assertIn("wrong_port", str(ctx.exception))
 
     def test_multiple_sources(self):
@@ -139,11 +153,11 @@ class TestValidateOutputEdgeSources(unittest.TestCase):
             edge_models.SourceHandle(node="a", port="out1"),
             edge_models.SourceHandle(node="b", port="out"),
         ]
-        subgraph_validation.validate_output_edge_sources(sources, nodes)
+        subgraph_validation.validate_output_edge_sources(sources, nodes, [])
 
     def test_empty_sources(self):
         nodes = {"a": MockNode(inputs=[], outputs=["out"])}
-        subgraph_validation.validate_output_edge_sources([], nodes)
+        subgraph_validation.validate_output_edge_sources([], nodes, [])
 
 
 class TestValidateProspectiveSources(unittest.TestCase):


### PR DESCRIPTION
To outputs, by extending the type to include InputSource in addition to SourceHandle, and updating the validation to compare against available input port labels.

It was originally forbidden because passing the input of a macro straight through to the output without touching it is dumb and wasteful, since you already have that value available upstream and could just bypass your subgraph! But actually, being able to do this is useful, e.g. for fallback values i a while-loop, where we want to return the input in case the body node never runs. As a silver lining, it also lets us define a unity operation without writing python, which is fun enough. Anyway, long story short it doesn't really hurt, and helps for the control flows.