### PR TITLE
Allow pass-through data in workflows

### DIFF
--- a/flowrep/models/parsers/workflow_parser.py
+++ b/flowrep/models/parsers/workflow_parser.py
@@ -432,20 +432,12 @@ class _WorkflowFunctionParser(WorkflowParser):
         final_ports = list(output_labels) if output_labels else scraped_labels
 
         for symbol, port in zip(returned_symbols, final_ports, strict=True):
-            try:
-                source = self.symbol_map[symbol]
-            except KeyError as e:
+            if symbol not in self.symbol_map:
                 raise ValueError(
                     f"Return symbol '{symbol}' is not defined. "
                     f"Available: {list(self.symbol_map)}"
-                ) from e
-
-            if isinstance(source, edge_models.InputSource):
-                raise ValueError(
-                    f"Workflows expect outputs to be sourced from the subgraph children, "
-                    f"but the symbol '{symbol}' appears to be resolved directly from the "
-                    f"workflow inputs."
                 )
+
             self.symbol_map.produce(port, symbol)
 
 

--- a/tests/unit/models/parsers/test_workflow_parser.py
+++ b/tests/unit/models/parsers/test_workflow_parser.py
@@ -223,6 +223,14 @@ class TestParseWorkflowBasic(unittest.TestCase):
         self.assertIn(target_y, node.input_edges)
         self.assertEqual(node.input_edges[target_y].port, "b")
 
+    def test_returning_input_directly_is_allowed(self):
+        def wf(x):
+            return x
+
+        node = workflow_parser.parse_workflow(wf)
+        self.assertIn("x", node.outputs)
+        self.assertIn(edge_models.InputSource(port="x"), node.output_edges.values())
+
 
 class TestParseWorkflowEdges(unittest.TestCase):
     def test_input_edges_from_workflow_inputs(self):
@@ -446,14 +454,6 @@ class TestParseWorkflowErrors(unittest.TestCase):
         with self.assertRaises(KeyError) as ctx:
             workflow_parser.parse_workflow(wf)
         self.assertIn("unknown_var", str(ctx.exception).lower())
-
-    def test_returning_input_directly_raises(self):
-        def wf(x):
-            return x
-
-        with self.assertRaises(ValueError) as ctx:
-            workflow_parser.parse_workflow(wf)
-        self.assertIn("workflow inputs", str(ctx.exception).lower())
 
     def test_non_call_rhs_raises(self):
         def wf(x):


### PR DESCRIPTION
It's usually going to be wasteful, but I don't think it needs to be strictly forbidden.