### PR TITLE
Detect local arguments and functions used in a function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.pyc
 .DS_Store
 .coverage
-.coverage.*
-*.py,cover
 .pre-commit-config.yaml
 nohup.out
 pyiron.log

--- a/tests/unit/parsers/test_dependency_parser.py
+++ b/tests/unit/parsers/test_dependency_parser.py
@@ -192,7 +192,9 @@ class TestFindUndefinedVariables(unittest.TestCase):
 
     def test_syntax_error_in_source_returns_empty_dict(self):
         """When ``ast.parse`` raises ``SyntaxError``, the result must be ``{}``."""
-        with patch("flowrep.parsers.dependency_parser.ast.parse", side_effect=SyntaxError):
+        with patch(
+            "flowrep.parsers.dependency_parser.ast.parse", side_effect=SyntaxError
+        ):
             result = dependency_parser.find_undefined_variables(test_function)
         self.assertEqual(result, {})
 


### PR DESCRIPTION
Following the effort in #155, I started trying to parse variables as well. Edits will follow....

**Summary**

Adds undefined-variable detection to `dependency_parser` to identify and resolve external symbols used within a function. This enables failing fast with a clear error when a function depends on unversioned external variables or callables, rather than silently producing incorrect provenance.

**Related Issue(s)**

**Backward Compatibility**

The `get_call_dependencies` and `find_undefined_variables` function signatures have been narrowed: the `func_or_var` parameter type changed from `Callable | object` to `Callable[..., Any] | type[Any]`. Callers passing arbitrary non-callable, non-type objects will now get a type error.

**Implementation Notes**

- Added `UndefinedVariableVisitor` AST visitor that collects used and locally-defined variable names; local (nested) function definitions raise `NotImplementedError` to fail fast. The function name itself, all argument kinds (`posonlyargs`, `args`, `kwonlyargs`, `*args`, `**kwargs`), and class definitions are all tracked in `defined_vars` to avoid false positives. `import` and `from … import` statements inside a function body are collected in `.imports` / `.import_froms`.
- Added `find_undefined_variables` to extract symbols used but not defined in a function's source and resolve them via `object_scope`. Built-in names are excluded; source retrieval failures return `{}` gracefully; unparseable source (e.g. `SyntaxError`) also returns `{}` gracefully.
- Reworked `get_call_dependencies` to discover dependencies from undefined variables rather than call-graph traversal; recursion into unversioned dependencies is guarded by a `callable(obj) or isinstance(obj, type)` type guard so non-callable values are recorded but not recursed into.
- Fixed mypy errors: added `from typing import Any`, narrowed `func_or_var` type annotations to `Callable[..., Any] | type[Any]`, and added a type guard before the recursive call to satisfy static analysis.
- Added comprehensive unit tests (20 tests, up from 6) achieving 100% line coverage of `dependency_parser.py`. Tests cover all new components: `UndefinedVariableVisitor` (function name tracking, class def tracking, import collection, top-level async def, nested local function/async function raising `NotImplementedError`), `find_undefined_variables` (builtins excluded, graceful failure for uninspectable callables, graceful failure on `SyntaxError`, argument exclusion), and `get_call_dependencies` (empty result, cycle detection, versioned dependency collection, recursion into unversioned callables, non-callable values not recursed). Tests use only CI-available packages (`pydantic`, `pyiron_snippets`).