### PR TITLE
Take back test and iter and use atomic

### DIFF
--- a/flowrep/workflow.py
+++ b/flowrep/workflow.py
@@ -584,9 +584,7 @@ def _get_nodes(
             if with_function:
                 result[label]["function"] = function["function"].func
         else:
-            t = function.get("control_flow", "atomic").split("-", 1)[-1]
-            t = {"body": "atomic"}.get(t, t)
-            result[label] = {"function": function["function"], "type": t}
+            result[label] = {"function": function["function"], "type": "atomic"}
     return result
 
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -418,7 +418,7 @@ class TestWorkflow(unittest.TestCase):
     def test_workflow_with_while(self):
         wf = fwf.workflow(workflow_with_while).serialize_workflow()
         self.assertIn("while_0", wf["nodes"])
-        self.assertEqual(wf["nodes"]["while_0"]["test"]["type"], "test")
+        self.assertEqual(wf["nodes"]["while_0"]["test"]["type"], "atomic")
         self.assertEqual(
             sorted(wf["nodes"]["while_0"]["edges"]),
             sorted(
@@ -490,7 +490,7 @@ class TestWorkflow(unittest.TestCase):
         data = fwf.get_workflow_dict(workflow_with_for)
         self.assertIn("for_0", data["nodes"])
         self.assertIn("iter", data["nodes"]["for_0"])
-        self.assertEqual(data["nodes"]["for_0"]["iter"]["type"], "iter")
+        self.assertEqual(data["nodes"]["for_0"]["iter"]["type"], "atomic")
         self.assertEqual(
             sorted(data["edges"]),
             sorted(


### PR DESCRIPTION
Following [@liamhuber's comment](https://github.com/pyiron/flowrep/pull/116#issuecomment-3879085927) I'm reversing part of #116: `"type": "test"` and `"type": "iter"` are `"type": "atomic"` again