### PR TITLE
Replace version fields with VersionInfo

### DIFF
--- a/flowrep/models/nodes/atomic_model.py
+++ b/flowrep/models/nodes/atomic_model.py
@@ -4,9 +4,9 @@ from enum import StrEnum
 from typing import Literal
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models
-from flowrep.models.nodes import helper_models
 
 
 class UnpackMode(StrEnum):
@@ -51,10 +51,13 @@ class AtomicNode(base_models.NodeModel):
     type: Literal[base_models.RecipeElementType.ATOMIC] = pydantic.Field(
         default=base_models.RecipeElementType.ATOMIC, frozen=True
     )
-    fully_qualified_name: helper_models.FullyQualifiedName
-    version: str | None = None
+    source: versions.VersionInfo
     source_code: str | None = None
     unpack_mode: UnpackMode = UnpackMode.TUPLE
+
+    @property
+    def fully_qualified_name(self) -> str:
+        return self.source.fully_qualified_name
 
     @pydantic.model_validator(mode="after")
     def check_outputs_when_not_unpacking(self):

--- a/flowrep/models/nodes/helper_models.py
+++ b/flowrep/models/nodes/helper_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING
 
 import pydantic
 
@@ -14,21 +14,6 @@ if TYPE_CHECKING:
     # Better to nonetheless leave the references as strings to make sure the pydantic
     # handling of forward references is maximally robust through the model_rebuild()
     # Ultimately, just silence ruff as needed
-
-
-def _validate_fully_qualified_name(v: str) -> str:
-    if not v or len(v.split(".")) < 2 or not all(part for part in v.split(".")):
-        msg = (
-            f"'fully_qualified_name' must be a non-empty string "
-            f"in the format 'module.qualname' with at least one period. Got {v}"
-        )
-        raise ValueError(msg)
-    return v
-
-
-FullyQualifiedName = Annotated[
-    str, pydantic.AfterValidator(_validate_fully_qualified_name)
-]
 
 
 class LabeledNode(pydantic.BaseModel):

--- a/flowrep/models/nodes/workflow_model.py
+++ b/flowrep/models/nodes/workflow_model.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models, edge_models, subgraph_validation
-from flowrep.models.nodes import helper_models
 
 if TYPE_CHECKING:
     from flowrep.models.nodes.union import Nodes
@@ -43,9 +43,12 @@ class WorkflowNode(base_models.NodeModel):
     input_edges: edge_models.InputEdges
     edges: edge_models.Edges
     output_edges: edge_models.OutputEdges
-    fully_qualified_name: helper_models.FullyQualifiedName | None = None
-    version: str | None = None
+    source: versions.VersionInfo | None = None
     source_code: str | None = None
+
+    @property
+    def fully_qualified_name(self) -> str | None:
+        return None if self.source is None else self.source.fully_qualified_name
 
     @pydantic.model_validator(mode="after")
     def validate_io_edges(self):

--- a/flowrep/models/parsers/atomic_parser.py
+++ b/flowrep/models/parsers/atomic_parser.py
@@ -126,8 +126,7 @@ def parse_atomic(
 
     source_code = parser_helpers.get_available_source_code(func)
     return atomic_model.AtomicNode(
-        fully_qualified_name=info.fully_qualified_name,
-        version=info.version,
+        source=info,
         source_code=source_code,
         inputs=input_labels,
         outputs=(

--- a/flowrep/models/parsers/workflow_parser.py
+++ b/flowrep/models/parsers/workflow_parser.py
@@ -122,8 +122,7 @@ def parse_workflow(
     state = _WorkflowFunctionParser(
         object_scope.get_scope(func),
         symbol_scope.SymbolScope({p: edge_models.InputSource(port=p) for p in inputs}),
-        fully_qualified_name=info.fully_qualified_name,
-        version=info.version,
+        source=info,
         func=func,
         output_labels=output_labels,
     )
@@ -168,14 +167,12 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         self,
         scope: object_scope.ScopeProxy,
         symbol_map: symbol_scope.SymbolScope,
-        fully_qualified_name: str | None = None,
-        version: str | None = None,
+        source: versions.VersionInfo | None = None,
     ):
         self.scope = scope
         self.symbol_map = symbol_map
         self.nodes: union.Nodes = {}
-        self.fully_qualified_name = fully_qualified_name
-        self.version = version
+        self.source = source
 
     @property
     def inputs(self) -> list[str]:
@@ -209,8 +206,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             input_edges=self.input_edges,
             edges=self.edges,
             output_edges=self.output_edges,
-            fully_qualified_name=self.fully_qualified_name,
-            version=self.version,
+            source=self.source,
             source_code=source_code,
         )
 
@@ -318,12 +314,11 @@ class _WorkflowFunctionParser(WorkflowParser):
         scope: object_scope.ScopeProxy,
         symbol_map: symbol_scope.SymbolScope,
         *,
-        fully_qualified_name: str | None = None,
-        version: str | None = None,
+        source: versions.VersionInfo | None = None,
         func: FunctionType,
         output_labels: Collection[str],
     ):
-        super().__init__(scope, symbol_map, fully_qualified_name, version)
+        super().__init__(scope, symbol_map, source=source)
         self._func = func
         self._output_labels = output_labels
         self._found_return = False

--- a/tests/integration/parsers/test_parsing_composite_workflow.py
+++ b/tests/integration/parsers/test_parsing_composite_workflow.py
@@ -281,7 +281,11 @@ full_composite_node = workflow_model.WorkflowNode.model_validate(
             "my_identity_0.x": "try_0.z",
         },
         "output_edges": {"result": "my_identity_0.x"},
-        "fully_qualified_name": "integration.parsers.test_parsing_composite_workflow.full_composite",
+        "source": {
+            "module": "integration.parsers.test_parsing_composite_workflow",
+            "qualname": "full_composite",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(full_composite),
     }
 )

--- a/tests/integration/parsers/test_parsing_for_nodes.py
+++ b/tests/integration/parsers/test_parsing_for_nodes.py
@@ -82,7 +82,11 @@ single_iteration_node = workflow_model.WorkflowNode.model_validate(
             "l": "how_many_0.length",
             "vecs": "for_0.vecs",
         },
-        "fully_qualified_name": "integration.parsers.test_parsing_for_nodes.single_iteration",
+        "source": {
+            "module": "integration.parsers.test_parsing_for_nodes",
+            "qualname": "single_iteration",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(single_iteration),
     }
 )
@@ -175,7 +179,11 @@ zbat_wf_node = workflow_model.WorkflowNode.model_validate(
             "d_accumulator": "for_0.d_accumulator",
             "sums": "for_0.sums",
         },
-        "fully_qualified_name": "integration.parsers.test_parsing_for_nodes.zipped_broadcast_and_transferred",
+        "source": {
+            "module": "integration.parsers.test_parsing_for_nodes",
+            "qualname": "zipped_broadcast_and_transferred",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(
             zipped_broadcast_and_transferred
         ),
@@ -278,7 +286,11 @@ nested_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"for_0.ns": "ns"},
         "edges": {},
         "output_edges": {"sq_sums": "for_0.sq_sums"},
-        "fully_qualified_name": "integration.parsers.test_parsing_for_nodes.nested",
+        "source": {
+            "module": "integration.parsers.test_parsing_for_nodes",
+            "qualname": "nested",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(nested),
     }
 )
@@ -397,7 +409,11 @@ nested_with_passed_input_node = workflow_model.WorkflowNode.model_validate(
         },
         "edges": {},
         "output_edges": {"sq_sums": "for_0.sq_sums"},
-        "fully_qualified_name": "integration.parsers.test_parsing_for_nodes.nested_with_passed_input",
+        "source": {
+            "module": "integration.parsers.test_parsing_for_nodes",
+            "qualname": "nested_with_passed_input",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(
             nested_with_passed_input
         ),

--- a/tests/integration/parsers/test_parsing_if_nodes.py
+++ b/tests/integration/parsers/test_parsing_if_nodes.py
@@ -95,7 +95,11 @@ simple_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"if_0.x": "x", "if_0.y": "y"},
         "edges": {},
         "output_edges": {"z": "if_0.z"},
