### PR TITLE
Extend variadics to `LiveNode`

### DIFF
--- a/src/flowrep/live.py
+++ b/src/flowrep/live.py
@@ -82,10 +82,12 @@ class LiveNode(abc.ABC):
     output_ports: MutableMapping[base_models.Label, OutputPort]
 
 
-def recipe2live(recipe: union.NodeType) -> LiveNode:
+def recipe2live(recipe: union.NodeType, allow_variadic_inputs: bool = True) -> LiveNode:
     match recipe:
         case atomic_model.AtomicNode():
-            return LiveAtomic.from_recipe(recipe)
+            return LiveAtomic.from_recipe(
+                recipe, allow_variadic_inputs=allow_variadic_inputs
+            )
         case for_model.ForEachNode():
             return FlowControl.from_recipe(recipe)
         case if_model.IfNode():
@@ -95,7 +97,9 @@ def recipe2live(recipe: union.NodeType) -> LiveNode:
         case while_model.WhileNode():
             return FlowControl.from_recipe(recipe)
         case workflow_model.WorkflowNode():
-            return LiveWorkflow.from_recipe(recipe)
+            return LiveWorkflow.from_recipe(
+                recipe, allow_variadic_inputs=allow_variadic_inputs
+            )
         case _:
             raise TypeError(f"Unrecognized recipe type {recipe}")
 
@@ -105,12 +109,15 @@ class LiveAtomic(LiveNode):
     function: Callable
 
     @classmethod
