### PR TITLE
Fix optional dependencies

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -33,3 +33,13 @@ jobs:
       extra-python-paths: tests
       # Don't include the API in coverage
       omit-patterns: '*/flowrep/api/*'
+
+  tests-without-optionals:
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.13
+    secrets: inherit
+    with:
+      tests-env-files: .ci_support/environment.yml
+      test-dir: tests/unit
+      extra-python-paths: tests
+      do-coveralls: false
+      do-codecov: false

--- a/src/flowrep/storage.py
+++ b/src/flowrep/storage.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from bagofholding import H5Bag
 
 
-@_import_alarm
 class LexicalBagBrowser:
     """
     A convenience class for browsing and loading data from
@@ -34,6 +33,7 @@ class LexicalBagBrowser:
     "inputs/outputs", and port names) instead of the actual H5 path inside the file.
     """
 
+    @_import_alarm
     def __init__(self, bag: H5Bag | str | pathlib.Path):
         if isinstance(bag, (str, pathlib.Path)):
             self.bag = boh.H5Bag(bag)

--- a/src/flowrep/storage.py
+++ b/src/flowrep/storage.py
@@ -15,7 +15,7 @@ from pyiron_snippets import import_alarm
 from flowrep import base_models, live, storage_widget
 
 with import_alarm.ImportAlarm(
-    "This tool requires the 'bagofholding' package."
+    "This tool requires the 'bagofholding' package.", raise_exception=True
 ) as _import_alarm:
     import bagofholding as boh
 

--- a/src/flowrep/storage_widget.py
+++ b/src/flowrep/storage_widget.py
@@ -13,11 +13,19 @@ from flowrep import base_models
 
 
 class _Base:
-    """A flexible faux base class in case ipytree is not available"""
+    """
+    A flexible faux base class in case ipytree is not available.
+
+    Satisfy mypy with method stubs from methods called from the true base,
+    `ipytree.Tree`.
+    """
 
     def __init__(self, *args, **kwargs):
         pass
 