-        "fully_qualified_name": "integration.parsers.test_parsing_if_nodes.simple_if_else",
+        "source": {
+            "module": "integration.parsers.test_parsing_if_nodes",
+            "qualname": "simple_if_else",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(simple_if_else),
     }
 )
@@ -200,7 +204,11 @@ elif_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"if_0.x": "x", "if_0.flag": "flag", "if_0.y": "y"},
         "edges": {},
         "output_edges": {"z": "if_0.z"},
-        "fully_qualified_name": "integration.parsers.test_parsing_if_nodes.if_elif_else",
+        "source": {
+            "module": "integration.parsers.test_parsing_if_nodes",
+            "qualname": "if_elif_else",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(if_elif_else),
     }
 )
@@ -280,7 +288,11 @@ context_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"my_add_0.a": "a", "my_add_0.b": "b", "if_0.b": "b"},
         "edges": {"if_0.x": "my_add_0.output_0", "my_identity_0.x": "if_0.y"},
         "output_edges": {"z": "my_identity_0.x"},
-        "fully_qualified_name": "integration.parsers.test_parsing_if_nodes.if_with_context",
+        "source": {
+            "module": "integration.parsers.test_parsing_if_nodes",
+            "qualname": "if_with_context",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(if_with_context),
     }
 )
@@ -379,7 +391,11 @@ multi_output_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"if_0.x": "x", "if_0.y": "y"},
         "edges": {},
         "output_edges": {"a": "if_0.a", "b": "if_0.b"},
-        "fully_qualified_name": "integration.parsers.test_parsing_if_nodes.multi_output_if",
+        "source": {
+            "module": "integration.parsers.test_parsing_if_nodes",
+            "qualname": "multi_output_if",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(multi_output_if),
     }
 )
@@ -441,7 +457,11 @@ no_else_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"my_identity_0.x": "x", "if_0.x": "x", "if_0.y": "y"},
         "edges": {},
         "output_edges": {"z": "if_0.z"},
-        "fully_qualified_name": "integration.parsers.test_parsing_if_nodes.if_no_else",
+        "source": {
+            "module": "integration.parsers.test_parsing_if_nodes",
+            "qualname": "if_no_else",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(if_no_else),
     }
 )

--- a/tests/integration/parsers/test_parsing_try_nodes.py
+++ b/tests/integration/parsers/test_parsing_try_nodes.py
@@ -89,7 +89,11 @@ simple_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"try_0.x": "x", "try_0.y": "y"},
         "edges": {},
         "output_edges": {"z": "try_0.z"},
-        "fully_qualified_name": "integration.parsers.test_parsing_try_nodes.simple_try_except",
+        "source": {
+            "module": "integration.parsers.test_parsing_try_nodes",
+            "qualname": "simple_try_except",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(simple_try_except),
     }
 )
@@ -188,7 +192,11 @@ multi_except_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"try_0.x": "x", "try_0.y": "y"},
         "edges": {},
         "output_edges": {"z": "try_0.z"},
-        "fully_qualified_name": "integration.parsers.test_parsing_try_nodes.try_multi_except",
+        "source": {
+            "module": "integration.parsers.test_parsing_try_nodes",
+            "qualname": "try_multi_except",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(try_multi_except),
     }
 )
@@ -270,7 +278,11 @@ context_node = workflow_model.WorkflowNode.model_validate(
             "my_identity_0.x": "try_0.y",
         },
         "output_edges": {"z": "my_identity_0.x"},
-        "fully_qualified_name": "integration.parsers.test_parsing_try_nodes.try_with_context",
+        "source": {
+            "module": "integration.parsers.test_parsing_try_nodes",
+            "qualname": "try_with_context",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(try_with_context),
     }
 )
@@ -363,7 +375,11 @@ multi_output_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"try_0.x": "x", "try_0.y": "y"},
         "edges": {},
         "output_edges": {"a": "try_0.a", "b": "try_0.b"},
-        "fully_qualified_name": "integration.parsers.test_parsing_try_nodes.multi_output_try",
+        "source": {
+            "module": "integration.parsers.test_parsing_try_nodes",
+            "qualname": "multi_output_try",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(multi_output_try),
     }
 )
@@ -441,7 +457,11 @@ tuple_exc_node = workflow_model.WorkflowNode.model_validate(
         "input_edges": {"try_0.x": "x", "try_0.y": "y"},
         "edges": {},
         "output_edges": {"z": "try_0.z"},
-        "fully_qualified_name": "integration.parsers.test_parsing_try_nodes.try_tuple_exceptions",
+        "source": {
+            "module": "integration.parsers.test_parsing_try_nodes",
+            "qualname": "try_tuple_exceptions",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(try_tuple_exceptions),
     }
 )

--- a/tests/integration/parsers/test_parsing_while_nodes.py
+++ b/tests/integration/parsers/test_parsing_while_nodes.py
@@ -86,7 +86,11 @@ simple_while_node = workflow_model.WorkflowNode.model_validate(
             "my_unity_1.x": "while_0.x",
         },
         "output_edges": {"y": "my_unity_1.x"},
-        "fully_qualified_name": "integration.parsers.test_parsing_while_nodes.simple_while",
+        "source": {
+            "module": "integration.parsers.test_parsing_while_nodes",
+            "qualname": "simple_while",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(simple_while),
     }
 )
@@ -198,7 +202,11 @@ nest_while_node = workflow_model.WorkflowNode.model_validate(
         },
         "edges": {"while_0.y": "my_unity_0.x"},
         "output_edges": {"x": "while_0.x", "y": "while_0.y"},
-        "fully_qualified_name": "integration.parsers.test_parsing_while_nodes.nested_while",
+        "source": {
+            "module": "integration.parsers.test_parsing_while_nodes",
+            "qualname": "nested_while",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(nested_while),
     }
 )
@@ -277,7 +285,11 @@ multi_reassign_node = workflow_model.WorkflowNode.model_validate(
             "x": "while_0.x",
             "y": "while_0.y",
         },
-        "fully_qualified_name": "integration.parsers.test_parsing_while_nodes.multi_reassign",
+        "source": {
+            "module": "integration.parsers.test_parsing_while_nodes",
+            "qualname": "multi_reassign",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(multi_reassign),
     }
 )
@@ -361,7 +373,11 @@ sequential_whiles_node = workflow_model.WorkflowNode.model_validate(
         "output_edges": {
             "x": "while_1.x",
         },
-        "fully_qualified_name": "integration.parsers.test_parsing_while_nodes.sequential_whiles",
+        "source": {
+            "module": "integration.parsers.test_parsing_while_nodes",
+            "qualname": "sequential_whiles",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(sequential_whiles),
     }
 )
@@ -431,7 +447,11 @@ chained_body_node = workflow_model.WorkflowNode.model_validate(
         },
         "edges": {},
         "output_edges": {"x": "while_0.x"},
-        "fully_qualified_name": "integration.parsers.test_parsing_while_nodes.chained_body",
+        "source": {
+            "module": "integration.parsers.test_parsing_while_nodes",
+            "qualname": "chained_body",
+            "version": None,
+        },
         "source_code": parser_helpers.get_available_source_code(chained_body),
     }
 )

--- a/tests/unit/models/nodes/test_atomic_model.py
+++ b/tests/unit/models/nodes/test_atomic_model.py
@@ -8,6 +8,11 @@ from flowrep.models import base_models
 from flowrep.models.nodes import atomic_model
 
 
+def _source(module: str = "mod", qualname: str = "func", version: str | None = None):
+    """Shorthand for building a source dict in tests."""
+    return {"module": module, "qualname": qualname, "version": version}
+
+
 class TestAtomicNodeStructure(unittest.TestCase):
     """Tests for basic structure and schema."""
 
@@ -17,74 +22,52 @@ class TestAtomicNodeStructure(unittest.TestCase):
 
     def test_type_defaults_to_atomic(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=[],
         )
         self.assertEqual(node.type, base_models.RecipeElementType.ATOMIC)
 
     def test_required_fields(self):
-        """fully_qualified_name is required; inputs/outputs have no default."""
+        """source is required; inputs/outputs have no default."""
         with self.assertRaises(pydantic.ValidationError):
             atomic_model.AtomicNode()
 
 
