### PR TITLE
Add `OutputEdges` to the API schemas

### DIFF
--- a/src/flowrep/api/schemas.py
+++ b/src/flowrep/api/schemas.py
@@ -15,6 +15,7 @@ from flowrep.base_models import RestrictedParamKind as RestrictedParamKind
 from flowrep.edge_models import Edges as Edges
 from flowrep.edge_models import InputEdges as InputEdges
 from flowrep.edge_models import InputSource as InputSource
+from flowrep.edge_models import OutputEdges as OutputEdges
 from flowrep.edge_models import OutputTarget as OutputTarget
 from flowrep.edge_models import SourceHandle as SourceHandle
 from flowrep.edge_models import TargetHandle as TargetHandle


### PR DESCRIPTION
It was just an oversight, they need to be there for completeness and symmetry.