-    def from_recipe(cls, recipe: atomic_model.AtomicNode) -> LiveAtomic:
+    def from_recipe(
+        cls, recipe: atomic_model.AtomicNode, allow_variadic_inputs: bool = True
+    ) -> LiveAtomic:
         function, input_ports, output_ports = _parse_function(
             recipe.reference.info.fully_qualified_name,
             recipe.inputs,
             recipe.outputs,
             recipe.unpack_mode,
+            allow_variadic_inputs=allow_variadic_inputs,
         )
         return LiveAtomic(
             recipe=recipe,
@@ -131,17 +138,23 @@ class Composite(LiveNode, abc.ABC):
 @dataclasses.dataclass(frozen=False)
 class LiveWorkflow(Composite):
     @classmethod
-    def from_recipe(cls, recipe: workflow_model.WorkflowNode) -> LiveWorkflow:
+    def from_recipe(
+        cls, recipe: workflow_model.WorkflowNode, allow_variadic_inputs: bool = True
+    ) -> LiveWorkflow:
         if recipe.reference:
             function, input_ports, output_ports = _parse_function(
                 recipe.reference.info.fully_qualified_name,
                 recipe.inputs,
                 recipe.outputs,
+                allow_variadic_inputs=allow_variadic_inputs,
             )
         else:
             input_ports = {label: InputPort() for label in recipe.inputs}
             output_ports = {label: OutputPort() for label in recipe.outputs}
-        nodes = {label: recipe2live(child) for label, child in recipe.nodes.items()}
+        nodes = {
+            label: recipe2live(child, allow_variadic_inputs=allow_variadic_inputs)
+            for label, child in recipe.nodes.items()
+        }
         return LiveWorkflow(
             recipe=recipe,
             input_ports=dict(input_ports),
@@ -189,6 +202,7 @@ def _parse_function(
     inputs: list[str],
     outputs: list[str],
     unpack_mode: atomic_model.UnpackMode = atomic_model.UnpackMode.TUPLE,
+    allow_variadic_inputs: bool = True,
 ) -> tuple[
     types.FunctionType,
     dict[base_models.Label, InputPort],
@@ -198,22 +212,39 @@ def _parse_function(
     hints = get_type_hints(function, include_extras=True)
     sig = inspect.signature(function)
 
+    variadics_in_sig = {
+        name
+        for name, p in sig.parameters.items()
+        if p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    }
+    accept_extra_inputs = allow_variadic_inputs and bool(variadics_in_sig)
+
     # --- input ports ---
+    if colliding := variadics_in_sig.intersection(inputs):
+        raise ValueError(
+            f"Recipe inputs {colliding} collide with variadic parameter(s) of "
+            f"{fully_qualified_name!r}; variadic parameter names cannot be used as "
+            f"port names."
+        )
+
     available = set(sig.parameters)
     missing = set(inputs) - available
-    if missing:
+    if missing and not accept_extra_inputs:
         raise ValueError(
             f"Requested inputs {missing} not found in signature of {fully_qualified_name!r}"
         )
 
     input_ports: dict[str, InputPort] = {}
     for name in inputs:
-        param = sig.parameters[name]
+        param = sig.parameters.get(name)
         input_port = InputPort()
-        input_port.annotation = hints.get(name, None)
-        input_port.default = (
-            param.default if param.default is not inspect.Parameter.empty else NOT_DATA
-        )
+        if param is not None:
+            input_port.annotation = hints.get(name, None)
+            input_port.default = (
+                param.default
+                if param.default is not inspect.Parameter.empty
+                else NOT_DATA
+            )
         input_ports[name] = input_port
 
     # --- output ports ---

--- a/tests/unit/test_live_wfms.py
+++ b/tests/unit/test_live_wfms.py
@@ -7,7 +7,7 @@ from typing import get_origin
 
 from pyiron_snippets import versions
 
-from flowrep import edge_models, live, wfms
+from flowrep import base_models, edge_models, live, wfms
 from flowrep.live import NOT_DATA
 from flowrep.nodes import (
     atomic_model,
@@ -441,6 +441,30 @@ def unsplittable_output(x: int, y: int) -> list[int]:
     return [x, y]
 
 
+def variadic_args(*items: str):
+    """N→1 with positional variadic."""
+    return tuple(items)
+
+
+def variadic_kwargs(**items):
+    """N→1 with keyword variadic."""
+    return dict(items)
+
+
+def variadic_mixed(x: int = 0, *extras):
+    """Concrete + variadic."""
+    return (x, *extras)
+
+
+def _variadic_recipe(func, inputs, outputs=("result",)):
+    return atomic_model.AtomicNode(
+        reference=base_models.PythonReference(info=versions.VersionInfo.of(func)),
+        inputs=list(inputs),
+        outputs=list(outputs),
+        unpack_mode=atomic_model.UnpackMode.NONE,
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # live.py tests
 # ═══════════════════════════════════════════════════════════════════════════
@@ -657,6 +681,118 @@ class TestRecipe2Live(unittest.TestCase):
     def test_clean_type_failure(self):
         with self.assertRaisesRegex(TypeError, "Unrecognized recipe type"):
             live.recipe2live("this is not even a recipe")
+
+
+class TestAtomicFromRecipeVariadic(unittest.TestCase):
+    """Coverage for `_parse_function`'s `allow_variadic_inputs` path."""
+
+    def test_var_positional_extras_accepted(self):
+        recipe = _variadic_recipe(variadic_args, inputs=["a", "b", "c"])
+        node = live.LiveAtomic.from_recipe(recipe)
+        self.assertEqual(set(node.input_ports), {"a", "b", "c"})
+
+    def test_var_keyword_extras_accepted(self):
+        recipe = _variadic_recipe(variadic_kwargs, inputs=["foo", "bar"])
+        node = live.LiveAtomic.from_recipe(recipe)
+        self.assertEqual(set(node.input_ports), {"foo", "bar"})
+
+    def test_extras_have_no_annotation_or_default(self):
+        recipe = _variadic_recipe(variadic_args, inputs=["a"])
+        node = live.LiveAtomic.from_recipe(recipe)
+        self.assertIsNone(node.input_ports["a"].annotation)
+        self.assertIs(node.input_ports["a"].default, NOT_DATA)
+
+    def test_concrete_param_keeps_metadata(self):
+        recipe = _variadic_recipe(variadic_mixed, inputs=["x", "extra1", "extra2"])
+        node = live.LiveAtomic.from_recipe(recipe)
+        self.assertIs(node.input_ports["x"].annotation, int)
+        self.assertEqual(node.input_ports["x"].default, 0)
+        for extra in ("extra1", "extra2"):
+            with self.subTest(extra=extra):
+                self.assertIsNone(node.input_ports[extra].annotation)
+                self.assertIs(node.input_ports[extra].default, NOT_DATA)
+
+    def test_default_flag_is_lenient(self):
+        recipe = _variadic_recipe(variadic_args, inputs=["a", "b"])
+        node = live.LiveAtomic.from_recipe(recipe)  # no flag → True
+        self.assertEqual(set(node.input_ports), {"a", "b"})
+
+    def test_disallow_with_variadic_in_sig_raises(self):
+        recipe = _variadic_recipe(variadic_args, inputs=["a", "b"])
+        with self.assertRaises(ValueError) as ctx:
+            live.LiveAtomic.from_recipe(recipe, allow_variadic_inputs=False)
+        self.assertIn("not found in signature", str(ctx.exception))
+
+    def test_disallow_with_only_concrete_inputs_is_fine(self):
+        """Flag=False is fine as long as no inputs are missing from the sig."""
+        recipe = _variadic_recipe(variadic_mixed, inputs=["x"])
+        node = live.LiveAtomic.from_recipe(recipe, allow_variadic_inputs=False)
+        self.assertIs(node.input_ports["x"].annotation, int)
+        self.assertEqual(node.input_ports["x"].default, 0)
+
+    def test_extras_without_variadic_always_raise(self):
+        """`library.identity` has no variadic absorber; extras must fail."""
+        recipe = atomic_model.AtomicNode(
+            inputs=["x", "extra"],
+            outputs=["x"],
+            reference=library.identity.flowrep_recipe.reference,
+        )
+        with self.assertRaises(ValueError) as ctx:
+            live.LiveAtomic.from_recipe(recipe, allow_variadic_inputs=True)
+        self.assertIn("not found in signature", str(ctx.exception))
+
+    def test_no_inputs_against_variadic(self):
+        recipe = _variadic_recipe(variadic_args, inputs=[])
+        node = live.LiveAtomic.from_recipe(recipe)
+        self.assertEqual(set(node.input_ports), set())
+
+    # --- collision tests; require the variadic-name collision check ----------
+
+    def test_input_collides_with_var_positional_raises(self):
+        recipe = _variadic_recipe(variadic_args, inputs=["items"])  # *items
+        with self.assertRaises(ValueError) as ctx:
+            live.LiveAtomic.from_recipe(recipe)
+        self.assertIn("collide", str(ctx.exception).lower())
+        self.assertIn("items", str(ctx.exception))
+
+    def test_input_collides_with_var_keyword_raises(self):
+        recipe = _variadic_recipe(variadic_kwargs, inputs=["items"])  # **items
+        with self.assertRaises(ValueError) as ctx:
+            live.LiveAtomic.from_recipe(recipe)
+        self.assertIn("collide", str(ctx.exception).lower())
+
+    def test_collision_check_independent_of_flag(self):
+        recipe = _variadic_recipe(variadic_args, inputs=["items"])
+        with self.assertRaises(ValueError):
+            live.LiveAtomic.from_recipe(recipe, allow_variadic_inputs=False)
+
+
+class TestRecipe2LiveVariadicPropagation(unittest.TestCase):
+    """`allow_variadic_inputs` propagates through `recipe2live` into children."""
+
+    def test_propagates_to_atomic(self):
+        recipe = _variadic_recipe(variadic_args, inputs=["a", "b"])
+        with self.assertRaises(ValueError):
+            live.recipe2live(recipe, allow_variadic_inputs=False)
+        node = live.recipe2live(recipe)
+        self.assertIsInstance(node, live.LiveAtomic)
+
+    def test_propagates_into_workflow_children(self):
+        child_recipe = _variadic_recipe(variadic_args, inputs=["a", "b"])
+        wf_recipe = _single_node_workflow(
+            inputs=["x", "y"],
+            outputs=["result"],
+            child_label="splitter_0",
+            child_recipe=child_recipe,
+            input_map={"a": "x", "b": "y"},
+            output_map={"result": "result"},
+        )
+        with self.assertRaises(ValueError):
+            live.recipe2live(wf_recipe, allow_variadic_inputs=False)
+
+        wf = live.recipe2live(wf_recipe, allow_variadic_inputs=True)
+        self.assertIsInstance(wf, live.LiveWorkflow)
+        self.assertIsInstance(wf.nodes["splitter_0"], live.LiveAtomic)
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
It was always permissible to define a recipe around a function with variadic input, but these could not be converted to a `LiveNode` because of details in the parsing. Here we allow it, guarding against inputs whose names match the variadic parameter name in the signature. (It would be nice to do such a check earlier, but a key element of the recipes is that we don't actually import the underlying functions, so we have nothing to compare against.)