-class TestAtomicNodeFQN(unittest.TestCase):
-    """Tests for fully_qualified_name validation."""
+class TestAtomicNodeSource(unittest.TestCase):
+    """Tests for the source field and fully_qualified_name property."""
 
-    def test_valid_fqn_simple(self):
+    def test_fully_qualified_name_property(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="module.func",
+            source=_source("module", "func"),
             inputs=[],
             outputs=[],
         )
         self.assertEqual(node.fully_qualified_name, "module.func")
 
-    def test_valid_fqn_deep(self):
+    def test_fully_qualified_name_deep(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="a.b.c.d",
+            source=_source("a.b.c", "d"),
             inputs=[],
             outputs=[],
         )
         self.assertEqual(node.fully_qualified_name, "a.b.c.d")
 
-    def test_fqn_no_period_rejected(self):
-        with self.assertRaises(pydantic.ValidationError) as ctx:
-            atomic_model.AtomicNode(
-                fully_qualified_name="noDot",
-                inputs=[],
-                outputs=[],
-            )
-        self.assertIn("at least one period", str(ctx.exception))
+    def test_version_accessible_via_source(self):
+        node = atomic_model.AtomicNode(
+            source=_source(version="1.2.3"),
+            inputs=[],
+            outputs=[],
+        )
+        self.assertEqual(node.source.version, "1.2.3")
 
-    def test_fqn_empty_string_rejected(self):
-        with self.assertRaises(pydantic.ValidationError) as ctx:
-            atomic_model.AtomicNode(
-                fully_qualified_name="",
-                inputs=[],
-                outputs=[],
-            )
-        self.assertIn("at least one period", str(ctx.exception))
-
-    def test_fqn_empty_parts_rejected(self):
-        """e.g., 'module.' or '.func' or 'a..b'"""
-        invalid_fqns = [
-            ("module.", "trailing dot"),
-            (".func", "leading dot"),
-            ("a..b", "consecutive dots"),
-            (".", "single dot"),
-            ("..", "only dots"),
-        ]
-        for fqn, reason in invalid_fqns:
-            with (
-                self.subTest(fqn=fqn, reason=reason),
-                self.assertRaises(pydantic.ValidationError),
-            ):
-                atomic_model.AtomicNode(
-                    fully_qualified_name=fqn,
-                    inputs=[],
-                    outputs=[],
-                )
+    def test_version_defaults_to_none(self):
+        node = atomic_model.AtomicNode(
+            source=_source(),
+            inputs=[],
+            outputs=[],
+        )
+        self.assertIsNone(node.source.version)
 
 
 class TestAtomicNodeUnpackMode(unittest.TestCase):
@@ -92,7 +75,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
 
     def test_default_unpack_mode_is_tuple(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=["a", "b"],
         )
@@ -100,7 +83,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
 
     def test_tuple_mode_multiple_outputs(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=["a", "b", "c"],
             unpack_mode=atomic_model.UnpackMode.TUPLE,
@@ -109,7 +92,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
 
     def test_tuple_mode_zero_outputs(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=[],
             unpack_mode=atomic_model.UnpackMode.TUPLE,
@@ -118,7 +101,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
 
     def test_dataclass_mode_multiple_outputs(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=["a", "b", "c"],
             unpack_mode=atomic_model.UnpackMode.DATACLASS,
@@ -128,7 +111,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
 
     def test_none_mode_single_output(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=["result"],
             unpack_mode=atomic_model.UnpackMode.NONE,
@@ -137,7 +120,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
 
     def test_none_mode_zero_outputs(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=[],
             unpack_mode=atomic_model.UnpackMode.NONE,
@@ -147,7 +130,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
     def test_none_mode_multiple_outputs_rejected(self):
         with self.assertRaises(pydantic.ValidationError) as ctx:
             atomic_model.AtomicNode(
-                fully_qualified_name="mod.func",
+                source=_source(),
                 inputs=[],
                 outputs=["a", "b"],
                 unpack_mode=atomic_model.UnpackMode.NONE,
@@ -159,7 +142,7 @@ class TestAtomicNodeUnpackMode(unittest.TestCase):
         for mode in ["none", "tuple", "dataclass"]:
             with self.subTest(mode=mode):
                 node = atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=[],
                     outputs=["out"],
                     unpack_mode=mode,
@@ -186,7 +169,7 @@ class TestAtomicNodeSerialization(unittest.TestCase):
 
     def test_roundtrip(self):
         original = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=["a"],
             outputs=["b"],
         )
@@ -200,7 +183,7 @@ class TestAtomicNodeSerialization(unittest.TestCase):
         for mode in atomic_model.UnpackMode:
             with self.subTest(mode=mode):
                 original = atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=[],
                     outputs=["out"],
                     unpack_mode=mode,
@@ -209,109 +192,59 @@ class TestAtomicNodeSerialization(unittest.TestCase):
                 restored = atomic_model.AtomicNode.model_validate(data)
                 self.assertEqual(original.unpack_mode, restored.unpack_mode)
 
+    def test_roundtrip_with_version(self):
+        original = atomic_model.AtomicNode(
+            source=_source(version="0.5.1"),
+            inputs=["a"],
+            outputs=["b"],
+        )
+        for mode in ["json", "python"]:
+            with self.subTest(mode=mode):
+                data = original.model_dump(mode=mode)
+                restored = atomic_model.AtomicNode.model_validate(data)
+                self.assertEqual(original.source.version, restored.source.version)
+
     def test_json_structure(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="pkg.mod.func",
+            source=_source("pkg.mod", "func", "2.0.0"),
             inputs=["x", "y"],
             outputs=["z"],
             unpack_mode=atomic_model.UnpackMode.NONE,
         )
         data = node.model_dump(mode="json")
         self.assertEqual(data["type"], "atomic")
-        self.assertEqual(data["fully_qualified_name"], "pkg.mod.func")
+        self.assertEqual(
+            data["source"],
+            {"module": "pkg.mod", "qualname": "func", "version": "2.0.0"},
+        )
         self.assertEqual(data["inputs"], ["x", "y"])
         self.assertEqual(data["outputs"], ["z"])
         self.assertEqual(data["unpack_mode"], "none")
 
-
-class TestAtomicNodeVersion(unittest.TestCase):
-    """Tests for the optional version field."""
-
-    def test_defaults_to_none(self):
-        node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
-            inputs=[],
-            outputs=[],
-        )
-        self.assertIsNone(node.version)
-
-    def test_accepts_version_string(self):
-        node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
-            inputs=[],
-            outputs=[],
-            version="1.2.3",
-        )
-        self.assertEqual(node.version, "1.2.3")
-
-    def test_accepts_none_explicitly(self):
-        node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
-            inputs=[],
-            outputs=[],
-            version=None,
-        )
-        self.assertIsNone(node.version)
-
-    def test_roundtrip_with_version(self):
-        original = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
-            inputs=["a"],
-            outputs=["b"],
-            version="0.5.1",
-        )
-        for mode in ["json", "python"]:
-            with self.subTest(mode=mode):
-                data = original.model_dump(mode=mode)
-                restored = atomic_model.AtomicNode.model_validate(data)
-                self.assertEqual(original.version, restored.version)
-
-    def test_roundtrip_without_version(self):
-        original = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
-            inputs=[],
-            outputs=[],
-        )
-        data = original.model_dump(mode="json")
-        restored = atomic_model.AtomicNode.model_validate(data)
-        self.assertIsNone(restored.version)
-
-    def test_json_structure_includes_version(self):
-        node = atomic_model.AtomicNode(
-            fully_qualified_name="pkg.mod.func",
-            inputs=["x"],
-            outputs=["y"],
-            version="2.0.0",
-        )
-        data = node.model_dump(mode="json")
-        self.assertEqual(data["version"], "2.0.0")
-
     def test_json_structure_version_null_when_absent(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=[],
         )
         data = node.model_dump(mode="json")
-        self.assertIsNone(data["version"])
+        self.assertIsNone(data["source"]["version"])
 
