### PR TITLE
Parse imports inside workflow definitions

### DIFF
--- a/flowrep/models/parsers/case_helpers.py
+++ b/flowrep/models/parsers/case_helpers.py
@@ -73,13 +73,26 @@ class WalkedBranch:
 
 
 def walk_branch(
-    walker: parser_protocol.BodyWalker, label: str, stmts: list[ast.stmt]
+    walker: parser_protocol.BodyWalker,
+    label: str,
+    stmts: list[ast.stmt],
 ) -> WalkedBranch:
-    fork = walker.symbol_map.fork()
-    branch_walker = walker.fork(new_symbol_map=fork)
+    """
+    Fork a walker and walk a conditional branch body.
+
+    Both the :class:`SymbolScope` and the :class:`ScopeProxy` are forked so
+    that symbol assignments *and* import-based scope extensions in one branch
+    do not leak into sibling or parent branches.
+    """
+    symbol_fork = walker.symbol_map.fork()
+    scope_fork = walker.scope.fork()
+    branch_walker = walker.fork(
+        new_symbol_map=symbol_fork,
+        new_scope=scope_fork,
+    )
     branch_walker.walk(stmts)
-    assigned = fork.assigned_symbols
-    fork.produce_symbols(assigned)
+    assigned = symbol_fork.assigned_symbols
+    symbol_fork.produce_symbols(assigned)
     return WalkedBranch(label, branch_walker, assigned)
 
 

--- a/flowrep/models/parsers/for_parser.py
+++ b/flowrep/models/parsers/for_parser.py
@@ -45,7 +45,7 @@ def parse_for_node(
         available_accumulators=walker.symbol_map.declared_accumulators.copy(),
     )
 
-    body_walker = walker.fork(new_symbol_map=body_symbol_map)
+    body_walker = walker.fork(new_symbol_map=body_symbol_map, new_scope=walker.scope)
     body_walker.walk(body_tree.body)
     consumed = body_walker.symbol_map.consumed_accumulators
 

--- a/flowrep/models/parsers/object_scope.py
+++ b/flowrep/models/parsers/object_scope.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import builtins
 import inspect
@@ -18,6 +20,27 @@ class ScopeProxy:
             return self._d[name]
         except KeyError:
             raise AttributeError(name) from None
+
+    def register(self, name: str, obj: object) -> None:
+        """
+        Add a name → object binding to this scope.
+
+        Used by the parser when encountering ``import`` statements inside
+        function bodies.  The binding is visible to all subsequent symbol
+        resolutions within this scope (or any scope that shares the same
+        backing namespace).
+        """
+        self._d[name] = obj
+
+    def fork(self) -> ScopeProxy:
+        """
+        Create a shallow copy of this scope.
+
+        Modifications to the fork (e.g. registering new imports) do *not*
+        affect the parent.  Used when walking conditional branches so that
+        branch-local imports don't leak into sibling branches.
+        """
+        return ScopeProxy(dict(self._d))
 
 
 def get_scope(func: FunctionType) -> ScopeProxy:

--- a/flowrep/models/parsers/parser_protocol.py
+++ b/flowrep/models/parsers/parser_protocol.py
@@ -36,7 +36,12 @@ class BodyWalker(Protocol):
 
     def build_model(self) -> workflow_model.WorkflowNode: ...
 
-    def fork(self, *, new_symbol_map: symbol_scope.SymbolScope) -> BodyWalker: ...
+    def fork(
+        self,
+        *,
+        new_symbol_map: symbol_scope.SymbolScope,
+        new_scope: object_scope.ScopeProxy,
+    ) -> BodyWalker: ...
 
     def walk(self, statements: list[ast.stmt]) -> None: ...
 

--- a/flowrep/models/parsers/while_parser.py
+++ b/flowrep/models/parsers/while_parser.py
@@ -32,7 +32,10 @@ def parse_while_node(
         WHILE_CONDITION_LABEL,
     )
 
-    body_walker = walker.fork(new_symbol_map=walker.symbol_map.fork())
+    body_walker = walker.fork(
+        new_symbol_map=walker.symbol_map.fork(),
+        new_scope=walker.scope,
+    )
     body_walker.walk(tree.body)
     reassigned_symbols = body_walker.symbol_map.reassigned_symbols
 

--- a/flowrep/models/parsers/workflow_parser.py
+++ b/flowrep/models/parsers/workflow_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import importlib
 from collections.abc import Callable, Collection
 from types import FunctionType
 from typing import cast
