### PR TITLE
Use VersionInfo to track exceptions

### DIFF
--- a/flowrep/models/nodes/helper_models.py
+++ b/flowrep/models/nodes/helper_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models
 
@@ -56,12 +57,19 @@ class ExceptionCase(pydantic.BaseModel):
     An exception/node pair.
 
     Attributes:
-        exceptions: The fully qualified names (i.e. module+qualname) of the exception
-            types.
+        exceptions: The version info for exception types against which to except.
         body: The node to couple to these exceptions.
+
+    Note:
+        In a try-except case, we expect the exception target to always be a type --
+        and more idiomatically a subclass of python's builtin :class:`BaseException`.
+        Here, we don't explicitly validate that. Using
+        :class:`pyiron_snippets.versions.VersionInfo` allows us to ensure that recipes
+        are able to fully specify where exceptions can be found, should a non-builtin
+        exception be used.
     """
 
-    exceptions: list[str]
+    exceptions: list[versions.VersionInfo]
     body: LabeledNode
 
     @pydantic.field_validator("exceptions")

--- a/flowrep/models/parsers/try_parser.py
+++ b/flowrep/models/parsers/try_parser.py
@@ -36,7 +36,7 @@ def parse_try_node(
     try_branch = case_helpers.walk_branch(walker, TRY_BODY_LABEL, tree.body)
 
     # 2. Parse each except handler
-    exception_groups: list[list[str]] = []
+    exception_groups: list[list[versions.VersionInfo]] = []
     except_branches: list[case_helpers.WalkedBranch] = []
     for idx, handler in enumerate(tree.handlers):
         body_label = f"{EXCEPT_BODY_LABEL_PREFIX}_{idx}"
@@ -72,7 +72,7 @@ def parse_try_node(
 def _parse_exception_types(
     handler: ast.ExceptHandler,
     scope: object_scope.ScopeProxy,
-) -> list[str]:
+) -> list[versions.VersionInfo]:
     """
     Resolve the exception type(s) from an except handler to fully qualified names.
 
@@ -94,7 +94,7 @@ def _parse_exception_types(
         handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
     )
 
-    fqns: list[str] = []
+    exception_records: list[versions.VersionInfo] = []
     for node in type_nodes:
         exc_class = object_scope.resolve_symbol_to_object(node, scope)
         exc_info = versions.VersionInfo.of(exc_class)
@@ -103,5 +103,5 @@ def _parse_exception_types(
                 f"Except handler must catch exception types, but resolved "
                 f"{ast.dump(node)} to {exc_class!r}"
             )
-        fqns.append(exc_info.fully_qualified_name)
-    return fqns
+        exception_records.append(exc_info)
+    return exception_records

--- a/tests/integration/parsers/test_parsing_composite_workflow.py
+++ b/tests/integration/parsers/test_parsing_composite_workflow.py
@@ -1,5 +1,7 @@
 import unittest
 
+from pyiron_snippets import versions
+
 from flowrep.models.nodes import workflow_model
 from flowrep.models.parsers import atomic_parser, parser_helpers, workflow_parser
 
