### PR TITLE
Propagate bagofholding bump

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - python >=3.11, <3.15
 - pydantic =2.12.5
 - pyiron_snippets =1.2.1
-- bagofholding =0.1.10
+- bagofholding =0.1.11
 - ipytree =0.2.2
 - python-workflow-definition =0.1.4
 - numpy =2.4.2

--- a/.ci_support/environment-optional.yml
+++ b/.ci_support/environment-optional.yml
@@ -1,6 +1,6 @@
 channels:
 - conda-forge
 dependencies:
-- bagofholding =0.1.10
+- bagofholding =0.1.11
 - ipytree =0.2.2
 - python-workflow-definition =0.1.4

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,6 @@ dependencies:
 - python >=3.11, <3.15
 - pydantic =2.12.5
 - pyiron_snippets =1.2.1
-- bagofholding =0.1.10
+- bagofholding =0.1.11
 - ipytree =0.2.2
 - python-workflow-definition =0.1.4


### PR DESCRIPTION
I should have looked more carefully at the dependabot PR -- it only hit the pyproject.toml