### PR TITLE
Improve API access

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -255,20 +255,16 @@ these underlying functions when we run the recipe with a WfMS.
 
 Recipes are *prospective* — they describe a computation template without holding
 data. For retrospective analysis (inspecting what actually happened during a
-run), flowrep provides two additional layers accessible through the API:
+run), flowrep provides two additional layers accessible through the `tools` and 
+`schemas` submodules of the API.
 
-```python
->>> from flowrep.api import tools as frt
-
-```
-
-**`flowrep.api.tools.recipe2data`** converts a recipe from the prospective "class view"
+**`flowrep.tools.recipe2data`** converts a recipe from the prospective "class view"
 to the retrospective "instance view" — a mutable data structure whose input and output 
 ports can hold actual Python values. Retrospective data objects mirror the recipe graph
 but trade JSON-serializability for the ability to carry arbitrary data:
 
 ```python
->>> wf_data = frt.recipe2data(double_and_add.flowrep_recipe)
+>>> wf_data = fr.tools.recipe2data(double_and_add.flowrep_recipe)
 
 ```
 
@@ -278,7 +274,7 @@ by a minimal, built-in WfMS intended as a reference implementation and for use
 in tests and documentation (like this!):
 
 ```python
->>> retrospective = frt.run_recipe(
+>>> retrospective = fr.tools.run_recipe(
 ...     double_and_add.flowrep_recipe, a=3, b=100, target=40
 ... )
 >>> retrospective.output_ports["result"].value

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -210,9 +210,7 @@
    },
    "cell_type": "code",
    "source": [
-    "from flowrep.api import schemas as frs, tools as frt\n",
-    "\n",
-    "for reserved in sorted(frs.RESERVED_NAMES):\n",
+    "for reserved in sorted(fr.schemas.RESERVED_NAMES):\n",
     "    print(reserved)"
    ],
    "id": "d652b49c0740e517",
@@ -250,7 +248,7 @@
     "# These will fail:\n",
     "from pydantic import TypeAdapter\n",
     "\n",
-    "label_adapter = TypeAdapter(frs.Label)\n",
+    "label_adapter = TypeAdapter(fr.schemas.Label)\n",
     "\n",
     "for bad_name in [\n",
     "    \"inputs\",  # Reserved by flowrep\n",
@@ -401,7 +399,7 @@
     }
    },
    "source": [
-    "@fr.atomic(unpack_mode=frs.UnpackMode.NONE)\n",
+    "@fr.atomic(unpack_mode=fr.schemas.UnpackMode.NONE)\n",
     "def righthanded2lefthanded(x, y, z):\n",
     "    return (x, z, y)\n",
     "\n",
@@ -464,7 +462,7 @@
     "    y: float\n",
     "\n",
     "\n",
-    "@fr.atomic(unpack_mode=frs.UnpackMode.DATACLASS)\n",
+    "@fr.atomic(unpack_mode=fr.schemas.UnpackMode.DATACLASS)\n",
     "def make_point(x, y) -> Point:\n",
     "    return Point(x, y)\n",
     "\n",
@@ -687,14 +685,14 @@
     "import numpy as np\n",
     "from pyiron_snippets import versions\n",
     "\n",
-    "linspace_node = frs.AtomicRecipe(\n",
-    "    reference=frs.PythonReference(\n",
+    "linspace_node = fr.schemas.AtomicRecipe(\n",
+    "    reference=fr.schemas.PythonReference(\n",
     "        info=versions.VersionInfo.of(np.linspace),\n",
     "        inputs_with_defaults=[\"num\"],\n",
     "    ),\n",
     "    inputs=[\"start\", \"stop\", \"num\"],  # Hide retstep, endpoint, dtype, axis\n",
     "    outputs=[\"samples\"],\n",
-    "    unpack_mode=frs.UnpackMode.NONE,\n",
+    "    unpack_mode=fr.schemas.UnpackMode.NONE,\n",
     ")\n",
     "print(f\"Inputs:  {linspace_node.inputs}\")\n",
     "print(f\"Outputs: {linspace_node.outputs}\")"
@@ -733,19 +731,19 @@
     }
    },
    "source": [
-    "arange_node = frs.AtomicRecipe(\n",
-    "    reference=frs.PythonReference(\n",
+    "arange_node = fr.schemas.AtomicRecipe(\n",
+    "    reference=fr.schemas.PythonReference(\n",
     "        info=versions.VersionInfo.of(np.arange),\n",
     "        inputs_with_defaults=[\"start\", \"step\"],\n",
     "        restricted_input_kinds={\n",
-    "            \"start\": frs.RestrictedParamKind.KEYWORD_ONLY,\n",
-    "            \"stop\": frs.RestrictedParamKind.KEYWORD_ONLY,\n",
-    "            \"step\": frs.RestrictedParamKind.KEYWORD_ONLY,\n",
+    "            \"start\": fr.schemas.RestrictedParamKind.KEYWORD_ONLY,\n",
+    "            \"stop\": fr.schemas.RestrictedParamKind.KEYWORD_ONLY,\n",
+    "            \"step\": fr.schemas.RestrictedParamKind.KEYWORD_ONLY,\n",
     "        },\n",
     "    ),\n",
     "    inputs=[\"start\", \"stop\", \"step\"],\n",
     "    outputs=[\"values\"],\n",
-    "    unpack_mode=frs.UnpackMode.NONE,\n",
+    "    unpack_mode=fr.schemas.UnpackMode.NONE,\n",
     ")\n",
     "print(f\"Restricted kinds: {arange_node.reference.restricted_input_kinds}\")"
    ],
@@ -829,18 +827,18 @@
     "def my_dict_maker(**kwargs):\n",
     "    return dict(**kwargs)\n",
     "\n",
-    "my_particular_dict_recipe = frs.AtomicRecipe(\n",
-    "    reference=frs.PythonReference(\n",
+    "my_particular_dict_recipe = fr.schemas.AtomicRecipe(\n",
+    "    reference=fr.schemas.PythonReference(\n",
     "        info=versions.VersionInfo.of(my_dict_maker),\n",
     "        restricted_input_kinds={\n",
-    "            \"this\": frs.RestrictedParamKind.KEYWORD_ONLY,\n",
-    "            \"that\": frs.RestrictedParamKind.KEYWORD_ONLY,\n",
-    "            \"the_other\": frs.RestrictedParamKind.KEYWORD_ONLY,\n",
+    "            \"this\": fr.schemas.RestrictedParamKind.KEYWORD_ONLY,\n",
+    "            \"that\": fr.schemas.RestrictedParamKind.KEYWORD_ONLY,\n",
+    "            \"the_other\": fr.schemas.RestrictedParamKind.KEYWORD_ONLY,\n",
     "        },\n",
     "    ),\n",
     "    inputs=[\"this\", \"that\", \"the_other\"],\n",
     "    outputs=[\"as_a_dict\"],\n",
-    "    unpack_mode=frs.UnpackMode.NONE,\n",
+    "    unpack_mode=fr.schemas.UnpackMode.NONE,\n",
     ")\n",
     "print(f\"Restricted kinds: {my_particular_dict_recipe.reference.restricted_input_kinds}\")"
    ],
@@ -901,19 +899,19 @@
     "        sum_ += term\n",
     "    return sum_\n",
     "\n",
-    "my_offset_sum = frs.AtomicRecipe(\n",
-    "    reference=frs.PythonReference(\n",
+    "my_offset_sum = fr.schemas.AtomicRecipe(\n",
+    "    reference=fr.schemas.PythonReference(\n",
     "        info=versions.VersionInfo.of(my_variadic_add),\n",
     "        inputs_with_defaults=[\"offset\"],\n",
     "        restricted_input_kinds={\n",
-    "            \"a\": frs.RestrictedParamKind.POSITIONAL_ONLY,\n",
-    "            \"b\": frs.RestrictedParamKind.POSITIONAL_ONLY,\n",
+    "            \"a\": fr.schemas.RestrictedParamKind.POSITIONAL_ONLY,\n",
+    "            \"b\": fr.schemas.RestrictedParamKind.POSITIONAL_ONLY,\n",
     "            # Offset can be positional or keyword, so no need to list it\n",
     "        },\n",
     "    ),\n",
     "    inputs=[\"a\", \"b\", \"offset\"],\n",
     "    outputs=[\"total\"],\n",
-    "    unpack_mode=frs.UnpackMode.TUPLE,\n",
+    "    unpack_mode=fr.schemas.UnpackMode.TUPLE,\n",
     ")\n",
     "print(f\"Restricted kinds: {my_offset_sum.reference.restricted_input_kinds}\")"
    ],
@@ -1408,7 +1406,7 @@
     }
    },
    "cell_type": "code",
-   "source": "frs.InputSource(port=\"inp\").node, frs.OutputTarget(port=\"out\").node",
+   "source": "fr.schemas.InputSource(port=\"inp\").node, fr.schemas.OutputTarget(port=\"out\").node",
    "id": "56384e86f385779d",
    "outputs": [
     {
@@ -1610,7 +1608,7 @@
    "source": [
     "# Round-trip demo\n",
     "json_str = recipe.model_dump_json()\n",
-    "reconstructed = frs.WorkflowRecipe.model_validate_json(json_str)\n",
+    "reconstructed = fr.schemas.WorkflowRecipe.model_validate_json(json_str)\n",
     "assert reconstructed == recipe\n",
     "print(\"Round-trip successful!\")"
    ],
@@ -2750,7 +2748,7 @@
     "    return total\n",
     "\n",
     "try:\n",
-    "    frt.flowrep2python(my_recipe.flowrep_recipe)\n",
+    "    fr.tools.flowrep2python(my_recipe.flowrep_recipe)\n",
     "except ValueError as e:\n",
     "    print(e)"
    ],
@@ -2786,7 +2784,7 @@
    "cell_type": "code",
    "source": [
     "unreferenced_recipe = my_recipe.flowrep_recipe.model_copy(update={\"reference\": None})\n",
-    "rendered = frt.flowrep2python(unreferenced_recipe)"
+    "rendered = fr.tools.flowrep2python(unreferenced_recipe)"
    ],
    "id": "664078176aceb6e0",
    "outputs": [],
@@ -2889,7 +2887,7 @@
     "    inspect.Parameter(\"y\", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=4, annotation=int),\n",
     "])\n",
     "\n",
-    "rendered_with_annotations = frt.flowrep2python(\n",
+    "rendered_with_annotations = fr.tools.flowrep2python(\n",
     "    unreferenced_recipe,\n",
     "    function_name=\"my_function_with_annotations\",\n",
     "    signature=sig,\n",
@@ -2954,7 +2952,7 @@
     "    ),\n",
     "])\n",
     "\n",
-    "complex_rendered = frt.flowrep2python(\n",
+    "complex_rendered = fr.tools.flowrep2python(\n",
     "    unreferenced_recipe,\n",
     "    function_name=\"wont_dump\",\n",
     "    signature=complex_sig,\n",
@@ -3099,7 +3097,7 @@
     "try:\n",
     "\n",
     "    # Use our simple linear workflow: y = slope * x + intercept\n",
-    "    pwd_wf = frt.flowrep2pwd(\n",
+    "    pwd_wf = fr.tools.flowrep2pwd(\n",
     "        linear.flowrep_recipe,\n",
     "        x=1.0,\n",
     "        slope=2.0,\n",
@@ -3156,13 +3154,13 @@
     "    from flowrep.api import converters\n",
     "\n",
     "    # Round-trip: flowrep → PWD → flowrep\n",
-    "    pwd_wf = frt.flowrep2pwd(\n",
+    "    pwd_wf = fr.tools.flowrep2pwd(\n",
     "        linear.flowrep_recipe,\n",
     "        x=0.0,\n",
     "        slope=1.0,\n",
     "        intercept=0.0,\n",
     "    )\n",
-    "    roundtripped, defaults = frt.pwd2flowrep(pwd_wf)\n",
+    "    roundtripped, defaults = fr.tools.pwd2flowrep(pwd_wf)\n",
     "    print(f\"Round-tripped inputs:  {roundtripped.inputs}\")\n",
     "    print(f\"Round-tripped outputs: {roundtripped.outputs}\")\n",
     "    print(f\"Round-tripped nodes:   {list(roundtripped.nodes.keys())}\")\n",
@@ -3267,7 +3265,7 @@
     }
    },
    "cell_type": "code",
-   "source": "node_data = frt.recipe2data(scaled_range.flowrep_recipe)",
+   "source": "node_data = fr.tools.recipe2data(scaled_range.flowrep_recipe)",
    "id": "f044f5954e57507c",
    "outputs": [],
    "execution_count": 57
@@ -3316,10 +3314,10 @@
    },
    "cell_type": "code",
    "source": [
-    "def recursively_look_at_data_nodes(node: frs.NodeData, tabs=0):\n",
+    "def recursively_look_at_data_nodes(node: fr.schemas.NodeData, tabs=0):\n",
     "    for recipe_child_label in node.recipe.nodes:\n",
     "        live_child = node.nodes[recipe_child_label]\n",
-    "        assert(isinstance(live_child, frs.NodeData))\n",
+    "        assert(isinstance(live_child, fr.schemas.NodeData))\n",
     "        print(f\"{tabs*'\\t'}{recipe_child_label}\")\n",
     "        if hasattr(live_child.recipe, \"nodes\"):\n",
     "            recursively_look_at_data_nodes(live_child, tabs+1)\n",
@@ -3637,7 +3635,7 @@
     }
    },
    "cell_type": "code",
-   "source": "ran_node = frt.run_recipe(scaled_range.flowrep_recipe, n=3)",
+   "source": "ran_node = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=3)",
    "id": "54c1c113638190b8",
    "outputs": [],
    "execution_count": 68
@@ -3761,7 +3759,7 @@
     "    scaled = rescale_all(to_scale, scale)\n",
     "    return scaled\n",
     "\n",
-    "executed = frt.run_recipe(scaled_range.flowrep_recipe, n=5)\n",
+    "executed = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=5)\n",
     "executed.output_ports"
    ],
    "id": "f94e046ee2730c68",
@@ -3809,7 +3807,7 @@
     "One of the benefits of `bagofholding`'s structure is that results are browseable and partially-loadable -- i.e. we don't need to reload the _entire_ python object from disk, rather we can reload just a subset, like a particular subgraph or particular output value.\n",
     "However, the HDF5 structure captures the entire object, and while it is systematic it is verbose.\n",
     "For workflows, we are mostly interested in nodes and ports.\n",
-    "Enter, `frt.LexicalBagBrowser`, a `flowrep` tool that lets us parse bagged live workflows using their **Lexical path** -- i.e. a string of node labels (to traverse subgraphs), then \"inputs\" or \"outputs\", and finally a port label.\n",
+    "Enter, `fr.tools.LexicalBagBrowser`, a `flowrep` tool that lets us parse bagged live workflows using their **Lexical path** -- i.e. a string of node labels (to traverse subgraphs), then \"inputs\" or \"outputs\", and finally a port label.\n",
     "\n",
     "For instance, we can browse the entire lexical structure of our stored workflow like this:"
    ],
@@ -3824,7 +3822,7 @@
    },
    "cell_type": "code",
    "source": [
-    "browser = frt.LexicalBagBrowser(\"executed.h5\")\n",
+    "browser = fr.tools.LexicalBagBrowser(\"executed.h5\")\n",
     "browser.list_paths()"
    ],
    "id": "4433e29b74f02efe",
@@ -3911,7 +3909,7 @@
    "cell_type": "code",
    "source": [
     "reloaded_node = browser.load(\"rescale_all_0\")\n",
-    "isinstance(reloaded_node, frs.DagData), reloaded_node.nodes.keys()"
+    "isinstance(reloaded_node, fr.schemas.DagData), reloaded_node.nodes.keys()"
    ],
    "id": "c3622954ff23bc6f",
    "outputs": [
@@ -3944,7 +3942,7 @@
    "cell_type": "code",
    "source": [
     "reloaded_port = browser.load(\"rescale_all_0.for_each_0.body_1.inputs.item\")\n",
-    "isinstance(reloaded_port, frs.InputDataPort), reloaded_port.value"
+    "isinstance(reloaded_port, fr.schemas.InputDataPort), reloaded_port.value"
    ],
    "id": "51463f7d0fa254be",
    "outputs": [
@@ -4043,7 +4041,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "There is no deep magic in this tool, it is just a convenient shortcut for mapping the \"Lexical path\" of a `frs.LiveWorkflow` to the underlying `bagofholding.H5Bag` file structure.",
+   "source": "There is no deep magic in this tool, it is just a convenient shortcut for mapping the \"Lexical path\" of a `fr.schemas.LiveWorkflow` to the underlying `bagofholding.H5Bag` file structure.",
    "id": "f1fcb3577dd088f8"
   },
   {

--- a/src/flowrep/__init__.py
+++ b/src/flowrep/__init__.py
@@ -6,10 +6,12 @@ attribute onto a function at definition time, and parsers (`parse_atomic`,
 
 import importlib.metadata
 
-from flowrep.api.tools import atomic as atomic
-from flowrep.api.tools import parse_atomic as parse_atomic
-from flowrep.api.tools import parse_workflow as parse_workflow
-from flowrep.api.tools import workflow as workflow
+from flowrep.api import atomic as atomic
+from flowrep.api import parse_atomic as parse_atomic
+from flowrep.api import parse_workflow as parse_workflow
+from flowrep.api import schemas as schemas
+from flowrep.api import tools as tools
+from flowrep.api import workflow as workflow
 
 try:
     # Installed package will find its version

--- a/src/flowrep/api/__init__.py
+++ b/src/flowrep/api/__init__.py
@@ -1,0 +1,15 @@
+"""
+The public interface for flowrep, protected by semver
+
+The most fundamental user tools (parsing and decorating) are provided here at the top
+level, while other resources are nested by category as tools or schemas. The shorter
+tools list is likely to be useful for all power users, while schemas are intended to
+primarily benefit downstream developers (e.g. WfMS creators).
+"""
+
+from flowrep.api import schemas as schemas
+from flowrep.api import tools as tools
+from flowrep.api.tools import atomic as atomic
+from flowrep.api.tools import parse_atomic as parse_atomic
+from flowrep.api.tools import parse_workflow as parse_workflow
+from flowrep.api.tools import workflow as workflow

--- a/src/flowrep/api/tools.py
+++ b/src/flowrep/api/tools.py
@@ -3,22 +3,6 @@ Functions for creating and transforming flowrep data.
 
 Intended for users who want to go beyond the simple parsers and decorators, as well as
 for downstream library developers.
-
-Use `flowrep2pwd` and `pwd2flowrep` to convert back and forth between flowrep recipes
-and the python-workflow-definition format. (When PWD is available in the environment;
-Where PWD supports the workflow structure; round-trip from flowrep to PWD and back is
-lossy in versioning info.)
-
-Use `recipe2data` to convert recipes into state-ful data-ful instances of recipes,
-which directly hold python objects (including, potentially, IO data values), but
-which no longer trivially serialize to JSON.
-
-Use decorators (`@atomic` and `@workflow`) to attach a recipe as a `.flowrep_recipe`
-attribute onto a function at definition time, and parsers (`parse_atomic`,
-`parse_workflow`) to return a recipe from an existing function object.
-
-Use `run_recipe` to convert recipes into retrospective instance objects with output
-data.
 """
 
 from flowrep.compiler.source import flowrep2python as flowrep2python

--- a/src/flowrep/retrospective.py
+++ b/src/flowrep/retrospective.py
@@ -96,6 +96,11 @@ class NodeData(Generic[RecipeType], abc.ABC):
 def recipe2data(
     recipe: union_types.RecipeDiscrimination, allow_variadic_inputs: bool = True
 ) -> NodeData:
+    """
+    Convert a prospective flowrep recipe object to a retrospective flowrep data object.
+    The data object is "empty" in that none of the actual data values will be filled;
+    This is is an empty-vessel creator to be filled, e.g. by a WfMS run of the recipe.
+    """
     match recipe:
         case atomic_recipe.AtomicRecipe():
             return AtomicData.from_recipe(


### PR DESCRIPTION
By making the `api` module _the_ source of truth, and exposing the `schemas` and `tools` submodules. In this way, instead of having to separately write `from flowrep.api import tools as frt`, if you've already `import flowrep as fr` you can simply `fr.tools...`

The API submodules are still there, so the old importing style will still work.

Updated the documentation to reflect the new import pattern and did some docstring stuff.