@@ -242,7 +244,7 @@ _try_node = {
     "try_node": {"label": "try_body", "node": _try_body},
     "exception_cases": [
         {
-            "exceptions": ["builtins.ValueError"],
+            "exceptions": [versions.VersionInfo.of(ValueError)],
             "body": {"label": "except_body_0", "node": _except_body},
         },
     ],

--- a/tests/integration/parsers/test_parsing_try_nodes.py
+++ b/tests/integration/parsers/test_parsing_try_nodes.py
@@ -1,7 +1,12 @@
 import unittest
 
+from pyiron_snippets import versions
+
 from flowrep.models.nodes import workflow_model
 from flowrep.models.parsers import atomic_parser, parser_helpers, workflow_parser
+
+_VALUE_ERROR_INFO = versions.VersionInfo.of(ValueError)
+_TYPE_ERROR_INFO = versions.VersionInfo.of(TypeError)
 
 
 # Reusable atomics (same as other test files)
@@ -55,7 +60,7 @@ simple_node = workflow_model.WorkflowNode.model_validate(
                 },
                 "exception_cases": [
                     {
-                        "exceptions": ["builtins.ValueError"],
+                        "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
                             "node": {
@@ -136,7 +141,7 @@ multi_except_node = workflow_model.WorkflowNode.model_validate(
                 },
                 "exception_cases": [
                     {
-                        "exceptions": ["builtins.ValueError"],
+                        "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
                             "node": {
@@ -156,7 +161,7 @@ multi_except_node = workflow_model.WorkflowNode.model_validate(
                         },
                     },
                     {
-                        "exceptions": ["builtins.TypeError"],
+                        "exceptions": [_TYPE_ERROR_INFO],
                         "body": {
                             "label": "except_body_1",
                             "node": {
@@ -240,7 +245,7 @@ context_node = workflow_model.WorkflowNode.model_validate(
                 },
                 "exception_cases": [
                     {
-                        "exceptions": ["builtins.ValueError"],
+                        "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
                             "node": {
@@ -334,7 +339,7 @@ multi_output_node = workflow_model.WorkflowNode.model_validate(
                 },
                 "exception_cases": [
                     {
-                        "exceptions": ["builtins.ValueError"],
+                        "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
                             "node": {
@@ -421,8 +426,8 @@ tuple_exc_node = workflow_model.WorkflowNode.model_validate(
                 "exception_cases": [
                     {
                         "exceptions": [
-                            "builtins.ValueError",
-                            "builtins.TypeError",
+                            _VALUE_ERROR_INFO,
+                            _TYPE_ERROR_INFO,
                         ],
                         "body": {
                             "label": "except_body_0",

--- a/tests/unit/models/nodes/test_helper_models.py
+++ b/tests/unit/models/nodes/test_helper_models.py
@@ -101,21 +101,22 @@ class TestExceptionCaseValidation(unittest.TestCase):
 
     def test_valid_single_exception(self):
         """ExceptionCase with a single exception type should validate."""
+        value_info = versions.VersionInfo.of(ValueError)
         case = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError"],
+            exceptions=[value_info],
             body=helper_models.LabeledNode(
                 label="handler", node=self._make_except_body()
             ),
         )
-        self.assertEqual(case.exceptions, ["builtins.ValueError"])
+        self.assertEqual(case.exceptions, [value_info])
 
     def test_valid_multiple_exceptions(self):
         """ExceptionCase with multiple exception types should validate."""
         case = helper_models.ExceptionCase(
             exceptions=[
-                "builtins.ValueError",
-                "builtins.TypeError",
-                "builtins.KeyError",
+                versions.VersionInfo.of(ValueError),
+                versions.VersionInfo.of(TypeError),
+                versions.VersionInfo.of(KeyError),
             ],
             body=helper_models.LabeledNode(
                 label="handler", node=self._make_except_body()
@@ -139,7 +140,10 @@ class TestExceptionCaseSerialization(unittest.TestCase):
     def test_exception_case_roundtrip(self):
         """ExceptionCase JSON roundtrip."""
         original = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError", "builtins.TypeError"],
+            exceptions=[
+                versions.VersionInfo.of(ValueError),
+                versions.VersionInfo.of(TypeError),
+            ],
             body=helper_models.LabeledNode(
                 label="handler",
                 node=atomic_model.AtomicNode(

--- a/tests/unit/models/nodes/test_try_model.py
+++ b/tests/unit/models/nodes/test_try_model.py
@@ -11,6 +11,8 @@ from flowrep.models.nodes import (
     workflow_model,
 )
 
+_VALUE_ERROR_INFO = versions.VersionInfo.of(ValueError)
+
 
 def _make_try_body(inputs=None, outputs=None) -> atomic_model.AtomicNode:
     return atomic_model.AtomicNode(
@@ -32,12 +34,12 @@ def _make_except_body(inputs=None, outputs=None) -> atomic_model.AtomicNode:
 
 def _make_exception_case(
     n: int,
-    exceptions: list[str] | None = None,
+    exceptions: list[versions.VersionInfo] | None = None,
     inputs=None,
     outputs=None,
 ) -> helper_models.ExceptionCase:
     return helper_models.ExceptionCase(
-        exceptions=exceptions or ["builtins.ValueError"],
+        exceptions=exceptions or [_VALUE_ERROR_INFO],
         body=helper_models.LabeledNode(
             label=f"except_{n}", node=_make_except_body(inputs=inputs, outputs=outputs)
         ),
@@ -123,7 +125,7 @@ class TestTryNodeExceptionCasesValidation(unittest.TestCase):
             label="shared_label", node=_make_try_body()
         )
         exception_case = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError"],
+            exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledNode(
                 label="shared_label", node=_make_except_body()
             ),  # Duplicate
@@ -147,11 +149,11 @@ class TestTryNodeExceptionCasesValidation(unittest.TestCase):
         """Labels must be unique across exception cases."""
         try_node = helper_models.LabeledNode(label="try_body", node=_make_try_body())
         case0 = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError"],
+            exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledNode(label="handler", node=_make_except_body()),
         )
         case1 = helper_models.ExceptionCase(
-            exceptions=["builtins.TypeError"],
+            exceptions=[versions.VersionInfo.of(TypeError)],
             body=helper_models.LabeledNode(
                 label="handler", node=_make_except_body()
             ),  # Dup
@@ -201,7 +203,7 @@ class TestTryNodeExceptionCasesValidation(unittest.TestCase):
 
         try_node = helper_models.LabeledNode(label="try_body", node=_make_try_body())
         exception_case = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError"],
+            exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledNode(
                 label="workflow_handler", node=workflow_body
             ),
@@ -520,7 +522,7 @@ class TestTryNodeProspectiveOutputEdgesValidation(unittest.TestCase):
         )
         try_node = helper_models.LabeledNode(label="try_body", node=body_node)
         exception_case = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError"],
+            exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledNode(label="except_body", node=body_node),
         )
         node = try_model.TryNode(
@@ -562,7 +564,7 @@ class TestTryNodeProspectiveOutputEdgesValidation(unittest.TestCase):
             ),
         )
         exception_case = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError"],
+            exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledNode(
                 label="handler",
                 node=atomic_model.AtomicNode(
@@ -613,7 +615,7 @@ class TestTryNodeProspectiveNodes(unittest.TestCase):
         """prospective_nodes rejects nodes with conflicting labels."""
         try_node = helper_models.LabeledNode(label="try_body", node=_make_try_body())
         exception_case = helper_models.ExceptionCase(
-            exceptions=["builtins.ValueError"],
+            exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledNode(label="try_body", node=_make_except_body()),
         )
         with self.assertRaises(pydantic.ValidationError) as ctx:
@@ -650,9 +652,9 @@ class TestTryNodeSerialization(unittest.TestCase):
         try_node = helper_models.LabeledNode(label="try_body", node=_make_try_body())
         exception_case = helper_models.ExceptionCase(
             exceptions=[
-                "builtins.ValueError",
-                "builtins.TypeError",
-                "builtins.KeyError",
+                _VALUE_ERROR_INFO,
+                versions.VersionInfo.of(TypeError),
+                versions.VersionInfo.of(KeyError),
             ],
             body=helper_models.LabeledNode(label="handler", node=_make_except_body()),
         )

--- a/tests/unit/models/nodes/test_union.py
+++ b/tests/unit/models/nodes/test_union.py
@@ -3,6 +3,7 @@
 import unittest
 
 import pydantic
+from pyiron_snippets import versions
 
 from flowrep.models import base_models
 from flowrep.models.nodes import (
@@ -209,7 +210,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                     },
                     "exception_cases": [
                         {
-                            "exceptions": ["builtins.ValueError"],
+                            "exceptions": [versions.VersionInfo.of(ValueError)],
                             "body": {
                                 "label": "except_0",
                                 "node": {

--- a/tests/unit/models/parsers/test_try_parser.py
+++ b/tests/unit/models/parsers/test_try_parser.py
@@ -1,5 +1,7 @@
 import unittest
 
+from pyiron_snippets import versions
+
 from flowrep.models import edge_models
 from flowrep.models.nodes import (
     for_model,
@@ -421,7 +423,9 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        self.assertEqual(tn.exception_cases[0].exceptions, ["builtins.ValueError"])
+        self.assertEqual(
+            tn.exception_cases[0].exceptions, [versions.VersionInfo.of(ValueError)]
+        )
 
     def test_tuple_exception_types_resolved(self):
         """Tuple exception types are all resolved."""
@@ -436,7 +440,10 @@ class TestTryParserStructure(unittest.TestCase):
         tn = self._parse(wf).nodes["try_0"]
         self.assertEqual(
             tn.exception_cases[0].exceptions,
-            ["builtins.ValueError", "builtins.TypeError"],
+            [
+                versions.VersionInfo.of(ValueError),
+                versions.VersionInfo.of(TypeError),
+            ],
         )
 
     def test_multiple_outputs(self):


### PR DESCRIPTION
Just a simple model update, and test massaging to get the new data format running. Per the new note in the `ExceptionCase` docstring:

In a try-except case, we expect the exception target to always be a type -- and more idiomatically a subclass of python's builtin :class:`BaseException`. Here, we don't explicitly validate that. Using :class:`pyiron_snippets.versions.VersionInfo` allows us to ensure that recipes are able to fully specify where exceptions can be found, should a non-builtin exception be used.