@@ -220,8 +221,23 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             source_code=source_code,
         )
 
-    def fork(self, new_symbol_map: symbol_scope.SymbolScope) -> WorkflowParser:
-        return WorkflowParser(self.scope, new_symbol_map, self.info_factory)
+    def fork(
+        self,
+        *,
+        new_symbol_map: symbol_scope.SymbolScope,
+        new_scope: object_scope.ScopeProxy,
+    ) -> WorkflowParser:
+        """Create a child walker with optionally replaced symbol map and scope.
+
+        Configuration (version scraping, constraints, etc.) is propagated
+        from this walker.  If *new_scope* is ``None``, ``self.scope`` is
+        reused (shared, not copied).
+        """
+        return WorkflowParser(
+            scope=new_scope,
+            symbol_map=new_symbol_map,
+            info_factory=self.info_factory,
+        )
 
     def walk(self, statements: list[ast.stmt]) -> None:
         for statement in statements:
@@ -298,6 +314,48 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             self._handle_appending_to_accumulator(cast(ast.Call, stmt.value))
         else:
             self.generic_visit(stmt)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """
+        Handle ``import foo`` and ``import foo as bar`` statements.
+
+        Resolves the imported module and registers it in the current
+        :class:`ScopeProxy` so that subsequent attribute-based calls
+        (e.g. ``foo.func(x)``) can be resolved.
+        """
+        for alias in node.names:
+            module = importlib.import_module(alias.name)
+            if alias.asname is not None:
+                # import numpy as np  →  register "np" → numpy module
+                self.scope.register(alias.asname, module)
+            else:
+                # import os.path  →  register "os" → os module (top-level only)
+                top_level_name = alias.name.split(".")[0]
+                top_level_module = importlib.import_module(top_level_name)
+                self.scope.register(top_level_name, top_level_module)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """
+        Handle ``from foo import bar`` and ``from foo import bar as baz``.
+
+        Resolves each imported name and registers it in the current scope.
+        """
+        if node.module is None:
+            raise ValueError(
+                "Relative imports without a module name are not supported in "
+                "workflow definitions."
+            )
+        for alias in node.names:
+            if alias.name == "*":
+                raise ValueError(
+                    f"Star imports (from {node.module} import *) are not supported "
+                    f"in workflow definitions.  Import specific names instead."
+                )
+        module = importlib.import_module(node.module)
+        for alias in node.names:
+            obj = getattr(module, alias.name)
+            local_name = alias.asname if alias.asname is not None else alias.name
+            self.scope.register(local_name, obj)
 
     def _handle_appending_to_accumulator(self, append_call: ast.Call) -> None:
         used_accumulator = cast(

--- a/tests/flowrep_static/local_library.py
+++ b/tests/flowrep_static/local_library.py
@@ -1,0 +1,7 @@
+"""
+For testing local imports inside parsed functions
+"""
+
+
+def my_add(a, b):
+    return a + b

--- a/tests/unit/models/parsers/test_if_parser.py
+++ b/tests/unit/models/parsers/test_if_parser.py
@@ -852,5 +852,53 @@ class TestIfParserVersionPropagation(unittest.TestCase):
         self.assertIn("Could not find a version", str(ctx.exception))
 
 
+class TestIfParserLocalImport(unittest.TestCase):
+    def test_local_import_resolves(self):
+
+        def my_wf(x, y):
+            if library.my_condition(x, y):
+                from flowrep_static.local_library import my_add as ma
+
+                sum_ = ma(x, y)
+            else:
+                sum_ = library.my_add(x, y)
+            return sum_
+
+        node = workflow_parser.parse_workflow(my_wf)
+        self.assertIsInstance(node, workflow_model.WorkflowNode)
+
+    def test_local_imports_do_not_leak_to_sibling(self):
+
+        def my_wf(x, y):
+            if library.my_condition(x, y):
+                from flowrep_static.local_library import my_add as ma
+
+                sum_ = ma(x, y)
+            else:
+                sum_ = ma(x, y)
+            return sum_
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(my_wf)
+        self.assertIn("Could not find attribute 'ma'", str(ctx.exception))
+
+    def test_local_imports_do_not_leak_to_parent(self):
+
+        def my_wf(x, y):
+            if library.my_condition(x, y):
+                from flowrep_static.local_library import my_add as ma
+
+                sum_ = ma(x, y)
+            else:
+                sum_ = library.my_add(x, y)
+
+            bigger = ma(sum_, y)
+            return bigger
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(my_wf)
+        self.assertIn("Could not find attribute 'ma'", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/models/parsers/test_try_parser.py
+++ b/tests/unit/models/parsers/test_try_parser.py
@@ -815,5 +815,53 @@ class TestTryParserVersionPropagation(unittest.TestCase):
         self.assertIn("Could not find a version", str(ctx.exception))
 
 
+class TestTryParserLocalImport(unittest.TestCase):
+    def test_local_import_resolves(self):
+
+        def my_wf(x, y):
+            try:
+                from flowrep_static.local_library import my_add as ma
+
+                sum_ = ma(x, y)
+            except ValueError:
+                sum_ = library.my_add(x, y)
+            return sum_
+
+        node = workflow_parser.parse_workflow(my_wf)
+        self.assertIsInstance(node, workflow_model.WorkflowNode)
+
+    def test_local_imports_do_not_leak_to_sibling(self):
+
+        def my_wf(x, y):
+            try:
+                from flowrep_static.local_library import my_add as ma
+
+                sum_ = ma(x, y)
+            except ValueError:
+                sum_ = ma(x, y)
+            return sum_
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(my_wf)
+        self.assertIn("Could not find attribute 'ma'", str(ctx.exception))
+
+    def test_local_imports_do_not_leak_to_parent(self):
+
+        def my_wf(x, y):
+            try:
+                from flowrep_static.local_library import my_add as ma
+
+                sum_ = ma(x, y)
+            except ValueError:
+                sum_ = library.my_add(x, y)
+
+            bigger = ma(sum_, y)
+            return bigger
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(my_wf)
+        self.assertIn("Could not find attribute 'ma'", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/models/parsers/test_workflow_parser.py
+++ b/tests/unit/models/parsers/test_workflow_parser.py
@@ -985,5 +985,63 @@ class TestWorkflowVersionScrapingPropagation(unittest.TestCase):
         self.assertEqual(child.reference.info.version, custom)
 
 
+class TestLocalImports(unittest.TestCase):
+    def test_local_imports(self):
+        def local_import(x, y):
+            import flowrep_static.local_library
+
+            sum_ = flowrep_static.local_library.my_add(x, y)
+            return sum_
+
+        def import_as(x, y):
+            import flowrep_static.local_library as ll
+
+            sum_ = ll.my_add(x, y)
+            return sum_
+
+        def import_from(x, y):
+            from flowrep_static import local_library
+
+            sum_ = local_library.my_add(x, y)
+            return sum_
+
+        def import_from_as(x, y):
+            from flowrep_static import local_library as ll
+
+            sum_ = ll.my_add(x, y)
+            return sum_
+
+        def import_function(x, y):
+            from flowrep_static.local_library import my_add
+
+            sum_ = my_add(x, y)
+            return sum_
+
+        def import_function_as(x, y):
+            from flowrep_static.local_library import my_add as ma
+
+            sum_ = ma(x, y)
+            return sum_
+
+        for wf_func in [
+            local_import,
+            import_as,
+            import_from,
+            import_from_as,
+            import_function,
+            import_function_as,
+        ]:
+            with self.subTest(wf_func.__name__):
+                node = workflow_parser.parse_workflow(wf_func)
+                self.assertEqual(
+                    node.nodes["my_add_0"].reference.info.module,
+                    "flowrep_static.local_library",
+                )
+                self.assertEqual(
+                    node.nodes["my_add_0"].reference.info.qualname,
+                    "my_add",
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
And prevent imports in conditional branches (if and try control flows) from leaking into sibling or parent contexts.

Closes #159 

I.e. we're allowed to shove imports inside the workflow definitions now, ala

```python
from flowrep_static import library

def my_wf(x, y):
    try:
        from flowrep_static.local_library import my_add as ma

        sum_ = ma(x, y)
    except ValueError:
        sum_ = library.my_add(x, y)
    return sum_
```

Note that in the process of parsing the function as a recipe, the local library will also get imported. That means that the speed benefit of shoving the import inside is lost if the `@workflow` decorator is added to the function. That means that if you want to delay the import until the node is used, delay parsing the function as a recipe until the node is used (or write your recipe in any way other than parsing it from python). It's bad python form to not import at the top of the module anyhow, and IIRC the original motivation was that `pyiron_base` and `pyiron_atomistics` imported horribly slowly. So ultimately I don't really mind much if `@workflow` discourages these local imports, as you can still access the "speedup" by doing anything other than early-parsing a recipe from a python definition.