### PR TITLE
Remove source code field

### DIFF
--- a/flowrep/models/nodes/atomic_model.py
+++ b/flowrep/models/nodes/atomic_model.py
@@ -53,7 +53,6 @@ class AtomicNode(base_models.NodeModel):
         default=base_models.RecipeElementType.ATOMIC, frozen=True
     )
     reference: base_models.PythonReference
-    source_code: str | None = None
     unpack_mode: UnpackMode = UnpackMode.TUPLE
 
     @property

--- a/flowrep/models/nodes/workflow_model.py
+++ b/flowrep/models/nodes/workflow_model.py
@@ -44,7 +44,6 @@ class WorkflowNode(base_models.NodeModel):
     edges: edge_models.Edges
     output_edges: edge_models.OutputEdges
     reference: base_models.PythonReference | None = None
-    source_code: str | None = None
 
     @property
     def inputs_with_defaults(self) -> base_models.Labels:

--- a/flowrep/models/parsers/atomic_parser.py
+++ b/flowrep/models/parsers/atomic_parser.py
@@ -125,13 +125,11 @@ def parse_atomic(
             f"unpacking mode '{unpack_mode}', got but got {output_labels}."
         )
 
-    source_code = parser_helpers.get_available_source_code(func)
     return atomic_model.AtomicNode(
         reference=base_models.PythonReference(
             info=info,
             inputs_with_defaults=[label for label, hd in input_info.items() if hd],
         ),
-        source_code=source_code,
         inputs=list(input_info),
         outputs=(
             list(output_labels) if len(output_labels) > 0 else scraped_output_labels

--- a/flowrep/models/parsers/workflow_parser.py
+++ b/flowrep/models/parsers/workflow_parser.py
@@ -142,8 +142,7 @@ def parse_workflow(
     if not state.found_return:
         raise ValueError("Workflow python definitions must have a return statement.")
 
-    source_code = parser_helpers.get_available_source_code(func)
-    return state.build_model(inputs_override=inputs, source_code=source_code)
+    return state.build_model(inputs_override=inputs)
 
 
 def skip_docstring(body: list[ast.stmt]) -> list[ast.stmt]:
@@ -208,7 +207,6 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
     def build_model(
         self,
         inputs_override: list[str] | None = None,
-        source_code: str | None = None,
     ) -> workflow_model.WorkflowNode:
         return workflow_model.WorkflowNode(
             inputs=self.inputs if inputs_override is None else inputs_override,
@@ -218,7 +216,6 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             edges=self.edges,
             output_edges=self.output_edges,
             reference=self.source,
-            source_code=source_code,
         )
 
     def fork(

--- a/tests/integration/parsers/test_parsing_composite_workflow.py
+++ b/tests/integration/parsers/test_parsing_composite_workflow.py
@@ -3,7 +3,7 @@ import unittest
 from pyiron_snippets import versions
 
 from flowrep.models.nodes import workflow_model
-from flowrep.models.parsers import atomic_parser, parser_helpers, workflow_parser
+from flowrep.models.parsers import atomic_parser, workflow_parser
 
 from flowrep_static import library
 
@@ -267,7 +267,6 @@ full_composite_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(full_composite),
     }
 )
 

--- a/tests/integration/parsers/test_parsing_for_nodes.py
+++ b/tests/integration/parsers/test_parsing_for_nodes.py
@@ -1,7 +1,7 @@
 import unittest
 
 from flowrep.models.nodes import for_model, workflow_model
-from flowrep.models.parsers import atomic_parser, parser_helpers, workflow_parser
+from flowrep.models.parsers import atomic_parser, workflow_parser
 
 from flowrep_static import library
 
@@ -82,7 +82,6 @@ single_iteration_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(single_iteration),
     }
 )
 
@@ -182,9 +181,6 @@ zbat_wf_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(
-            zipped_broadcast_and_transferred
-        ),
     }
 )
 
@@ -292,7 +288,6 @@ nested_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(nested),
     }
 )
 
@@ -418,9 +413,6 @@ nested_with_passed_input_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(
-            nested_with_passed_input
-        ),
     }
 )
 

--- a/tests/integration/parsers/test_parsing_if_nodes.py
+++ b/tests/integration/parsers/test_parsing_if_nodes.py
@@ -1,7 +1,7 @@
 import unittest
 
 from flowrep.models.nodes import workflow_model