+    def observe(self, *args, **kwargs): ...
+
+    def add_node(self, *args, **kwargs): ...
 
 
 with import_alarm.ImportAlarm(
@@ -25,7 +33,7 @@ with import_alarm.ImportAlarm(
 ) as _import_alarm:
     import ipytree
 
-    _Base = ipytree.Tree
+    _Base = ipytree.Tree  # type: ignore[misc]
 
 if TYPE_CHECKING:
     import traitlets  # Expected as a dependency of ipytree

--- a/src/flowrep/storage_widget.py
+++ b/src/flowrep/storage_widget.py
@@ -19,7 +19,10 @@ class _Base:
         pass
 
 
-with import_alarm.ImportAlarm("This tool requires 'ipytree'.") as _import_alarm:
+
+with import_alarm.ImportAlarm(
+    "This tool requires 'ipytree'.", raise_exception=True
+) as _import_alarm:
     import ipytree
 
     _Base = ipytree.Tree

--- a/src/flowrep/storage_widget.py
+++ b/src/flowrep/storage_widget.py
@@ -11,8 +11,12 @@ from pyiron_snippets import import_alarm
 
 from flowrep import base_models
 
+_Base: type = object
+
 with import_alarm.ImportAlarm("This tool requires 'ipytree'.") as _import_alarm:
     import ipytree
+
+    _Base = ipytree.Tree
 
 if TYPE_CHECKING:
     import traitlets  # Expected as a dependency of ipytree
@@ -28,7 +32,7 @@ class _NodeMeta:
     loaded: bool = False
 
 
-class LexicalBagTree(ipytree.Tree):
+class LexicalBagTree(_Base):
     """Notebook tree widget driven by lexical paths."""
 
     @_import_alarm

--- a/src/flowrep/storage_widget.py
+++ b/src/flowrep/storage_widget.py
@@ -20,7 +20,7 @@ class _Base:
     `ipytree.Tree`.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # pragma: no cover
         pass
 
     def observe(self, *args, **kwargs): ...

--- a/src/flowrep/storage_widget.py
+++ b/src/flowrep/storage_widget.py
@@ -11,7 +11,13 @@ from pyiron_snippets import import_alarm
 
 from flowrep import base_models
 
-_Base: type = object
+
+class _Base:
+    """A flexible faux base class in case ipytree is not available"""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
 
 with import_alarm.ImportAlarm("This tool requires 'ipytree'.") as _import_alarm:
     import ipytree

--- a/tests/unit/converters/test_python_workflow_definition.py
+++ b/tests/unit/converters/test_python_workflow_definition.py
@@ -11,7 +11,6 @@ import unittest
 from pathlib import Path
 
 import pydantic
-import python_workflow_definition.models as pwd_models
 
 from flowrep import edge_models
 from flowrep.converters import python_workflow_definition as pwd_conv
@@ -22,6 +21,13 @@ from flowrep.nodes import (
 from flowrep.parsers import workflow_parser
 
 from flowrep_static import library, makers  # noqa: E402
+
+try:
+    import python_workflow_definition.models as pwd_models
+
+    _has_pwd = True
+except ImportError:
+    _has_pwd = False
 
 _PWD_JSON_WORKFLOW_LOCATION = (
     Path(__file__).resolve().parent.parent.parent
@@ -144,13 +150,16 @@ def _assert_flowrep_roundtrip_equal(
     tc.assertEqual(terminal_inputs, defaults_rt)
 
 
-def _load_pwd_workflow(name: str) -> pwd_models.PythonWorkflowDefinitionWorkflow:
+def _load_pwd_workflow(
+    name: str,
+) -> pwd_models.PythonWorkflowDefinitionWorkflow:
     path = _PWD_JSON_WORKFLOW_LOCATION / name
     with open(path, encoding="utf-8") as f:
         data = json.load(f)
     return pwd_models.PythonWorkflowDefinitionWorkflow.model_validate(data)
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestPortSanitization(unittest.TestCase):
     """Unit tests for pwd._sanitize_port / pwd._desanitize_port."""
 
@@ -202,6 +211,7 @@ class TestPortSanitization(unittest.TestCase):
                 self.assertTrue(sanitized.isidentifier())
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestPwd2FlowrepArithmetic(unittest.TestCase):
     """Smoke-test conversion of the arithmetic example."""
 
@@ -236,6 +246,7 @@ class TestPwd2FlowrepArithmetic(unittest.TestCase):
         self.assertEqual(set(prod_div[0].outputs), {"prod", "div"})
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestPwd2FlowrepNfdi(unittest.TestCase):
     """Smoke-test conversion of the NFDI example."""
 
@@ -264,6 +275,7 @@ class TestPwd2FlowrepNfdi(unittest.TestCase):
         self.assertGreater(len(source_edges), 1)
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestPwd2FlowrepQuantumEspresso(unittest.TestCase):
     """Smoke-test conversion of the quantum-espresso example."""
 
@@ -309,6 +321,7 @@ class TestPwd2FlowrepQuantumEspresso(unittest.TestCase):
                     self.assertTrue(port.startswith(pwd_conv._PORT_SANITIZE_PREFIX))
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestPwd2FlowrepErrorCases(unittest.TestCase):
 
     def test_cycle_raises_validation_error(self):
@@ -428,6 +441,7 @@ class TestPwd2FlowrepErrorCases(unittest.TestCase):
         self.assertEqual(wf_result.nodes["func_b_0"].outputs, [])
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestFlowrep2PwdValidation(unittest.TestCase):
     """Edge-case validation in pwd.flowrep2pwd."""
 
@@ -517,6 +531,7 @@ class TestFlowrep2PwdValidation(unittest.TestCase):
         self.assertIsInstance(result, pwd_models.PythonWorkflowDefinitionWorkflow)
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestRoundTripPwdToFlowrep(unittest.TestCase):
     """pwd → flowrep → pwd → flowrep must produce identical flowrep structure."""
 
@@ -541,6 +556,7 @@ class TestRoundTripPwdToFlowrep(unittest.TestCase):
         self._assert_roundtrip("quantum_espresso-workflow.json")
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestRoundTripFlowrepToPwd(unittest.TestCase):
     """flowrep → pwd → flowrep must preserve graph structure."""
 
@@ -636,6 +652,7 @@ class TestRoundTripFlowrepToPwd(unittest.TestCase):
         self.assertEqual(add_node.outputs, fr_rt.nodes["add_0"].outputs)
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestDefaultOutputPort(unittest.TestCase):
     """Verify that the null-sourcePort ↔ ``pwd.DEFAULT_OUTPUT_PORT`` mapping works."""
 
@@ -690,6 +707,7 @@ class TestDefaultOutputPort(unittest.TestCase):
         self.assertEqual(len(named_orig), len(named_rt))
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestSanitizedPortRoundTrip(unittest.TestCase):
     """Integer-string ports from ``get_list`` survive a full round-trip."""
 
@@ -742,6 +760,7 @@ class TestSanitizedPortRoundTrip(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestRoundTripEdgeNodeCounts(unittest.TestCase):
     """Quick structural invariant: node/edge counts survive a full round-trip."""
 
@@ -763,6 +782,7 @@ class TestRoundTripEdgeNodeCounts(unittest.TestCase):
         self._assert_counts_preserved("quantum_espresso-workflow.json")
 
 
+@unittest.skipUnless(_has_pwd, "python_workflow_definition not installed")
 class TestPassThroughEdge(unittest.TestCase):
     """A workflow input wired directly to a workflow output, bypassing all nodes."""
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -9,11 +9,23 @@ import tempfile
 import unittest
 from unittest import mock
 
-import bagofholding as boh
-
 from flowrep import live, storage, storage_widget, wfms
 
 from flowrep_static import library
+
+try:
+    import bagofholding as boh
+
+    _has_boh = True
+except ImportError:
+    _has_boh = False
+
+try:
+    import ipytree  # noqa: F401
+
+    _has_ipytree = True
+except ImportError:
+    _has_ipytree = False
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helpers
@@ -35,6 +47,7 @@ def _save_voidflow(path: str):
     return live_wf
 
 
+@unittest.skipUnless(_has_boh, "bagofholding not installed")
 class _BagTestCase(unittest.TestCase):
     """Base class that provides a temporary directory cleaned up after each test."""
 
@@ -326,13 +339,17 @@ class TestLexicalBagBrowserMethods(_BagTestCase):
 
     def test_browse_returns_widget(self):
         result = self.browser.browse()
-        self.assertIsInstance(result, storage_widget.LexicalBagTree)
+        if _has_ipytree:
+            self.assertIsInstance(result, storage_widget.LexicalBagTree)
+        else:
+            self.assertIsInstance(result, list)
 
     def test_browse_falls_back_to_list(self):
         with mock.patch.object(self.browser, "widget", side_effect=ImportError):
             result = self.browser.browse()
         self.assertIsInstance(result, list)
 
+    @unittest.skipUnless(_has_ipytree, "ipytree not installed")
     def test_widget_returns_tree(self):
         result = self.browser.widget()
         self.assertIsInstance(result, storage_widget.LexicalBagTree)

--- a/tests/unit/test_storage_widget.py
+++ b/tests/unit/test_storage_widget.py
@@ -4,13 +4,12 @@ import os
 import tempfile
 import unittest
 
-import bagofholding as boh
-
 from flowrep import live, storage, storage_widget, wfms
 
 from flowrep_static import library
 
 try:
+    import bagofholding as boh
     import ipytree
 
     _has_ipytree = True

--- a/tests/unit/test_storage_widget.py
+++ b/tests/unit/test_storage_widget.py
@@ -74,7 +74,7 @@ class TestImportAlarm(unittest.TestCase):
 
     @unittest.skipIf(_has_ipytree, "ipytree IS installed; alarm won't fire")
     def test_alarm_fires_without_ipytree(self):
-        with self.assertRaisesRegex(ImportWarning, "ipytree"):
+        with self.assertRaisesRegex(ImportError, "ipytree"):
             storage_widget.LexicalBagTree(mock.MagicMock())
 
 

--- a/tests/unit/test_storage_widget.py
+++ b/tests/unit/test_storage_widget.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from flowrep import live, storage, storage_widget, wfms
 
@@ -74,10 +75,7 @@ class TestImportAlarm(unittest.TestCase):
     @unittest.skipIf(_has_ipytree, "ipytree IS installed; alarm won't fire")
     def test_alarm_fires_without_ipytree(self):
         with self.assertWarns(ImportWarning):
-            path = os.path.join(tempfile.mkdtemp(), "dummy.h5")
-            _save_workflow(path, a=1, b=2)
-            browser = storage.LexicalBagBrowser(path)
-            storage_widget.LexicalBagTree(browser)
+            storage_widget.LexicalBagTree(mock.MagicMock())
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/test_storage_widget.py
+++ b/tests/unit/test_storage_widget.py
@@ -5,11 +5,17 @@ import tempfile
 import unittest
 
 import bagofholding as boh
-import ipytree
 
 from flowrep import live, storage, storage_widget, wfms
 
 from flowrep_static import library
+
+try:
+    import ipytree
+
+    _has_ipytree = True
+except ImportError:
+    _has_ipytree = False
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helpers
@@ -30,6 +36,7 @@ def _save_voidflow(path: str):
     return live_wf
 
 
+@unittest.skipUnless(_has_ipytree, "ipytree not installed")
 class _WidgetTestCase(unittest.TestCase):
     """Base class providing a browser backed by a temporary H5 file."""
 
@@ -43,12 +50,35 @@ class _WidgetTestCase(unittest.TestCase):
         self.browser = storage.LexicalBagBrowser(path)
         self.tree = storage_widget.LexicalBagTree(self.browser)
 
-    def _root_node(self) -> ipytree.Node:
+    def _root_node(self) -> "ipytree.Node":
         return self._get_root_node(self.tree)
 
     @staticmethod
-    def _get_root_node(tree) -> ipytree.Node:
+    def _get_root_node(tree) -> "ipytree.Node":
         return tree.nodes[0]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Import alarm behaviour
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestImportAlarm(unittest.TestCase):
+    """The module itself should always be importable."""
+
+    def test_module_importable(self):
+        """storage_widget can be imported regardless of ipytree availability."""
+        from flowrep import storage_widget as sw  # noqa: F811
+
+        self.assertTrue(hasattr(sw, "LexicalBagTree"))
+
+    @unittest.skipIf(_has_ipytree, "ipytree IS installed; alarm won't fire")
+    def test_alarm_fires_without_ipytree(self):
+        with self.assertWarns(ImportWarning):
+            path = os.path.join(tempfile.mkdtemp(), "dummy.h5")
+            _save_workflow(path, a=1, b=2)
+            browser = storage.LexicalBagBrowser(path)
+            storage_widget.LexicalBagTree(browser)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -179,7 +209,7 @@ class TestOnSelect(_WidgetTestCase):
 
 
 class TestLazyExpand(_WidgetTestCase):
-    def _find_collapsed_node(self) -> ipytree.Node:
+    def _find_collapsed_node(self) -> "ipytree.Node":
         """Find a child that has a '...' placeholder (not yet expanded)."""
         root = self._root_node()
         for child in root.nodes:
@@ -248,7 +278,7 @@ class TestHasExpandableChildren(_WidgetTestCase):
 
 
 class TestIOGroupExpansion(_WidgetTestCase):
-    def _find_io_group(self, io_type: str) -> ipytree.Node:
+    def _find_io_group(self, io_type: str) -> "ipytree.Node":
         root = self._root_node()
         for child in root.nodes:
             if child.name == io_type:

--- a/tests/unit/test_storage_widget.py
+++ b/tests/unit/test_storage_widget.py
@@ -74,7 +74,7 @@ class TestImportAlarm(unittest.TestCase):
 
     @unittest.skipIf(_has_ipytree, "ipytree IS installed; alarm won't fire")
     def test_alarm_fires_without_ipytree(self):
-        with self.assertWarns(ImportWarning):
+        with self.assertRaisesRegex(ImportWarning, "ipytree"):
             storage_widget.LexicalBagTree(mock.MagicMock())
 
 


### PR DESCRIPTION
Critically, `LexicalBagTree` inherited directly from `ipytree.Tree`, so [conda couldn't build it](https://github.com/conda-forge/flowrep-feedstock/pull/28). Now I try to fix that, wrap all the tests for optional features in skipif/skipunless infrastructure, and add a job to explicitly run the unit tests _without_ the optional dependencies.