-    def test_json_schema_includes_version(self):
+    def test_json_schema_includes_source(self):
         schema = atomic_model.AtomicNode.model_json_schema()
-        self.assertIn("version", schema.get("properties", {}))
+        self.assertIn("source", schema.get("properties", {}))
 
 
 class TestAtomicNodeSourceCode(unittest.TestCase):
     """Tests for the optional source_code field."""
 
     def test_defaults_to_none(self):
-        node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func", inputs=[], outputs=[]
-        )
+        node = atomic_model.AtomicNode(source=_source(), inputs=[], outputs=[])
         self.assertIsNone(node.source_code)
 
     def test_accepts_string(self):
         node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=[],
             outputs=[],
             source_code="def func(): pass",
@@ -320,7 +253,7 @@ class TestAtomicNodeSourceCode(unittest.TestCase):
 
     def test_roundtrip(self):
         original = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=_source(),
             inputs=["a"],
             outputs=["b"],
             source_code="def func(a):\n    return a",
@@ -332,9 +265,7 @@ class TestAtomicNodeSourceCode(unittest.TestCase):
                 self.assertEqual(original.source_code, restored.source_code)
 
     def test_json_structure_null_when_absent(self):
-        node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func", inputs=[], outputs=[]
-        )
+        node = atomic_model.AtomicNode(source=_source(), inputs=[], outputs=[])
         self.assertIsNone(node.model_dump(mode="json")["source_code"])
 
 

--- a/tests/unit/models/nodes/test_for_model.py
+++ b/tests/unit/models/nodes/test_for_model.py
@@ -11,6 +11,11 @@ from flowrep.models.nodes import (
 )
 
 
+def _source(module: str = "mod", qualname: str = "func", version: str | None = None):
+    """Shorthand for building a source dict in tests."""
+    return {"module": module, "qualname": qualname, "version": version}
+
+
 class TestForNodeBasic(unittest.TestCase):
     def test_schema_generation(self):
         """model_json_schema() fails if forward refs aren't resolved."""
@@ -24,7 +29,7 @@ class TestForNodeBasic(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["item"],
                     outputs=["result"],
                 ),
@@ -42,7 +47,7 @@ class TestForNodeBasic(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["item"],
                     outputs=["result"],
                 ),
@@ -70,7 +75,7 @@ class TestForNodeBasic(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["x", "y"],
                     outputs=["result"],
                 ),
@@ -100,7 +105,7 @@ class TestForNodeBasic(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["a", "b", "c"],
                     outputs=["out"],
                 ),
@@ -137,7 +142,7 @@ class TestForNodeLoopPortValidation(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["inp"],
                         outputs=["out"],
                     ),
@@ -165,7 +170,7 @@ class TestForNodeLoopPortValidation(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -192,7 +197,7 @@ class TestForNodeLoopPortValidation(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["x"],
                         outputs=["result"],
                     ),
@@ -219,7 +224,7 @@ class TestForNodeLoopPortValidation(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -248,7 +253,7 @@ class TestForNodeLoopPortValidation(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -277,7 +282,7 @@ class TestForNodeInputEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -304,7 +309,7 @@ class TestForNodeInputEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -331,7 +336,7 @@ class TestForNodeInputEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -360,7 +365,7 @@ class TestForNodeOutputEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -388,7 +393,7 @@ class TestForNodeOutputEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -415,7 +420,7 @@ class TestForNodeOutputEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -444,7 +449,7 @@ class TestForNodeTransferEdges(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["item", "static"],
                     outputs=["result"],
                 ),
@@ -478,7 +483,7 @@ class TestForNodeTransferEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -510,7 +515,7 @@ class TestForNodeTransferEdges(unittest.TestCase):
                 body_node=helper_models.LabeledNode(
                     label="body",
                     node=atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=_source(),
                         inputs=["item"],
                         outputs=["result"],
                     ),
@@ -542,7 +547,7 @@ class TestForNodeSerialization(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["item", "mult"],
                     outputs=["result"],
                 ),
@@ -586,7 +591,7 @@ class TestForNodeComposition(unittest.TestCase):
             outputs=["y"],
             nodes={
                 "leaf": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["inp"],
                     outputs=["out"],
                 )
@@ -632,7 +637,7 @@ class TestForNodeComposition(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=_source(),
                     inputs=["item"],
                     outputs=["result"],
                 ),
@@ -678,7 +683,7 @@ class TestForNodeComposition(unittest.TestCase):
             body_node=helper_models.LabeledNode(
                 label="body",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.transform",
+                    source=_source(qualname="transform"),
                     inputs=["item"],
                     outputs=["result"],
                 ),
@@ -701,13 +706,13 @@ class TestForNodeComposition(unittest.TestCase):
             outputs=["final"],
             nodes={
                 "preprocess": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.preprocess",
+                    source=_source(qualname="preprocess"),
                     inputs=["data"],
                     outputs=["items"],
                 ),
                 "for_node": for_node,
                 "postprocess": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.postprocess",
+                    source=_source(qualname="postprocess"),
                     inputs=["results"],
                     outputs=["output"],
                 ),
@@ -748,7 +753,7 @@ class TestForNodeOutputProperties(unittest.TestCase):
                 "type": "atomic",
                 "inputs": inputs,
                 "outputs": outputs,
-                "fully_qualified_name": "mod.func",
+                "source": _source(),
             },
         }
 