-from flowrep.models.parsers import parser_helpers, workflow_parser
+from flowrep.models.parsers import workflow_parser
 
 from flowrep_static import library
 
@@ -84,7 +84,6 @@ simple_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(simple_if_else),
     }
 )
 
@@ -196,7 +195,6 @@ elif_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(if_elif_else),
     }
 )
 
@@ -283,7 +281,6 @@ context_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(if_with_context),
     }
 )
 
@@ -389,7 +386,6 @@ multi_output_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(multi_output_if),
     }
 )
 
@@ -458,7 +454,6 @@ no_else_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(if_no_else),
     }
 )
 

--- a/tests/integration/parsers/test_parsing_try_nodes.py
+++ b/tests/integration/parsers/test_parsing_try_nodes.py
@@ -3,7 +3,7 @@ import unittest
 from pyiron_snippets import versions
 
 from flowrep.models.nodes import workflow_model
-from flowrep.models.parsers import parser_helpers, workflow_parser
+from flowrep.models.parsers import workflow_parser
 
 from flowrep_static import library
 
@@ -88,7 +88,6 @@ simple_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(simple_try_except),
     }
 )
 
@@ -194,7 +193,6 @@ multi_except_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(try_multi_except),
     }
 )
 
@@ -283,7 +281,6 @@ context_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(try_with_context),
     }
 )
 
@@ -383,7 +380,6 @@ multi_output_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(multi_output_try),
     }
 )
 
@@ -468,7 +464,6 @@ tuple_exc_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(try_tuple_exceptions),
     }
 )
 

--- a/tests/integration/parsers/test_parsing_while_nodes.py
+++ b/tests/integration/parsers/test_parsing_while_nodes.py
@@ -1,7 +1,7 @@
 import unittest
 
 from flowrep.models.nodes import while_model, workflow_model
-from flowrep.models.parsers import parser_helpers, workflow_parser
+from flowrep.models.parsers import workflow_parser
 
 from flowrep_static import library
 
@@ -81,7 +81,6 @@ simple_while_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": ["a", "b", "c"],
         },
-        "source_code": parser_helpers.get_available_source_code(simple_while),
     }
 )
 
@@ -200,7 +199,6 @@ nest_while_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(nested_while),
     }
 )
 
@@ -286,7 +284,6 @@ multi_reassign_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(multi_reassign),
     }
 )
 
@@ -379,7 +376,6 @@ sequential_whiles_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(sequential_whiles),
     }
 )
 
@@ -456,7 +452,6 @@ chained_body_node = workflow_model.WorkflowNode.model_validate(
             },
             "inputs_with_defaults": [],
         },
-        "source_code": parser_helpers.get_available_source_code(chained_body),
     }
 )
 

--- a/tests/unit/models/nodes/test_atomic_model.py
+++ b/tests/unit/models/nodes/test_atomic_model.py
@@ -287,43 +287,5 @@ class TestAtomicNodeHasDefault(unittest.TestCase):
             )
 
 
-class TestAtomicNodeSourceCode(unittest.TestCase):
-    """Tests for the optional source_code field."""
-
-    def test_defaults_to_none(self):
-        node = atomic_model.AtomicNode(
-            reference=makers.make_reference(), inputs=[], outputs=[]
-        )
-        self.assertIsNone(node.source_code)
-
-    def test_accepts_string(self):
-        node = atomic_model.AtomicNode(
-            reference=makers.make_reference(),
-            inputs=[],
-            outputs=[],
-            source_code="def func(): pass",
-        )
-        self.assertEqual(node.source_code, "def func(): pass")
-
-    def test_roundtrip(self):
-        original = atomic_model.AtomicNode(
-            reference=makers.make_reference(),
-            inputs=["a"],
-            outputs=["b"],
-            source_code="def func(a):\n    return a",
-        )
-        for mode in ["json", "python"]:
-            with self.subTest(mode=mode):
-                data = original.model_dump(mode=mode)
-                restored = atomic_model.AtomicNode.model_validate(data)
-                self.assertEqual(original.source_code, restored.source_code)
-
-    def test_json_structure_null_when_absent(self):
-        node = atomic_model.AtomicNode(
-            reference=makers.make_reference(), inputs=[], outputs=[]
-        )
-        self.assertIsNone(node.model_dump(mode="json")["source_code"])
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/models/nodes/test_workflow_model.py
+++ b/tests/unit/models/nodes/test_workflow_model.py
@@ -929,36 +929,5 @@ class TestWorkflowNodeHasDefault(unittest.TestCase):
         self.assertIn("z", str(ctx.exception))
 
 
