### PR TITLE
Disallow child input from having two sources

### DIFF
--- a/src/flowrep/nodes/workflow_model.py
+++ b/src/flowrep/nodes/workflow_model.py
@@ -93,3 +93,15 @@ class WorkflowNode(base_models.NodeModel):
             )
         func = retrieve.import_from_string(self.reference.info.fully_qualified_name)
         return func(*args, **kwargs)
+
+    @pydantic.model_validator(mode="after")
+    def validate_child_input_single_source(self):
+        if two_sources := tuple(
+            target for target in self.input_edges if target in self.edges
+        ):
+            raise ValueError(
+                "Child input may have a parent source or a peer source, but not both. "
+                "Dual sourced input: "
+                f"{tuple(target.serialize() for target in two_sources)}"
+            )
+        return self

--- a/tests/unit/nodes/test_workflow_model.py
+++ b/tests/unit/nodes/test_workflow_model.py
@@ -320,6 +320,34 @@ class TestWorkflowNodeInternalEdges(unittest.TestCase):
         self.assertIn("wrong", str(ctx.exception))
 
 
+class TestWorkflowNodeChildrenOversourced(unittest.TestCase):
+    def test_too_many_sources(self):
+        with self.assertRaises(pydantic.ValidationError) as ctx:
+            workflow_model.WorkflowNode(
+                inputs=["x"],
+                outputs=[],
+                nodes={
+                    "a": makers.make_atomic(inputs=["inp"], outputs=["out"]),
+                    "b": makers.make_atomic(inputs=["inp"], outputs=["out"]),
+                },
+                input_edges={
+                    edge_models.TargetHandle(
+                        node="a", port="inp"
+                    ): edge_models.InputSource(port="x"),
+                    edge_models.TargetHandle(
+                        node="b", port="inp"
+                    ): edge_models.InputSource(port="x"),
+                },
+                edges={
+                    edge_models.TargetHandle(
+                        node="b", port="inp"
+                    ): edge_models.SourceHandle(node="a", port="out"),
+                },
+                output_edges={},
+            )
+        self.assertIn("'b.inp'", str(ctx.exception))
+
+
 class TestWorkflowNodeFullySourcing(unittest.TestCase):
     """Tests that validate_internal_data_completeness catches unsourced child inputs."""
 


### PR DESCRIPTION
By cross-checking parent and peer sources

Closes #241 