--- a/tests/unit/models/nodes/test_helper_models.py
+++ b/tests/unit/models/nodes/test_helper_models.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models
 from flowrep.models.nodes import (
@@ -11,12 +12,13 @@ from flowrep.models.nodes import (
 
 
 def _make_atomic(
-    fully_qualified_name: str = "mod.func",
+    module: str = "mod",
+    qualname: str = "func",
     inputs: list[str] | None = None,
     outputs: list[str] | None = None,
 ) -> atomic_model.AtomicNode:
     return atomic_model.AtomicNode(
-        fully_qualified_name=fully_qualified_name,
+        source=versions.VersionInfo(module=module, qualname=qualname, version=None),
         inputs=inputs or [],
         outputs=outputs or [],
     )
@@ -28,7 +30,9 @@ class TestConditionalCaseValidation(unittest.TestCase):
         return helper_models.LabeledNode(
             label="condition",
             node=atomic_model.AtomicNode(
-                fully_qualified_name="mod.check",
+                source=versions.VersionInfo(
+                    module="mod", qualname="check", version=None
+                ),
                 inputs=["x"],
                 outputs=outputs or ["result"],
             ),
@@ -39,7 +43,9 @@ class TestConditionalCaseValidation(unittest.TestCase):
         return helper_models.LabeledNode(
             label="body",
             node=atomic_model.AtomicNode(
-                fully_qualified_name="mod.handle",
+                source=versions.VersionInfo(
+                    module="mod", qualname="handle", version=None
+                ),
                 inputs=["x"],
                 outputs=["y"],
             ),
@@ -86,7 +92,9 @@ class TestExceptionCaseValidation(unittest.TestCase):
     @staticmethod
     def _make_except_body(inputs=None, outputs=None) -> atomic_model.AtomicNode:
         return atomic_model.AtomicNode(
-            fully_qualified_name="mod.handle_error",
+            source=versions.VersionInfo(
+                module="mod", qualname="handle_error", version=None
+            ),
             inputs=inputs or ["x"],
             outputs=outputs or ["y"],
         )
@@ -135,7 +143,9 @@ class TestExceptionCaseSerialization(unittest.TestCase):
             body=helper_models.LabeledNode(
                 label="handler",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.handle_error",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="handle_error", version=None
+                    ),
                     inputs=["x"],
                     outputs=["y"],
                 ),

--- a/tests/unit/models/nodes/test_if_model.py
+++ b/tests/unit/models/nodes/test_if_model.py
@@ -11,9 +11,14 @@ from flowrep.models.nodes import (
 )
 
 
+def _source(module: str = "mod", qualname: str = "func", version: str | None = None):
+    """Shorthand for building a source dict in tests."""
+    return {"module": module, "qualname": qualname, "version": version}
+
+
 def _make_condition(inputs=None, outputs=None) -> atomic_model.AtomicNode:
     return atomic_model.AtomicNode(
-        fully_qualified_name="mod.check",
+        source=_source(qualname="check"),
         inputs=inputs or ["x"],
         outputs=outputs or ["result"],
     )
@@ -21,7 +26,7 @@ def _make_condition(inputs=None, outputs=None) -> atomic_model.AtomicNode:
 
 def _make_body(inputs=None, outputs=None) -> atomic_model.AtomicNode:
     return atomic_model.AtomicNode(
-        fully_qualified_name="mod.handle",
+        source=_source(qualname="handle"),
         inputs=inputs or ["x"],
         outputs=outputs or ["y"],
     )
@@ -165,7 +170,7 @@ class TestIfNodeCasesValidation(unittest.TestCase):
             outputs=["result"],
             nodes={
                 "inner": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.f",
+                    source=_source(qualname="f"),
                     inputs=["a"],
                     outputs=["b"],
                 )
@@ -528,12 +533,12 @@ class TestIfNodeSerialization(unittest.TestCase):
 
     def test_roundtrip_with_condition_output(self):
         condition = atomic_model.AtomicNode(
-            fully_qualified_name="mod.check",
+            source=_source(qualname="check"),
             inputs=["x"],
             outputs=["a", "b"],
         )
         body = atomic_model.AtomicNode(
-            fully_qualified_name="mod.handle",
+            source=_source(qualname="handle"),
             inputs=["x"],
             outputs=["y"],
         )
@@ -673,7 +678,7 @@ class TestIfNodeProspectiveOutputEdgesPortValidation(unittest.TestCase):
     def test_prospective_output_edges_valid_source_ports(self):
         """output_edges with valid source ports should pass."""
         body_node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.handle",
+            source=_source(qualname="handle"),
             inputs=["x"],
             outputs=["out1", "out2"],
         )
@@ -704,7 +709,7 @@ class TestIfNodeProspectiveOutputEdgesPortValidation(unittest.TestCase):
     def test_prospective_output_edges_valid_source_ports_with_else(self):
         """output_edges with valid source ports and else_case should pass."""
         body_node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.handle",
+            source=_source(qualname="handle"),
             inputs=["x"],
             outputs=["out1", "out2"],
         )

--- a/tests/unit/models/nodes/test_try_model.py
+++ b/tests/unit/models/nodes/test_try_model.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models, edge_models, subgraph_validation
 from flowrep.models.nodes import (
@@ -13,7 +14,7 @@ from flowrep.models.nodes import (
 
 def _make_try_body(inputs=None, outputs=None) -> atomic_model.AtomicNode:
     return atomic_model.AtomicNode(
-        fully_qualified_name="mod.try_func",
+        source=versions.VersionInfo(module="mod", qualname="try_func", version=None),
         inputs=inputs or ["x"],
         outputs=outputs or ["y"],
     )
@@ -21,7 +22,9 @@ def _make_try_body(inputs=None, outputs=None) -> atomic_model.AtomicNode:
 
 def _make_except_body(inputs=None, outputs=None) -> atomic_model.AtomicNode:
     return atomic_model.AtomicNode(
-        fully_qualified_name="mod.handle_error",
+        source=versions.VersionInfo(
+            module="mod", qualname="handle_error", version=None
+        ),
         inputs=inputs or ["x"],
         outputs=outputs or ["y"],
     )
@@ -176,7 +179,9 @@ class TestTryNodeExceptionCasesValidation(unittest.TestCase):
             outputs=["y"],
             nodes={
                 "inner": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.f",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="f", version=None
+                    ),
                     inputs=["a"],
                     outputs=["b"],
                 )
@@ -509,7 +514,7 @@ class TestTryNodeProspectiveOutputEdgesValidation(unittest.TestCase):
     def test_prospective_output_edges_valid_multiple_outputs(self):
         """prospective_output_edges works with multiple outputs."""
         body_node = atomic_model.AtomicNode(
-            fully_qualified_name="mod.func",
+            source=versions.VersionInfo(module="mod", qualname="func", version=None),
             inputs=["x"],
             outputs=["out1", "out2"],
         )
@@ -549,7 +554,9 @@ class TestTryNodeProspectiveOutputEdgesValidation(unittest.TestCase):
         try_node = helper_models.LabeledNode(
             label="try_body",
             node=atomic_model.AtomicNode(
-                fully_qualified_name="mod.func",
+                source=versions.VersionInfo(
+                    module="mod", qualname="func", version=None
+                ),
                 inputs=["x"],
                 outputs=[],
             ),
@@ -559,7 +566,9 @@ class TestTryNodeProspectiveOutputEdgesValidation(unittest.TestCase):
             body=helper_models.LabeledNode(
                 label="handler",
                 node=atomic_model.AtomicNode(
-                    fully_qualified_name="mod.handler",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="handler", version=None
+                    ),
                     inputs=["x"],
                     outputs=[],
                 ),

--- a/tests/unit/models/nodes/test_union.py
+++ b/tests/unit/models/nodes/test_union.py
@@ -16,18 +16,24 @@ from flowrep.models.nodes import (
 )
 
 
+def _source(module: str = "mod", qualname: str = "func", version: str | None = None):
+    """Shorthand for building a source dict in tests."""
+    return {"module": module, "qualname": qualname, "version": version}
+
+
 class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
     """Parameterized tests for NodeType discriminated union deserialization."""
 
     @classmethod
     def setUpClass(cls):
         """Define test cases: (type_enum, minimal_json_data, expected_class)"""
+
         cls.test_cases = [
             (
                 base_models.RecipeElementType.ATOMIC,
                 {
                     "type": "atomic",
-                    "fully_qualified_name": "mod.func",
+                    "source": _source(),
                     "inputs": ["x"],
                     "outputs": ["y"],
                 },
@@ -56,7 +62,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                         "label": "body",
                         "node": {
                             "type": "atomic",
-                            "fully_qualified_name": "mod.func",
+                            "source": _source(),
                             "inputs": ["item"],
                             "outputs": ["result"],
                         },
@@ -80,7 +86,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             "label": "c",
                             "node": {
                                 "type": "atomic",
-                                "fully_qualified_name": "m.f",
+                                "source": _source("m", "f"),
                                 "inputs": [],
                                 "outputs": ["ok"],
                             },
@@ -89,7 +95,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             "label": "b",
                             "node": {
                                 "type": "atomic",
-                                "fully_qualified_name": "m.g",
+                                "source": _source("m", "g"),
                                 "inputs": [],
                                 "outputs": [],
                             },
@@ -116,7 +122,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["result"],
-                                    "fully_qualified_name": "mod.check",
+                                    "source": _source(qualname="check"),
                                     "unpack_mode": "tuple",
                                 },
                             },
@@ -126,7 +132,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["y"],
-                                    "fully_qualified_name": "mod.handle",
+                                    "source": _source(qualname="handle"),
                                     "unpack_mode": "tuple",
                                 },
                             },
@@ -153,7 +159,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["result"],
-                                    "fully_qualified_name": "mod.check",
+                                    "source": _source(qualname="check"),
                                     "unpack_mode": "tuple",
                                 },
                             },
@@ -163,7 +169,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["y"],
-                                    "fully_qualified_name": "mod.handle",
+                                    "source": _source(qualname="hanlde"),
                                     "unpack_mode": "tuple",
                                 },
                             },
@@ -178,7 +184,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             "type": "atomic",
                             "inputs": ["x"],
                             "outputs": ["y"],
-                            "fully_qualified_name": "mod.handle",
+                            "source": _source(qualname="handle"),
                             "unpack_mode": "tuple",
                         },
                     },
@@ -197,7 +203,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             "type": "atomic",
                             "inputs": ["x"],
                             "outputs": ["y"],
-                            "fully_qualified_name": "mod.try_func",
+                            "source": _source(qualname="try_func"),
                             "unpack_mode": "tuple",
                         },
                     },
@@ -210,7 +216,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["y"],
-                                    "fully_qualified_name": "mod.handle_error",
+                                    "source": _source(qualname="handle_error"),
                                     "unpack_mode": "tuple",
                                 },
                             },