-class TestWorkflowNodeSourceCode(unittest.TestCase):
-    """Tests for the optional source_code field."""
-
-    def _minimal_wf(self, **overrides):
-        defaults = dict(
-            inputs=[],
-            outputs=[],
-            nodes={},
-            input_edges={},
-            edges={},
-            output_edges={},
-        )
-        defaults.update(overrides)
-        return workflow_model.WorkflowNode(**defaults)
-
-    def test_defaults_to_none(self):
-        self.assertIsNone(self._minimal_wf().source_code)
-
-    def test_accepts_string(self):
-        wf = self._minimal_wf(source_code="def wf(): pass")
-        self.assertEqual(wf.source_code, "def wf(): pass")
-
-    def test_roundtrip(self):
-        original = self._minimal_wf(source_code="def wf(x):\n    return x")
-        for mode in ["json", "python"]:
-            with self.subTest(mode=mode):
-                data = original.model_dump(mode=mode)
-                restored = workflow_model.WorkflowNode.model_validate(data)
-                self.assertEqual(original.source_code, restored.source_code)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/models/parsers/test_atomic_parser.py
+++ b/tests/unit/models/parsers/test_atomic_parser.py
@@ -1005,22 +1005,5 @@ class TestParseAtomicHasDefault(unittest.TestCase):
                 self.assertEqual(restored.reference.inputs_with_defaults, ["b", "c"])
 
 
-class TestParseAtomicSourceCode(unittest.TestCase):
-    def test_source_code_populated(self):
-        def my_func(x):
-            return x
-
-        node = atomic_parser.parse_atomic(my_func)
-        self.assertIsNotNone(node.source_code)
-        self.assertIn("def my_func", node.source_code)
-
-    def test_source_code_none_when_unavailable(self):
-        f = _make_func_in_module("__main__", "f")
-        node = atomic_parser.parse_atomic(f)
-        # _make_func_in_module creates a real function with source,
-        # but exec-defined ones won't; just check the field exists
-        self.assertIsInstance(node.source_code, (str, type(None)))
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/models/parsers/test_workflow_parser.py
+++ b/tests/unit/models/parsers/test_workflow_parser.py
@@ -889,38 +889,6 @@ class TestParseWorkflowHasDefault(unittest.TestCase):
                 self.assertEqual(restored.reference.inputs_with_defaults, ["b"])
 
 
-class TestParseWorkflowSourceCode(unittest.TestCase):
-    def test_source_code_populated(self):
-        def my_wf(x):
-            y = add(x)
-            return y
-
-        node = workflow_parser.parse_workflow(my_wf)
-        self.assertIsNotNone(node.source_code)
-        self.assertIn("def my_wf", node.source_code)
-
-    def test_decorator_populates_source_code(self):
-        @workflow_parser.workflow
-        def decorated_wf(x):
-            y = add(x)
-            return y
-
-        self.assertIsNotNone(decorated_wf.flowrep_recipe.source_code)
-        self.assertIn("def decorated_wf", decorated_wf.flowrep_recipe.source_code)
-
-    def test_source_code_roundtrips(self):
-        def my_wf(x):
-            y = add(x)
-            return y
-
-        node = workflow_parser.parse_workflow(my_wf)
-        for mode in ["json", "python"]:
-            with self.subTest(mode=mode):
-                data = node.model_dump(mode=mode)
-                restored = workflow_model.WorkflowNode.model_validate(data)
-                self.assertEqual(node.source_code, restored.source_code)
-
-
 class TestWorkflowVersionScrapingPropagation(unittest.TestCase):
     """Verify version_scraping propagates to child nodes parsed inside a workflow."""
 


### PR DESCRIPTION
from atomic and workflow node models.

Per discussions with @samwaseda, internal non-local calls a variables actually make naive storage of the source code rather useless. We can return to storing it (probably inside the `PythonReference`) in the future if we get some robust/cleanly failing validation for when it is not useful.