@@ -275,7 +281,7 @@ class TestDiscriminatorValidation(unittest.TestCase):
         with self.assertRaises(pydantic.ValidationError):
             adapter.validate_python(
                 {
-                    "fully_qualified_name": "mod.func",
+                    "source": _source(),
                     "inputs": [],
                     "outputs": [],
                 }
@@ -306,13 +312,13 @@ class TestNodesTypeAlias(unittest.TestCase):
         nodes_data = {
             "step1": {
                 "type": "atomic",
-                "fully_qualified_name": "mod.f",
+                "source": _source(qualname="f"),
                 "inputs": [],
                 "outputs": ["x"],
             },
             "step2": {
                 "type": "atomic",
-                "fully_qualified_name": "mod.g",
+                "source": _source(qualname="g"),
                 "inputs": ["x"],
                 "outputs": [],
             },
@@ -328,7 +334,7 @@ class TestNodesTypeAlias(unittest.TestCase):
         nodes_data = {
             "for": {  # Python keyword
                 "type": "atomic",
-                "fully_qualified_name": "mod.f",
+                "source": _source(qualname="f"),
                 "inputs": [],
                 "outputs": [],
             },
@@ -345,7 +351,7 @@ class TestNodesTypeAlias(unittest.TestCase):
                 nodes_data = {
                     reserved: {
                         "type": "atomic",
-                        "fully_qualified_name": "mod.f",
+                        "source": _source(qualname="f"),
                         "inputs": [],
                         "outputs": [],
                     },
@@ -363,7 +369,7 @@ class TestNodesTypeAlias(unittest.TestCase):
             "nodes": {
                 "leaf": {
                     "type": "atomic",
-                    "fully_qualified_name": "mod.f",
+                    "source": _source(qualname="f"),
                     "inputs": ["x"],
                     "outputs": ["y"],
                 },
@@ -375,7 +381,7 @@ class TestNodesTypeAlias(unittest.TestCase):
         nodes_data = {
             "atomic_node": {
                 "type": "atomic",
-                "fully_qualified_name": "mod.g",
+                "source": _source(qualname="g"),
                 "inputs": [],
                 "outputs": [],
             },
@@ -410,7 +416,7 @@ class TestNestedUnionResolution(unittest.TestCase):
                         "label": "body",
                         "node": {
                             "type": "atomic",
-                            "fully_qualified_name": "mod.transform",
+                            "source": _source(qualname="transform"),
                             "inputs": ["item"],
                             "outputs": ["result"],
                         },
@@ -438,7 +444,7 @@ class TestNestedUnionResolution(unittest.TestCase):
         """Three levels of workflow nesting."""
         innermost = {
             "type": "atomic",
-            "fully_qualified_name": "mod.leaf",
+            "source": _source(qualname="leaf"),
             "inputs": ["x"],
             "outputs": ["y"],
         }

--- a/tests/unit/models/nodes/test_while_model.py
+++ b/tests/unit/models/nodes/test_while_model.py
@@ -3,6 +3,7 @@
 import unittest
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models, edge_models, subgraph_validation
 from flowrep.models.nodes import (
@@ -15,7 +16,7 @@ from flowrep.models.nodes import (
 
 def make_atomic(inputs: list[str], outputs: list[str]) -> atomic_model.AtomicNode:
     return atomic_model.AtomicNode(
-        fully_qualified_name="mod.func",
+        source=versions.VersionInfo(module="mod", qualname="func", version=None),
         inputs=inputs,
         outputs=outputs,
     )

--- a/tests/unit/models/nodes/test_workflow_model.py
+++ b/tests/unit/models/nodes/test_workflow_model.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models, edge_models, subgraph_validation
 from flowrep.models.nodes import atomic_model, workflow_model
@@ -35,7 +36,9 @@ class TestWorkflowNodeInputEdges(unittest.TestCase):
             outputs=["y"],
             nodes={
                 "child": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="func", version=None
+                    ),
                     inputs=["inp"],
                     outputs=["out"],
                 )
@@ -62,7 +65,9 @@ class TestWorkflowNodeInputEdges(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -85,7 +90,9 @@ class TestWorkflowNodeInputEdges(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -109,7 +116,9 @@ class TestWorkflowNodeInputEdges(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -136,7 +145,9 @@ class TestWorkflowNodeOutputEdges(unittest.TestCase):
             outputs=["y"],
             nodes={
                 "child": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="func", version=None
+                    ),
                     inputs=["inp"],
                     outputs=["out"],
                 )
@@ -177,7 +188,9 @@ class TestWorkflowNodeOutputEdges(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -201,7 +214,9 @@ class TestWorkflowNodeOutputEdges(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -225,7 +240,9 @@ class TestWorkflowNodeOutputEdges(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -253,12 +270,16 @@ class TestWorkflowNodeInternalEdges(unittest.TestCase):
             outputs=["y"],
             nodes={
                 "a": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.f",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="f", version=None
+                    ),
                     inputs=["inp"],
                     outputs=["out"],
                 ),
                 "b": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.g",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="g", version=None
+                    ),
                     inputs=["inp"],
                     outputs=["out"],
                 ),
@@ -289,7 +310,9 @@ class TestWorkflowNodeInternalEdges(unittest.TestCase):
                 outputs=[],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -313,7 +336,9 @@ class TestWorkflowNodeInternalEdges(unittest.TestCase):
                 outputs=[],
                 nodes={
                     "child": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.func",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="func", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     )
@@ -337,12 +362,16 @@ class TestWorkflowNodeInternalEdges(unittest.TestCase):
                 outputs=[],
                 nodes={
                     "a": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.f",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="f", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     ),
                     "b": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.g",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="g", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     ),
@@ -366,12 +395,16 @@ class TestWorkflowNodeInternalEdges(unittest.TestCase):
                 outputs=[],
                 nodes={
                     "a": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.f",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="f", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     ),
                     "b": atomic_model.AtomicNode(
-                        fully_qualified_name="mod.g",
+                        source=versions.VersionInfo(
+                            module="mod", qualname="g", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out"],
                     ),
@@ -398,7 +431,9 @@ class TestWorkflowNodeMultiplePorts(unittest.TestCase):
             outputs=["x", "y"],
             nodes={
                 "node1": atomic_model.AtomicNode(
-                    fully_qualified_name="mod.func",
+                    source=versions.VersionInfo(
+                        module="mod", qualname="func", version=None
+                    ),
                     inputs=["in1", "in2"],
                     outputs=["out1", "out2"],
                 )
@@ -448,7 +483,9 @@ class TestWorkflowNodeReservedNames(unittest.TestCase):
                         outputs=["b"],
                         nodes={
                             invalid_label: atomic_model.AtomicNode(
-                                fully_qualified_name="m.f",
+                                source=versions.VersionInfo(
+                                    module="m", qualname="f", version=None
+                                ),
                                 inputs=[],
                                 outputs=[],
                             )
@@ -472,12 +509,16 @@ class TestWorkflowNodeAcyclic(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "a": atomic_model.AtomicNode(
-                        fully_qualified_name="m.f",
+                        source=versions.VersionInfo(
+                            module="m", qualname="f", version=None
+                        ),
                         inputs=["inp", "feedback"],
                         outputs=["out"],
                     ),
                     "b": atomic_model.AtomicNode(
-                        fully_qualified_name="m.g",
+                        source=versions.VersionInfo(
+                            module="m", qualname="g", version=None
+                        ),
                         inputs=["inp"],
                         outputs=["out", "out2"],
                     ),
@@ -511,7 +552,9 @@ class TestWorkflowNodeAcyclic(unittest.TestCase):
                 outputs=["y"],
                 nodes={
                     "a": atomic_model.AtomicNode(
-                        fully_qualified_name="m.f",
+                        source=versions.VersionInfo(
+                            module="m", qualname="f", version=None
+                        ),
                         inputs=["inp", "feedback"],
                         outputs=["out", "out2"],
                     )
@@ -541,17 +584,17 @@ class TestWorkflowNodeAcyclic(unittest.TestCase):
             outputs=["y"],
             nodes={
                 "a": atomic_model.AtomicNode(
-                    fully_qualified_name="m.f",
+                    source=versions.VersionInfo(module="m", qualname="f", version=None),
                     inputs=["inp"],
                     outputs=["out"],
                 ),
                 "b": atomic_model.AtomicNode(
-                    fully_qualified_name="m.g",
+                    source=versions.VersionInfo(module="m", qualname="g", version=None),
                     inputs=["inp"],
                     outputs=["out"],
                 ),
                 "c": atomic_model.AtomicNode(
-                    fully_qualified_name="m.h",
+                    source=versions.VersionInfo(module="m", qualname="h", version=None),
                     inputs=["inp"],
                     outputs=["out"],
                 ),
@@ -588,7 +631,7 @@ class TestNestedWorkflow(unittest.TestCase):
             outputs=["b"],
             nodes={
                 "leaf": atomic_model.AtomicNode(
-                    fully_qualified_name="m.f",
+                    source=versions.VersionInfo(module="m", qualname="f", version=None),
                     inputs=["inp"],
                     outputs=["out"],
                 )
@@ -636,7 +679,7 @@ class TestNestedWorkflow(unittest.TestCase):
                         outputs=["b"],
                         nodes={
                             "bad": atomic_model.AtomicNode(
-                                fully_qualified_name="noDot",
+                                source="Not a VersionInfo",
                                 inputs=[],
                                 outputs=[],
                             )
@@ -658,7 +701,7 @@ class TestNestedWorkflow(unittest.TestCase):
             outputs=["inner_out"],
             nodes={
                 "leaf": atomic_model.AtomicNode(
-                    fully_qualified_name="m.f",
+                    source=versions.VersionInfo(module="m", qualname="f", version=None),
                     inputs=["x"],
                     outputs=["y"],
                 )
@@ -701,7 +744,7 @@ class TestNestedWorkflow(unittest.TestCase):
             outputs=["inner_out"],
             nodes={
                 "leaf": atomic_model.AtomicNode(
-                    fully_qualified_name="m.f",
+                    source=versions.VersionInfo(module="m", qualname="f", version=None),
                     inputs=["x"],
                     outputs=["y"],
                 )
@@ -763,7 +806,7 @@ class TestEmptyWorkflow(unittest.TestCase):
             outputs=[],
             nodes={
                 "n": atomic_model.AtomicNode(
-                    fully_qualified_name="m.f",
+                    source=versions.VersionInfo(module="m", qualname="f", version=None),
                     inputs=[],
                     outputs=[],
                 )
@@ -784,7 +827,7 @@ class TestWorkflowNodeSerialization(unittest.TestCase):
             outputs=["y"],
             nodes={
                 "n": atomic_model.AtomicNode(
-                    fully_qualified_name="m.f",
+                    source=versions.VersionInfo(module="m", qualname="f", version=None),
                     inputs=["inp"],
                     outputs=["out"],
                 )
@@ -819,12 +862,12 @@ class TestWorkflowNodeSerialization(unittest.TestCase):
             outputs=["z", "w"],
             nodes={
                 "a": atomic_model.AtomicNode(
-                    fully_qualified_name="m.f",
+                    source=versions.VersionInfo(module="m", qualname="f", version=None),
                     inputs=["i1", "i2"],
                     outputs=["o1", "o2"],
                 ),
                 "b": atomic_model.AtomicNode(
-                    fully_qualified_name="m.g",
+                    source=versions.VersionInfo(module="m", qualname="g", version=None),
                     inputs=["inp"],
                     outputs=["out"],
                 ),
@@ -869,9 +912,7 @@ class TestWorkflowNodeSerialization(unittest.TestCase):
         self.assertEqual(data["output_edges"]["z"], "a.o2")
 
 
-class TestWorkflowNodeFullyQualifiedName(unittest.TestCase):
-    """Tests for the optional fully_qualified_name field."""
-
+class TestWorkflowNodeSource(unittest.TestCase):
     def _minimal_wf(self, **overrides):
         defaults = dict(
             inputs=[],
@@ -886,39 +927,14 @@ class TestWorkflowNodeFullyQualifiedName(unittest.TestCase):
 
     def test_defaults_to_none(self):
         wf = self._minimal_wf()
-        self.assertIsNone(wf.fully_qualified_name)
+        self.assertIsNone(wf.source)
 
-    def test_accepts_valid_fqn(self):
-        wf = self._minimal_wf(fully_qualified_name="my_module.MyClass")
-        self.assertEqual(wf.fully_qualified_name, "my_module.MyClass")
+    def test_accepts_valid_source(self):
+        wf = self._minimal_wf(source=versions.VersionInfo("mod", "func", "1.2.3"))
+        self.assertEqual(wf.fully_qualified_name, "mod.func")
 
-    def test_accepts_deeply_nested_fqn(self):
-        wf = self._minimal_wf(fully_qualified_name="a.b.c.d.e")
-        self.assertEqual(wf.fully_qualified_name, "a.b.c.d.e")
-
-    def test_rejects_single_segment(self):
-        with self.assertRaises(pydantic.ValidationError) as ctx:
-            self._minimal_wf(fully_qualified_name="noDot")
-        self.assertIn("fully_qualified_name", str(ctx.exception))
-
-    def test_rejects_empty_string(self):
-        with self.assertRaises(pydantic.ValidationError):
-            self._minimal_wf(fully_qualified_name="")
-
-    def test_rejects_leading_dot(self):
-        with self.assertRaises(pydantic.ValidationError):
-            self._minimal_wf(fully_qualified_name=".leading")
-
-    def test_rejects_trailing_dot(self):
-        with self.assertRaises(pydantic.ValidationError):
-            self._minimal_wf(fully_qualified_name="trailing.")
-
-    def test_rejects_consecutive_dots(self):
-        with self.assertRaises(pydantic.ValidationError):
-            self._minimal_wf(fully_qualified_name="a..b")
-
-    def test_roundtrip_with_fqn(self):
-        original = self._minimal_wf(fully_qualified_name="pkg.mod.func")
+    def test_roundtrip_with_source(self):
+        original = self._minimal_wf(source=versions.VersionInfo("mod", "func", "1.2.3"))
         for mode in ["python", "json"]:
             with self.subTest(mode=mode):
                 data = original.model_dump(mode=mode)
@@ -927,89 +943,13 @@ class TestWorkflowNodeFullyQualifiedName(unittest.TestCase):
                     original.fully_qualified_name, restored.fully_qualified_name
                 )
 
-    def test_roundtrip_without_fqn(self):
-        original = self._minimal_wf()
-        data = original.model_dump(mode="json")
-        restored = workflow_model.WorkflowNode.model_validate(data)
-        self.assertIsNone(restored.fully_qualified_name)
-
-    def test_json_schema_includes_fqn(self):
+    def test_json_schema_includes_source(self):
         schema = workflow_model.WorkflowNode.model_json_schema()
         # Pydantic v2 may put properties under $defs for recursive models
         props = schema.get("properties") or schema.get("$defs", {}).get(
             "WorkflowNode", {}
         ).get("properties", {})
-        self.assertIn("fully_qualified_name", props)
-
-
-class TestWorkflowNodeVersion(unittest.TestCase):
-    """Tests for the optional version field."""
-
-    def _minimal_wf(self, **overrides):
-        defaults = dict(
-            inputs=[],
-            outputs=[],
-            nodes={},
-            input_edges={},
-            edges={},
-            output_edges={},
-        )
-        defaults.update(overrides)
-        return workflow_model.WorkflowNode(**defaults)
-
-    def test_defaults_to_none(self):
-        wf = self._minimal_wf()
-        self.assertIsNone(wf.version)
-
-    def test_accepts_version_string(self):
-        wf = self._minimal_wf(version="3.1.4")
-        self.assertEqual(wf.version, "3.1.4")
-
-    def test_accepts_none_explicitly(self):
-        wf = self._minimal_wf(version=None)
-        self.assertIsNone(wf.version)
-
-    def test_roundtrip_with_version(self):
-        original = self._minimal_wf(fully_qualified_name="pkg.func", version="1.0.0")
-        for mode in ["json", "python"]:
-            with self.subTest(mode=mode):
-                data = original.model_dump(mode=mode)
-                restored = workflow_model.WorkflowNode.model_validate(data)
-                self.assertEqual(original.version, restored.version)
-
-    def test_roundtrip_without_version(self):
-        original = self._minimal_wf()
-        data = original.model_dump(mode="json")
-        restored = workflow_model.WorkflowNode.model_validate(data)
-        self.assertIsNone(restored.version)
-
-    def test_json_structure_includes_version(self):
-        wf = self._minimal_wf(version="2.0.0")
-        data = wf.model_dump(mode="json")
-        self.assertEqual(data["version"], "2.0.0")
-
-    def test_json_structure_version_null_when_absent(self):
-        wf = self._minimal_wf()
-        data = wf.model_dump(mode="json")
-        self.assertIsNone(data["version"])
-
-    def test_json_schema_includes_version(self):
-        schema = workflow_model.WorkflowNode.model_json_schema()
-        props = schema.get("properties") or schema.get("$defs", {}).get(
-            "WorkflowNode", {}
-        ).get("properties", {})
-        self.assertIn("version", props)
-
-    def test_version_and_fqn_together(self):
-        wf = self._minimal_wf(fully_qualified_name="my_pkg.my_func", version="0.1.0")
-        self.assertEqual(wf.fully_qualified_name, "my_pkg.my_func")
-        self.assertEqual(wf.version, "0.1.0")
-
-    def test_version_without_fqn(self):
-        """version can be set even without fully_qualified_name."""
-        wf = self._minimal_wf(version="1.0.0")
-        self.assertIsNone(wf.fully_qualified_name)
-        self.assertEqual(wf.version, "1.0.0")
+        self.assertIn("source", props)
 
 
 class TestWorkflowNodeSourceCode(unittest.TestCase):

--- a/tests/unit/models/parsers/test_atomic_parser.py
+++ b/tests/unit/models/parsers/test_atomic_parser.py
@@ -862,8 +862,8 @@ class TestParseAtomicVersionParams(unittest.TestCase):
 
         node = atomic_parser.parse_atomic(dataclasses.is_dataclass)
         # math is a stdlib module; version should be the python version
-        self.assertIsNotNone(node.version)
-        self.assertIsInstance(node.version, str)
+        self.assertIsNotNone(node.source.version)
+        self.assertIsInstance(node.source.version, str)
 
     def test_version_none_for_unversioned(self):
         """Functions from unversioned modules should yield version=None."""
@@ -872,7 +872,7 @@ class TestParseAtomicVersionParams(unittest.TestCase):
         # forbid_main=False; the version for __main__ is None
         # Actually __main__ may not have a version. Let's just check it doesn't crash.
         node = atomic_parser.parse_atomic(f)
-        self.assertIsInstance(node.version, (str, type(None)))
+        self.assertIsInstance(node.source.version, (str, type(None)))
 
     def test_forbid_main_raises(self):
         f = _make_func_in_module("__main__", "f")
@@ -906,7 +906,7 @@ class TestParseAtomicVersionParams(unittest.TestCase):
         custom_version = "99.0.0"
         scraping = {"mypkg.sub": lambda _name: custom_version}
         node = atomic_parser.parse_atomic(f, version_scraping=scraping)
-        self.assertEqual(node.version, custom_version)
+        self.assertEqual(node.source.version, custom_version)
 
     def test_fqn_matches_module_and_qualname(self):
         scraping = {
@@ -934,7 +934,7 @@ class TestAtomicDecoratorVersionParams(unittest.TestCase):
         def my_func(x):
             return x
 
-        self.assertEqual(my_func.flowrep_recipe.version, custom_version)
+        self.assertEqual(my_func.flowrep_recipe.source.version, custom_version)
 
     def test_decorator_forbid_locals_on_inner_function(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/models/parsers/test_parser_helpers.py
+++ b/tests/unit/models/parsers/test_parser_helpers.py
@@ -1,6 +1,8 @@
 import ast
 import unittest
 
+from pyiron_snippets import versions
+
 from flowrep.models import edge_models
 from flowrep.models.nodes import atomic_model, helper_models
 from flowrep.models.parsers import parser_helpers, symbol_scope
@@ -188,7 +190,9 @@ class TestConsumeCallArguments(unittest.TestCase):
         return helper_models.LabeledNode(
             label=label,
             node=atomic_model.AtomicNode(
-                fully_qualified_name="test.module.func",
+                source=versions.VersionInfo(
+                    module="test.module", qualname="func", version=None
+                ),
                 inputs=inputs,
                 outputs=outputs,
             ),

--- a/tests/unit/models/parsers/test_symbol_scope.py
+++ b/tests/unit/models/parsers/test_symbol_scope.py
@@ -1,5 +1,7 @@
 import unittest
 
+from pyiron_snippets import versions
+
 from flowrep.models import edge_models
 from flowrep.models.nodes import atomic_model, helper_models
 from flowrep.models.parsers.symbol_scope import SymbolScope
@@ -17,7 +19,9 @@ def _make_labeled_node(label: str, outputs: list[str]) -> helper_models.LabeledN
     return helper_models.LabeledNode(
         label=label,
         node=atomic_model.AtomicNode(
-            fully_qualified_name="test.module.func",
+            source=versions.VersionInfo(
+                module="test.module", qualname="func", version=None
+            ),
             inputs=["x"],
             outputs=outputs,
             unpack_mode="tuple",

--- a/tests/unit/models/parsers/test_workflow_parser.py
+++ b/tests/unit/models/parsers/test_workflow_parser.py
@@ -611,12 +611,6 @@ class TestWorkflowFullyQualifiedName(unittest.TestCase):
             f"{inner_macro.__module__}.{inner_macro.__qualname__}",
         )
 
-    def test_fqn_defaults_to_none_on_raw_parser(self):
-        parser = workflow_parser.WorkflowParser(
-            object_scope.ScopeProxy({}), symbol_scope.SymbolScope({})
-        )
-        self.assertIsNone(parser.fully_qualified_name)
-
     def test_fqn_roundtrips_through_serialization(self):
         def wf(x):
             y = add(x)
@@ -643,7 +637,7 @@ class TestParseWorkflowVersionParams(unittest.TestCase):
         node = workflow_parser.parse_workflow(my_wf)
         # The workflow function is defined in this test module; version depends
         # on whether this package exposes __version__
-        self.assertIsInstance(node.version, (str, type(None)))
+        self.assertIsInstance(node.source.version, (str, type(None)))
 
     def test_fqn_is_populated(self):
         def my_wf(x):
@@ -694,7 +688,7 @@ class TestParseWorkflowVersionParams(unittest.TestCase):
         pkg = my_wf.__module__.split(".")[0]
         scraping = {pkg: lambda _name: custom_version}
         node = workflow_parser.parse_workflow(my_wf, version_scraping=scraping)
-        self.assertEqual(node.version, custom_version)
+        self.assertEqual(node.source.version, custom_version)
 
     def test_child_nodes_not_affected_by_workflow_version_params(self):
         """Sub-workflow bodies built during parsing should not carry the
@@ -727,7 +721,7 @@ class TestWorkflowDecoratorVersionParams(unittest.TestCase):
             y = _wp_identity(x)
             return y
 
-        self.assertEqual(my_wf.flowrep_recipe.version, custom_version)
+        self.assertEqual(my_wf.flowrep_recipe.source.version, custom_version)
 
     def test_decorator_forbid_locals_on_inner_function(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Use a single source of truth -- the snippets `VersionInfo`. I.e.

```
fully_qualified_name: FullyQualifiedName
version: str | None
```

becomes

```
source: pyiron_snippets.versions.VersionInfo
```

for both the atomic and (`|None`) workflow models.

This (de)serializes fine in pydantic2+ since it's a dataclass with primitive fields. The `fully_qualified_name` is re-exposed as a property shortcut on the workflow and node models.

The changes here are verbose because we're changing the actual data field structure, but it really is simple since `VersionInfo.version` and `VersionInfo.fully_qualified_name` exist anyhow, so we're just moving data around a bit.

The only thing really "lacking" is that we no longer validate that hand-written module and qualname values are properly formatted strings. If you hand-write complete nonsense (`"qualname": "42totally!not a name"`) you will hit trouble only later and not at validation.