### PR TITLE
Handle forward references in data objects

### DIFF
--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -3618,7 +3618,77 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "### 8.5 A Toy WfMS\n",
+    "### 8.5 Aside on annotations\n",
+    "\n",
+    "The retrospective data objects have space to hold type hints and annotations, which, as with data values, they do _as realy python objects_.\n",
+    "\n",
+    "It's customary in python to sometimes hide annotations behind a fake import, which never actually executes at runtime:"
+   ],
+   "id": "5dd2fc6e39e728b4"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "from typing import TYPE_CHECKING\n",
+    "\n",
+    "if TYPE_CHECKING:\n",
+    "    from pyiron_snippets.colors import SeabornColors\n",
+    "\n",
+    "@fr.atomic\n",
+    "def get_blue(colors: SeabornColors) -> str:\n",
+    "    return colors.blue"
+   ],
+   "id": "ca0292eb59cf963a"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "This is completely fine at a recipe level, but if we try to convert the recipe into data we won't be able to find `SeabornColors` to populate the hint field!",
+   "id": "36045479099ade66"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "try:\n",
+    "    fr.tools.recipe2data(get_blue.flowrep_recipe)\n",
+    "except NameError as e:\n",
+    "    print(e)"
+   ],
+   "id": "44fa91cf59e164c7"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "To solve this, prior to data-fying your recipes, you need to locally import the relevant types. We try to make the error message above as helpful as possible, but you may need to go read the source scope where the underlying function was defined and decorated to learn exactly what import to use.",
+   "id": "8fc856912a06a735"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "from pyiron_snippets.colors import SeabornColors\n",
+    "\n",
+    "data = fr.tools.recipe2data(get_blue.flowrep_recipe)\n",
+    "\n",
+    "data.input_ports[\"colors\"].annotation"
+   ],
+   "id": "1fc5221b5f62a0da"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### 8.6 A Toy WfMS\n",
     "\n",
     "Along with these data classes, we also provide a toy WfMS for digesting recipes directly into retrospective instance-view nodes fully populated with data.\n",
     "This is useful for tests and documentation (like here!) and is also meant as a representative implementation to guide WfMS designers.\n",
@@ -3716,7 +3786,7 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "### 8.6 Convenient storage and retrieval\n",
+    "### 8.7 Convenient storage and retrieval\n",
     "\n",
     "[`bagofholding`](https://github.com/pyiron/bagofholding/) is a pyiron solution for storing arbitrary (pickle-able!) python objects to HDF5 with automated scraping and storage of object metadata.\n",
     "In this section, we'll review how you can save completed workflows to file with `bagofholding`, and then demonstrate a `flowrep` convenience tool for reviewing and reloading your results.\n",

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -3620,7 +3620,7 @@
    "source": [
     "### 8.5 Aside on annotations\n",
     "\n",
-    "The retrospective data objects have space to hold type hints and annotations, which, as with data values, they do _as realy python objects_.\n",
+    "The retrospective data objects have space to hold type hints and annotations, which, as with data values, they do so _as real Python objects_.\n",
     "\n",
     "It's customary in python to sometimes hide annotations behind a fake import, which never actually executes at runtime:"
    ],

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -37,8 +37,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:11.757157Z",
-     "start_time": "2026-06-11T14:35:11.406164Z"
+     "end_time": "2026-06-15T20:20:48.158975Z",
+     "start_time": "2026-06-15T20:20:47.831494Z"
     }
    },
    "cell_type": "code",
@@ -103,8 +103,8 @@
    "id": "8590ac6e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:11.826405Z",
-     "start_time": "2026-06-11T14:35:11.775076Z"
+     "end_time": "2026-06-15T20:20:48.212985Z",
+     "start_time": "2026-06-15T20:20:48.162764Z"
     }
    },
    "source": [
@@ -163,8 +163,8 @@
    "id": "fbb2ac82",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:11.889300Z",
-     "start_time": "2026-06-11T14:35:11.840085Z"
+     "end_time": "2026-06-15T20:20:48.260749Z",
+     "start_time": "2026-06-15T20:20:48.226095Z"
     }
    },
    "source": [
@@ -204,8 +204,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:11.900466Z",
-     "start_time": "2026-06-11T14:35:11.890433Z"
+     "end_time": "2026-06-15T20:20:48.306323Z",
+     "start_time": "2026-06-15T20:20:48.273183Z"
     }
    },
    "cell_type": "code",
@@ -240,8 +240,8 @@
    "id": "4ce6917d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:11.979201Z",
-     "start_time": "2026-06-11T14:35:11.912619Z"
+     "end_time": "2026-06-15T20:20:48.327777Z",
+     "start_time": "2026-06-15T20:20:48.317933Z"
     }
    },
    "source": [
@@ -313,8 +313,8 @@
    "id": "cac0a1bd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.071536Z",
-     "start_time": "2026-06-11T14:35:11.982333Z"
+     "end_time": "2026-06-15T20:20:48.354255Z",
+     "start_time": "2026-06-15T20:20:48.337505Z"
     }
    },
    "source": [
@@ -354,8 +354,8 @@
    "id": "9f659bd7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.102325Z",
-     "start_time": "2026-06-11T14:35:12.074159Z"
+     "end_time": "2026-06-15T20:20:48.394894Z",
+     "start_time": "2026-06-15T20:20:48.368596Z"
     }
    },
    "source": [
@@ -394,8 +394,8 @@
    "id": "467bd6b8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.119102Z",
-     "start_time": "2026-06-11T14:35:12.104394Z"
+     "end_time": "2026-06-15T20:20:48.416075Z",
+     "start_time": "2026-06-15T20:20:48.405917Z"
     }
    },
    "source": [
@@ -448,8 +448,8 @@
    "id": "0d46e437",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.150505Z",
-     "start_time": "2026-06-11T14:35:12.130656Z"
+     "end_time": "2026-06-15T20:20:48.443122Z",
+     "start_time": "2026-06-15T20:20:48.426590Z"
     }
    },
    "source": [
@@ -498,8 +498,8 @@
    "id": "77276c40",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.182750Z",
-     "start_time": "2026-06-11T14:35:12.161862Z"
+     "end_time": "2026-06-15T20:20:48.486595Z",
+     "start_time": "2026-06-15T20:20:48.454920Z"
     }
    },
    "source": [
@@ -549,8 +549,8 @@
    "id": "a4019caa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.219424Z",
-     "start_time": "2026-06-11T14:35:12.192567Z"
+     "end_time": "2026-06-15T20:20:48.503829Z",
+     "start_time": "2026-06-15T20:20:48.488676Z"
     }
    },
    "source": [
@@ -599,8 +599,8 @@
    "id": "b8f03ee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.239449Z",
-     "start_time": "2026-06-11T14:35:12.229243Z"
+     "end_time": "2026-06-15T20:20:48.546452Z",
+     "start_time": "2026-06-15T20:20:48.516323Z"
     }
    },
    "source": [
@@ -677,8 +677,8 @@
    "id": "9ac92af2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.276209Z",
-     "start_time": "2026-06-11T14:35:12.249802Z"
+     "end_time": "2026-06-15T20:20:48.638142Z",
+     "start_time": "2026-06-15T20:20:48.590450Z"
     }
    },
    "source": [
@@ -726,8 +726,8 @@
    "id": "1037ac27",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.297265Z",
-     "start_time": "2026-06-11T14:35:12.278394Z"
+     "end_time": "2026-06-15T20:20:48.654226Z",
+     "start_time": "2026-06-15T20:20:48.640322Z"
     }
    },
    "source": [
@@ -784,8 +784,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.323945Z",
-     "start_time": "2026-06-11T14:35:12.308082Z"
+     "end_time": "2026-06-15T20:20:48.681626Z",
+     "start_time": "2026-06-15T20:20:48.666365Z"
     }
    },
    "cell_type": "code",
@@ -818,8 +818,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.361786Z",
-     "start_time": "2026-06-11T14:35:12.334911Z"
+     "end_time": "2026-06-15T20:20:48.711518Z",
+     "start_time": "2026-06-15T20:20:48.692678Z"
     }
    },
    "cell_type": "code",
@@ -857,8 +857,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.389123Z",
-     "start_time": "2026-06-11T14:35:12.363804Z"
+     "end_time": "2026-06-15T20:20:48.747165Z",
+     "start_time": "2026-06-15T20:20:48.721212Z"
     }
    },
    "cell_type": "code",
@@ -887,8 +887,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.405945Z",
-     "start_time": "2026-06-11T14:35:12.391409Z"
+     "end_time": "2026-06-15T20:20:48.777397Z",
+     "start_time": "2026-06-15T20:20:48.750521Z"
     }
    },
    "cell_type": "code",
@@ -930,8 +930,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.452693Z",
-     "start_time": "2026-06-11T14:35:12.416067Z"
+     "end_time": "2026-06-15T20:20:48.804059Z",
+     "start_time": "2026-06-15T20:20:48.777886Z"
     }
    },
    "cell_type": "code",
@@ -986,8 +986,8 @@
    "id": "d39608c2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.554964Z",
-     "start_time": "2026-06-11T14:35:12.484082Z"
+     "end_time": "2026-06-15T20:20:48.823762Z",
+     "start_time": "2026-06-15T20:20:48.813134Z"
     }
    },
    "source": [
@@ -1016,7 +1016,6 @@
     "print(f\"Recipe type: {type(linear.flowrep_recipe).__name__}\")\n",
     "linear.flowrep_recipe"
    ],
-   "execution_count": 20,
    "outputs": [
     {
      "name": "stdout",
@@ -1036,7 +1035,8 @@
      "metadata": {},
      "output_type": "execute_result"
     }
-   ]
+   ],
+   "execution_count": 20
   },
   {
    "cell_type": "markdown",
@@ -1066,8 +1066,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.615976Z",
-     "start_time": "2026-06-11T14:35:12.595124Z"
+     "end_time": "2026-06-15T20:20:48.863427Z",
+     "start_time": "2026-06-15T20:20:48.833581Z"
     }
    },
    "cell_type": "code",
@@ -1123,8 +1123,8 @@
    "id": "55716aa9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.700306Z",
-     "start_time": "2026-06-11T14:35:12.642727Z"
+     "end_time": "2026-06-15T20:20:48.886634Z",
+     "start_time": "2026-06-15T20:20:48.875473Z"
     }
    },
    "source": [
@@ -1196,8 +1196,8 @@
    "id": "cd45cbb2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.745399Z",
-     "start_time": "2026-06-11T14:35:12.713899Z"
+     "end_time": "2026-06-15T20:20:48.922552Z",
+     "start_time": "2026-06-15T20:20:48.895931Z"
     }
    },
    "source": [
@@ -1251,8 +1251,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.809286Z",
-     "start_time": "2026-06-11T14:35:12.764784Z"
+     "end_time": "2026-06-15T20:20:48.934468Z",
+     "start_time": "2026-06-15T20:20:48.924770Z"
     }
    },
    "cell_type": "code",
@@ -1285,8 +1285,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.859688Z",
-     "start_time": "2026-06-11T14:35:12.811295Z"
+     "end_time": "2026-06-15T20:20:48.968168Z",
+     "start_time": "2026-06-15T20:20:48.943975Z"
     }
    },
    "cell_type": "code",
@@ -1326,8 +1326,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.881085Z",
-     "start_time": "2026-06-11T14:35:12.870760Z"
+     "end_time": "2026-06-15T20:20:48.984846Z",
+     "start_time": "2026-06-15T20:20:48.970172Z"
     }
    },
    "cell_type": "code",
@@ -1401,8 +1401,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.913806Z",
-     "start_time": "2026-06-11T14:35:12.889763Z"
+     "end_time": "2026-06-15T20:20:49.022304Z",
+     "start_time": "2026-06-15T20:20:48.995786Z"
     }
    },
    "cell_type": "code",
@@ -1435,8 +1435,8 @@
    "id": "06c2b2eb",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.942447Z",
-     "start_time": "2026-06-11T14:35:12.915932Z"
+     "end_time": "2026-06-15T20:20:49.050883Z",
+     "start_time": "2026-06-15T20:20:49.024532Z"
     }
    },
    "source": [
@@ -1491,8 +1491,8 @@
    "id": "6d7a6e2a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:12.994622Z",
-     "start_time": "2026-06-11T14:35:12.954017Z"
+     "end_time": "2026-06-15T20:20:49.142150Z",
+     "start_time": "2026-06-15T20:20:49.063193Z"
     }
    },
    "source": [
@@ -1601,8 +1601,8 @@
    "id": "53e8f09d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.080583Z",
-     "start_time": "2026-06-11T14:35:13.042072Z"
+     "end_time": "2026-06-15T20:20:49.169528Z",
+     "start_time": "2026-06-15T20:20:49.144143Z"
     }
    },
    "source": [
@@ -1654,8 +1654,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.119514Z",
-     "start_time": "2026-06-11T14:35:13.091889Z"
+     "end_time": "2026-06-15T20:20:49.184912Z",
+     "start_time": "2026-06-15T20:20:49.171340Z"
     }
    },
    "cell_type": "code",
@@ -1821,8 +1821,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.138708Z",
-     "start_time": "2026-06-11T14:35:13.122912Z"
+     "end_time": "2026-06-15T20:20:49.238550Z",
+     "start_time": "2026-06-15T20:20:49.195654Z"
     }
    },
    "cell_type": "code",
@@ -1905,8 +1905,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.167227Z",
-     "start_time": "2026-06-11T14:35:13.151018Z"
+     "end_time": "2026-06-15T20:20:49.250846Z",
+     "start_time": "2026-06-15T20:20:49.240738Z"
     }
    },
    "cell_type": "code",
@@ -1974,8 +1974,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.206416Z",
-     "start_time": "2026-06-11T14:35:13.177287Z"
+     "end_time": "2026-06-15T20:20:49.284595Z",
+     "start_time": "2026-06-15T20:20:49.260898Z"
     }
    },
    "cell_type": "code",
@@ -2020,8 +2020,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.232332Z",
-     "start_time": "2026-06-11T14:35:13.208406Z"
+     "end_time": "2026-06-15T20:20:49.302533Z",
+     "start_time": "2026-06-15T20:20:49.294333Z"
     }
    },
    "cell_type": "code",
@@ -2111,8 +2111,8 @@
    "id": "0a285891",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.262871Z",
-     "start_time": "2026-06-11T14:35:13.234520Z"
+     "end_time": "2026-06-15T20:20:49.338953Z",
+     "start_time": "2026-06-15T20:20:49.312165Z"
     }
    },
    "source": [
@@ -2207,8 +2207,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.304158Z",
-     "start_time": "2026-06-11T14:35:13.273604Z"
+     "end_time": "2026-06-15T20:20:49.372302Z",
+     "start_time": "2026-06-15T20:20:49.341179Z"
     }
    },
    "cell_type": "code",
@@ -2247,9 +2247,9 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_19609/3477409776.py\", line 16, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_14836/3477409776.py\", line 16, in <module>\n",
       "    conditional_availability(-1)\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_19609/3477409776.py\", line 9, in conditional_availability\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_14836/3477409776.py\", line 9, in conditional_availability\n",
       "    downstream = identity(result)\n",
       "                          ^^^^^^\n",
       "UnboundLocalError: cannot access local variable 'result' where it is not associated with a value\n"
@@ -2289,8 +2289,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.322097Z",
-     "start_time": "2026-06-11T14:35:13.313290Z"
+     "end_time": "2026-06-15T20:20:49.387841Z",
+     "start_time": "2026-06-15T20:20:49.382926Z"
     }
    },
    "source": [
@@ -2336,8 +2336,8 @@
    "id": "52ab25e4",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.331565Z",
-     "start_time": "2026-06-11T14:35:13.322881Z"
+     "end_time": "2026-06-15T20:20:49.406059Z",
+     "start_time": "2026-06-15T20:20:49.388431Z"
     }
    },
    "source": [
@@ -2381,8 +2381,8 @@
    "id": "79c1d339",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.368407Z",
-     "start_time": "2026-06-11T14:35:13.343270Z"
+     "end_time": "2026-06-15T20:20:49.421062Z",
+     "start_time": "2026-06-15T20:20:49.408411Z"
     }
    },
    "source": [
@@ -2455,8 +2455,8 @@
    "id": "d76836d6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.383784Z",
-     "start_time": "2026-06-11T14:35:13.370344Z"
+     "end_time": "2026-06-15T20:20:49.449218Z",
+     "start_time": "2026-06-15T20:20:49.433062Z"
     }
    },
    "source": [
@@ -2544,8 +2544,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.418071Z",
-     "start_time": "2026-06-11T14:35:13.393787Z"
+     "end_time": "2026-06-15T20:20:49.485038Z",
+     "start_time": "2026-06-15T20:20:49.460470Z"
     }
    },
    "cell_type": "code",
@@ -2574,8 +2574,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.435044Z",
-     "start_time": "2026-06-11T14:35:13.420139Z"
+     "end_time": "2026-06-15T20:20:49.501381Z",
+     "start_time": "2026-06-15T20:20:49.486896Z"
     }
    },
    "cell_type": "code",
@@ -2623,8 +2623,8 @@
    "id": "3efa3180",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.461085Z",
-     "start_time": "2026-06-11T14:35:13.446495Z"
+     "end_time": "2026-06-15T20:20:49.538282Z",
+     "start_time": "2026-06-15T20:20:49.511684Z"
     }
    },
    "source": [
@@ -2645,7 +2645,7 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_19609/3041652459.py\", line 4, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_14836/3041652459.py\", line 4, in <module>\n",
       "    @fr.atomic(forbid_main=True)\n",
       "     ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/parser_helpers.py\", line 44, in decorator\n",
@@ -2654,9 +2654,9 @@
       "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 110, in parse_atomic\n",
       "    function_info = versions.VersionInfo.of(\n",
       "                    ^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 123, in of\n",
+      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 125, in of\n",
       "    info.validate_constraints(\n",
-      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 141, in validate_constraints\n",
+      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 143, in validate_constraints\n",
       "    raise ValueError(f\"Found forbidden module '__main__' in module for {self}\")\n",
       "ValueError: Found forbidden module '__main__' in module for VersionInfo(module='__main__', qualname='my_func', version=None)\n"
      ]
@@ -2697,8 +2697,8 @@
    "id": "82468383",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.502559Z",
-     "start_time": "2026-06-11T14:35:13.473405Z"
+     "end_time": "2026-06-15T20:20:49.568712Z",
+     "start_time": "2026-06-15T20:20:49.540444Z"
     }
    },
    "source": [
@@ -2736,8 +2736,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.593647Z",
-     "start_time": "2026-06-11T14:35:13.503988Z"
+     "end_time": "2026-06-15T20:20:49.601318Z",
+     "start_time": "2026-06-15T20:20:49.570723Z"
     }
    },
    "cell_type": "code",
@@ -2777,8 +2777,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.624822Z",
-     "start_time": "2026-06-11T14:35:13.606491Z"
+     "end_time": "2026-06-15T20:20:49.649999Z",
+     "start_time": "2026-06-15T20:20:49.602021Z"
     }
    },
    "cell_type": "code",
@@ -2799,8 +2799,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.635741Z",
-     "start_time": "2026-06-11T14:35:13.627543Z"
+     "end_time": "2026-06-15T20:20:49.680862Z",
+     "start_time": "2026-06-15T20:20:49.670652Z"
     }
    },
    "cell_type": "code",
@@ -2837,8 +2837,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.671367Z",
-     "start_time": "2026-06-11T14:35:13.643987Z"
+     "end_time": "2026-06-15T20:20:49.717671Z",
+     "start_time": "2026-06-15T20:20:49.692204Z"
     }
    },
    "cell_type": "code",
@@ -2874,8 +2874,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.689045Z",
-     "start_time": "2026-06-11T14:35:13.680378Z"
+     "end_time": "2026-06-15T20:20:49.745335Z",
+     "start_time": "2026-06-15T20:20:49.719551Z"
     }
    },
    "cell_type": "code",
@@ -2930,8 +2930,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.721660Z",
-     "start_time": "2026-06-11T14:35:13.697898Z"
+     "end_time": "2026-06-15T20:20:49.762454Z",
+     "start_time": "2026-06-15T20:20:49.747275Z"
     }
    },
    "cell_type": "code",
@@ -2995,8 +2995,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.754457Z",
-     "start_time": "2026-06-11T14:35:13.723630Z"
+     "end_time": "2026-06-15T20:20:49.797072Z",
+     "start_time": "2026-06-15T20:20:49.775805Z"
     }
    },
    "cell_type": "code",
@@ -3027,8 +3027,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.771286Z",
-     "start_time": "2026-06-11T14:35:13.762711Z"
+     "end_time": "2026-06-15T20:20:49.824947Z",
+     "start_time": "2026-06-15T20:20:49.809289Z"
     }
    },
    "cell_type": "code",
@@ -3089,8 +3089,8 @@
    "id": "cabe9313",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.811121Z",
-     "start_time": "2026-06-11T14:35:13.780008Z"
+     "end_time": "2026-06-15T20:20:49.864816Z",
+     "start_time": "2026-06-15T20:20:49.835479Z"
     }
    },
    "source": [
@@ -3143,8 +3143,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.842907Z",
-     "start_time": "2026-06-11T14:35:13.820400Z"
+     "end_time": "2026-06-15T20:20:49.885473Z",
+     "start_time": "2026-06-15T20:20:49.875587Z"
     }
    },
    "cell_type": "code",
@@ -3222,8 +3222,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.858807Z",
-     "start_time": "2026-06-11T14:35:13.851087Z"
+     "end_time": "2026-06-15T20:20:49.908116Z",
+     "start_time": "2026-06-15T20:20:49.895676Z"
     }
    },
    "cell_type": "code",
@@ -3261,8 +3261,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.862819Z",
-     "start_time": "2026-06-11T14:35:13.859322Z"
+     "end_time": "2026-06-15T20:20:49.938676Z",
+     "start_time": "2026-06-15T20:20:49.917880Z"
     }
    },
    "cell_type": "code",
@@ -3274,8 +3274,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.878864Z",
-     "start_time": "2026-06-11T14:35:13.863320Z"
+     "end_time": "2026-06-15T20:20:49.953938Z",
+     "start_time": "2026-06-15T20:20:49.940590Z"
     }
    },
    "cell_type": "code",
@@ -3309,8 +3309,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.894006Z",
-     "start_time": "2026-06-11T14:35:13.880486Z"
+     "end_time": "2026-06-15T20:20:49.978245Z",
+     "start_time": "2026-06-15T20:20:49.963378Z"
     }
    },
    "cell_type": "code",
@@ -3357,8 +3357,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.904279Z",
-     "start_time": "2026-06-11T14:35:13.895775Z"
+     "end_time": "2026-06-15T20:20:50.013054Z",
+     "start_time": "2026-06-15T20:20:49.988270Z"
     }
    },
    "cell_type": "code",
@@ -3387,8 +3387,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.923416Z",
-     "start_time": "2026-06-11T14:35:13.910662Z"
+     "end_time": "2026-06-15T20:20:50.029465Z",
+     "start_time": "2026-06-15T20:20:50.014910Z"
     }
    },
    "cell_type": "code",
@@ -3417,8 +3417,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.939969Z",
-     "start_time": "2026-06-11T14:35:13.927863Z"
+     "end_time": "2026-06-15T20:20:50.053963Z",
+     "start_time": "2026-06-15T20:20:50.039390Z"
     }
    },
    "cell_type": "code",
@@ -3452,8 +3452,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.956273Z",
-     "start_time": "2026-06-11T14:35:13.943839Z"
+     "end_time": "2026-06-15T20:20:50.080783Z",
+     "start_time": "2026-06-15T20:20:50.066061Z"
     }
    },
    "cell_type": "code",
@@ -3495,8 +3495,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:13.972365Z",
-     "start_time": "2026-06-11T14:35:13.957839Z"
+     "end_time": "2026-06-15T20:20:50.112147Z",
+     "start_time": "2026-06-15T20:20:50.093356Z"
     }
    },
    "cell_type": "code",
@@ -3520,8 +3520,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.033554Z",
-     "start_time": "2026-06-11T14:35:13.974086Z"
+     "end_time": "2026-06-15T20:20:50.188571Z",
+     "start_time": "2026-06-15T20:20:50.112852Z"
     }
    },
    "cell_type": "code",
@@ -3544,8 +3544,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.095197Z",
-     "start_time": "2026-06-11T14:35:14.035519Z"
+     "end_time": "2026-06-15T20:20:50.206549Z",
+     "start_time": "2026-06-15T20:20:50.190916Z"
     }
    },
    "cell_type": "code",
@@ -3583,8 +3583,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.109551Z",
-     "start_time": "2026-06-11T14:35:14.096787Z"
+     "end_time": "2026-06-15T20:20:50.232137Z",
+     "start_time": "2026-06-15T20:20:50.217169Z"
     }
    },
    "cell_type": "code",
@@ -3627,10 +3627,13 @@
    "id": "5dd2fc6e39e728b4"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-15T20:20:50.258258Z",
+     "start_time": "2026-06-15T20:20:50.243150Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "from __future__ import annotations\n",
     "\n",
@@ -3643,7 +3646,9 @@
     "def get_blue(colors: SeabornColors) -> str:\n",
     "    return colors.blue"
    ],
-   "id": "ca0292eb59cf963a"
+   "id": "ca0292eb59cf963a",
+   "outputs": [],
+   "execution_count": 68
   },
   {
    "metadata": {},
@@ -3652,17 +3657,30 @@
    "id": "36045479099ade66"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-15T20:20:50.289860Z",
+     "start_time": "2026-06-15T20:20:50.259837Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "try:\n",
     "    fr.tools.recipe2data(get_blue.flowrep_recipe)\n",
     "except NameError as e:\n",
     "    print(e)"
    ],
-   "id": "44fa91cf59e164c7"
+   "id": "44fa91cf59e164c7",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "While parsing '__main__.get_blue' for recipe inputs ['colors'] and outputs ['output_0'], could not find the symbol for at least one annotation. This is likely due to forward referenced annotations. Please cross reference the underlying name error (\"name 'SeabornColors' is not defined\") and the function being parsed, and locally make the necessary imports before re-parsing.\n"
+     ]
+    }
+   ],
+   "execution_count": 69
   },
   {
    "metadata": {},
@@ -3671,10 +3689,13 @@
    "id": "8fc856912a06a735"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-15T20:20:50.333353Z",
+     "start_time": "2026-06-15T20:20:50.292002Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "from pyiron_snippets.colors import SeabornColors\n",
     "\n",
@@ -3682,7 +3703,20 @@
     "\n",
     "data.input_ports[\"colors\"].annotation"
    ],
-   "id": "1fc5221b5f62a0da"
+   "id": "1fc5221b5f62a0da",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pyiron_snippets.colors.SeabornColors"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 70
   },
   {
    "metadata": {},
@@ -3701,15 +3735,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.116427Z",
-     "start_time": "2026-06-11T14:35:14.111440Z"
+     "end_time": "2026-06-15T20:20:50.350392Z",
+     "start_time": "2026-06-15T20:20:50.334412Z"
     }
    },
    "cell_type": "code",
    "source": "ran_node = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=3)",
    "id": "54c1c113638190b8",
    "outputs": [],
-   "execution_count": 68
+   "execution_count": 71
   },
   {
    "metadata": {},
@@ -3723,8 +3757,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.128389Z",
-     "start_time": "2026-06-11T14:35:14.117333Z"
+     "end_time": "2026-06-15T20:20:50.374833Z",
+     "start_time": "2026-06-15T20:20:50.352141Z"
     }
    },
    "cell_type": "code",
@@ -3737,12 +3771,12 @@
        "[0.0, 1.0, 2.0]"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 69
+   "execution_count": 72
   },
   {
    "metadata": {},
@@ -3753,8 +3787,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.141580Z",
-     "start_time": "2026-06-11T14:35:14.129729Z"
+     "end_time": "2026-06-15T20:20:50.398129Z",
+     "start_time": "2026-06-15T20:20:50.376817Z"
     }
    },
    "cell_type": "code",
@@ -3780,7 +3814,7 @@
      ]
     }
    ],
-   "execution_count": 70
+   "execution_count": 73
   },
   {
    "metadata": {},
@@ -3798,8 +3832,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.157802Z",
-     "start_time": "2026-06-11T14:35:14.143694Z"
+     "end_time": "2026-06-15T20:20:50.424487Z",
+     "start_time": "2026-06-15T20:20:50.400958Z"
     }
    },
    "cell_type": "code",
@@ -3841,12 +3875,12 @@
        "{'scaled': OutputDataPort(value=[0.0, 1.0, 2.0, 3.0, 4.0], annotation=list[float])}"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 71
+   "execution_count": 74
   },
   {
    "metadata": {},
@@ -3857,8 +3891,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.556342Z",
-     "start_time": "2026-06-11T14:35:14.159927Z"
+     "end_time": "2026-06-15T20:20:50.790383Z",
+     "start_time": "2026-06-15T20:20:50.426647Z"
     }
    },
    "cell_type": "code",
@@ -3869,7 +3903,7 @@
    ],
    "id": "c4fe9644c6e43a16",
    "outputs": [],
-   "execution_count": 72
+   "execution_count": 75
   },
   {
    "metadata": {},
@@ -3887,8 +3921,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.619140Z",
-     "start_time": "2026-06-11T14:35:14.557778Z"
+     "end_time": "2026-06-15T20:20:50.826Z",
+     "start_time": "2026-06-15T20:20:50.794245Z"
     }
    },
    "cell_type": "code",
@@ -3957,12 +3991,12 @@
        " 'rescale_all_0.for_each_0.body_4.rescale_0.outputs.result']"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 73
+   "execution_count": 76
   },
   {
    "metadata": {},
@@ -3973,8 +4007,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:14.994907Z",
-     "start_time": "2026-06-11T14:35:14.621274Z"
+     "end_time": "2026-06-15T20:20:51.167127Z",
+     "start_time": "2026-06-15T20:20:50.828109Z"
     }
    },
    "cell_type": "code",
@@ -3990,12 +4024,12 @@
        "(True, dict_keys(['for_each_0']))"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 74
+   "execution_count": 77
   },
   {
    "metadata": {},
@@ -4006,8 +4040,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:15.011476Z",
-     "start_time": "2026-06-11T14:35:14.996249Z"
+     "end_time": "2026-06-15T20:20:51.210041Z",
+     "start_time": "2026-06-15T20:20:51.182670Z"
     }
    },
    "cell_type": "code",
@@ -4023,12 +4057,12 @@
        "(True, 1)"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 75
+   "execution_count": 78
   },
   {
    "metadata": {},
@@ -4042,8 +4076,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:15.104721Z",
-     "start_time": "2026-06-11T14:35:15.012390Z"
+     "end_time": "2026-06-15T20:20:51.243942Z",
+     "start_time": "2026-06-15T20:20:51.212076Z"
     }
    },
    "cell_type": "code",
@@ -4063,7 +4097,7 @@
      ]
     }
    ],
-   "execution_count": 76
+   "execution_count": 79
   },
   {
    "metadata": {},
@@ -4074,8 +4108,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:15.129115Z",
-     "start_time": "2026-06-11T14:35:15.107176Z"
+     "end_time": "2026-06-15T20:20:51.278858Z",
+     "start_time": "2026-06-15T20:20:51.246052Z"
     }
    },
    "cell_type": "code",
@@ -4093,15 +4127,15 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "cfb0e9d66df64aa29fbe69ba7a8c1ba2"
+       "model_id": "d5f4fedb7719457abd1df2956b963a26"
       }
      },
-     "execution_count": 77,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 77
+   "execution_count": 80
   },
   {
    "metadata": {},
@@ -4148,15 +4182,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-11T14:35:15.135952Z",
-     "start_time": "2026-06-11T14:35:15.131441Z"
+     "end_time": "2026-06-15T20:20:51.291333Z",
+     "start_time": "2026-06-15T20:20:51.287330Z"
     }
    },
    "cell_type": "code",
    "source": "",
    "id": "f9bf1a0cd6d6913c",
    "outputs": [],
-   "execution_count": 77
+   "execution_count": 80
   }
  ],
  "metadata": {

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -242,25 +242,24 @@ def _parse_dataclass_return_labels(func: FunctionType) -> list[str]:
         )
 
     try:
-        sig = inspect.signature(func, eval_str=True)
+        hints = get_type_hints(func, include_extras=True)
     except NameError as e:
         raise NameError(
             "Dataclass unpack mode requires the return annotation to be importable at "
             "runtime. Evaluating the return annotation for "
             f"{func.__module__}.{func.__qualname__} failed with: {e}"
         ) from e
-    ann = sig.return_annotation
+    ann = hints.get("return")
 
-    # unwrap Annotated
     origin = get_origin(ann)
-    return_annotation = get_args(ann)[0] if origin is Annotated else ann
+    return_hint = get_args(ann)[0] if origin is Annotated else ann
 
-    if dataclasses.is_dataclass(return_annotation):
-        return [f.name for f in dataclasses.fields(return_annotation)]
+    if dataclasses.is_dataclass(return_hint):
+        return [f.name for f in dataclasses.fields(return_hint)]
 
     raise ValueError(
         f"Dataclass unpack mode requires a return type annotation that is a "
-        f"(perhaps Annotated) dataclass, but got {ann}"
+        f"(perhaps Annotated) dataclass, but got {return_hint}"
     )
 
 

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -241,13 +241,14 @@ def _parse_dataclass_return_labels(func: FunctionType) -> list[str]:
             f"{source_code_return}"
         )
 
-    sig = inspect.signature(func, eval_str=True)
-    # We can safely force-eval string hints resulting from
-    # `from __future__ import annotations` because a dataclass-returning function
-    # probably has actual access to that dataclass object to return it
-    # The edge case is a `if TYPE_CHECKING` import for the hint, and then _inside_ the
-    # function properly importing it, and using it as a return. That's ridiculous and
-    # I'm not supporting it.
+    try:
+        sig = inspect.signature(func, eval_str=True)
+    except NameError as e:
+        raise ValueError(
+            "Dataclass unpack mode requires the return annotation to be importable at "
+            "runtime. Evaluating the return annotation for "
+            f"{func.__module__}.{func.__qualname__} failed with: {e}"
+        ) from e
     ann = sig.return_annotation
 
     # unwrap Annotated

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -241,7 +241,13 @@ def _parse_dataclass_return_labels(func: FunctionType) -> list[str]:
             f"{source_code_return}"
         )
 
-    sig = inspect.signature(func)
+    sig = inspect.signature(func, eval_str=True)
+    # We can safely force-eval string hints resulting from
+    # `from __future__ import annotations` because a dataclass-returning function
+    # probably has actual access to that dataclass object to return it
+    # The edge case is a `if TYPE_CHECKING` import for the hint, and then _inside_ the
+    # function properly importing it, and using it as a return. That's ridiculous and
+    # I'm not supporting it.
     ann = sig.return_annotation
 
     # unwrap Annotated

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -244,7 +244,7 @@ def _parse_dataclass_return_labels(func: FunctionType) -> list[str]:
     try:
         sig = inspect.signature(func, eval_str=True)
     except NameError as e:
-        raise ValueError(
+        raise NameError(
             "Dataclass unpack mode requires the return annotation to be importable at "
             "runtime. Evaluating the return annotation for "
             f"{func.__module__}.{func.__qualname__} failed with: {e}"

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -359,7 +359,15 @@ def _parse_return_dataclass(
         )
 
     # de-stringify dataclass annotations, if they were forward-references
-    hints = get_type_hints(return_annotation, include_extras=True)
+    try:
+        hints = get_type_hints(return_annotation, include_extras=True)
+    except NameError as e:
+        fqdn = f"{return_annotation.__module__}.{return_annotation.__qualname__}"
+        raise NameError(
+            f"While parsing return dataclass annotation {fqdn!r}, could not resolve "
+            f"at least one field annotation ({e}). Ensure the missing symbols are "
+            f"importable at runtime in the dataclass' defining module."
+        ) from e
 
     fields = dataclasses.fields(return_annotation)
     if len(outputs) != len(fields):  # pragma: no cover

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -351,7 +351,10 @@ def _parse_return_tuple(
 def _parse_return_dataclass(
     return_annotation, outputs: list[str]
 ) -> dict[str, OutputDataPort]:
-    if not dataclasses.is_dataclass(return_annotation):  # pragma: no cover
+    if not (
+        isinstance(return_annotation, type)
+        and dataclasses.is_dataclass(return_annotation)
+    ):  # pragma: no cover
         raise TypeError(
             f"Return annotation {return_annotation!r} is not a dataclass. This should "
             f"have been caught by the underlying recipe validation. Please raise a "

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -239,7 +239,16 @@ def _parse_function(
     dict[base_models.Label, OutputDataPort],
 ]:
     function = retrieve.import_from_string(fully_qualified_name)
-    hints = get_type_hints(function, include_extras=True)
+    try:
+        hints = get_type_hints(function, include_extras=True)
+    except NameError as e:
+        raise NameError(
+            f"While parsing {fully_qualified_name!r} for recipe inputs {inputs} and "
+            f"outputs {outputs}, could not find the symbol for at least one "
+            f"annotation. This is likely due to forward referenced annotations. Please "
+            f"cross reference the underlying name error ({str(e)!r}) and the function "
+            f"being parsed, and locally make the necessary imports before re-parsing."
+        ) from e
     sig = inspect.signature(function)
 
     variadics_in_sig = {

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -358,6 +358,9 @@ def _parse_return_dataclass(
             f"GitHub issue reporting how you got here!"
         )
 
+    # de-stringify dataclass annotations, if they were forward-references
+    hints = get_type_hints(return_annotation, include_extras=True)
+
     fields = dataclasses.fields(return_annotation)
     if len(outputs) != len(fields):  # pragma: no cover
         raise ValueError(
@@ -368,8 +371,6 @@ def _parse_return_dataclass(
         )
 
     return {
-        label: OutputDataPort(
-            annotation=(field.type if field.type is not dataclasses.MISSING else None),
-        )
+        label: OutputDataPort(annotation=hints.get(field.name, None))
         for label, field in zip(outputs, fields, strict=True)
     }

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -19,6 +19,11 @@ class _Result:
     y: int
 
 
+@dataclasses.dataclass
+class _TypingProblem:
+    x: YouCantFindThis  # noqa: F821
+
+
 def _make_func_in_module(module: str, qualname: str) -> FunctionType:
     """Create a trivial function with controlled __module__ and __qualname__."""
 
@@ -670,6 +675,22 @@ class TestParseDataclassReturnLabels(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             atomic_parser._parse_dataclass_return_labels(func)
         self.assertIn("same number of elements", str(ctx.exception).lower())
+
+    def test_unimportable_annotation_raises(self):
+        """
+        This should probably never be hittable in practice, because it requires the
+        user to ask for dataclass unpacking, and hinting something unimported, but
+        usually the hint and the returned object will be the same in this case (and
+        thus safely imported!)
+        """
+
+        def func() -> NotImportable:  # noqa: F821
+            return _TypingProblem(42)
+
+        with self.assertRaisesRegex(
+            NameError, "requires the return annotation to be importable"
+        ):
+            atomic_parser._parse_dataclass_return_labels(func)
 
 
 class TestParseTupleReturnLabelsWithAnnotations(unittest.TestCase):

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import dataclasses
 import inspect
@@ -9,6 +11,12 @@ from typing import Annotated
 from flowrep import base_models
 from flowrep.parsers import atomic_parser, label_helpers, parser_helpers
 from flowrep.prospective import atomic_recipe
+
+
+@dataclasses.dataclass
+class _Result:
+    x: int
+    y: int
 
 
 def _make_func_in_module(module: str, qualname: str) -> FunctionType:
@@ -291,13 +299,9 @@ class TestParseAtomicWithOutputLabels(unittest.TestCase):
         self.assertEqual(node.outputs, ["result"])
 
     def test_explicit_labels_with_dataclass(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
-            y: int
 
-        def func() -> Result:
-            return Result(1, 2)
+        def func() -> _Result:
+            return _Result(1, 2)
 
         # Should use dataclass fields, not explicit labels
         node = atomic_parser.parse_atomic(
@@ -306,13 +310,9 @@ class TestParseAtomicWithOutputLabels(unittest.TestCase):
         self.assertEqual(node.outputs, ["x", "y"])
 
     def test_explicit_labels_with_dataclass_wrong_count_raises(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
-            y: int
 
-        def func() -> Result:
-            return Result(1, 2)
+        def func() -> _Result:
+            return _Result(1, 2)
 
         with self.assertRaises(ValueError) as ctx:
             atomic_parser.parse_atomic(
@@ -597,13 +597,9 @@ class TestExtractCombinedReturnLabels(unittest.TestCase):
 
 class TestParseDataclassReturnLabels(unittest.TestCase):
     def test_valid_dataclass_return(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
-            y: int
 
-        def func() -> Result:
-            return Result(1, 2)
+        def func() -> _Result:
+            return _Result(1, 2)
 
         labels = atomic_parser._parse_dataclass_return_labels(func)
         self.assertEqual(labels, ["x", "y"])
@@ -625,32 +621,26 @@ class TestParseDataclassReturnLabels(unittest.TestCase):
         self.assertIn("dataclass", str(ctx.exception))
 
     def test_multiple_return_statements(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
 
-        def func(flag) -> Result:
+        def func(flag) -> _Result:
             if flag:
-                return Result(1)
-            return Result(2)
+                return _Result(1, 2)
+            return _Result(2, 3)
 
         labels = atomic_parser._parse_dataclass_return_labels(func)
-        self.assertEqual(labels, ["x"])
+        self.assertEqual(labels, ["x", "y"])
 
     def test_dangerous_returns(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
 
-        def func(flag) -> Result:
+        def func(flag) -> _Result:
             if flag:
                 return 42
-            return Result(2)
+            return _Result(2, 3)
 
         labels = atomic_parser._parse_dataclass_return_labels(func)
         self.assertEqual(
             labels,
-            ["x"],
+            ["x", "y"],
             msg="THIS IS THE DEVELOPER'S PROBLEM. We can't stop them from lying in "
             "their return statements.",
         )
@@ -899,13 +889,9 @@ class TestAtomicWithAnnotations(unittest.TestCase):
 
 class TestAnnotationWithDataclass(unittest.TestCase):
     def test_dataclass_mode_ignores_annotated_wrapper(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
-            y: int
 
-        def func() -> Annotated[Result, {"label": "ignored"}]:
-            return Result(1, 2)
+        def func() -> Annotated[_Result, {"label": "ignored"}]:
+            return _Result(1, 2)
 
         node = atomic_parser.parse_atomic(
             func, unpack_mode=atomic_recipe.UnpackMode.DATACLASS
@@ -913,13 +899,9 @@ class TestAnnotationWithDataclass(unittest.TestCase):
         self.assertEqual(node.outputs, ["x", "y"])
 
     def test_dataclass_mode_ignores_output_meta_wrapper(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
-            y: int
 
-        def func() -> Annotated[Result, label_helpers.OutputMeta(label="ignored")]:
-            return Result(1, 2)
+        def func() -> Annotated[_Result, label_helpers.OutputMeta(label="ignored")]:
+            return _Result(1, 2)
 
         node = atomic_parser.parse_atomic(
             func, unpack_mode=atomic_recipe.UnpackMode.DATACLASS

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -30,13 +30,22 @@ if TYPE_CHECKING:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Unavailable annotation node
+# Unavailable annotations
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 @atomic_parser.atomic
 def get_blue(colors: SeabornColors) -> str:
     return colors.blue
+
+
+@dataclasses.dataclass
+class InaccessibleFieldAnnotation:
+    x: SeabornColors
+
+
+def return_problematic_dataclass(x) -> InaccessibleFieldAnnotation:
+    return InaccessibleFieldAnnotation(x)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -578,6 +587,14 @@ class TestAtomicFromRecipe(unittest.TestCase):
         node = datastructures.AtomicData.from_recipe(recipe)
         self.assertIs(node.output_ports["x"].annotation, int)
         self.assertIs(node.output_ports["y"].annotation, int)
+
+    def test_unpacking_dataclass_with_inaccessible_field_raises(self):
+        recipe = atomic_parser.parse_atomic(
+            return_problematic_dataclass,
+            unpack_mode=atomic_recipe.UnpackMode.DATACLASS,
+        )
+        with self.assertRaisesRegex(NameError, "name 'SeabornColors' is not defined"):
+            datastructures.AtomicData.from_recipe(recipe)
 
     def test_unpacking_dataclass_as_none(self):
         recipe = atomic_parser.parse_atomic(

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -638,13 +638,15 @@ class TestAtomicFromRecipe(unittest.TestCase):
         with self.assertRaisesRegex(NameError, "name 'SeabornColors' is not defined"):
             datastructures.AtomicData.from_recipe(get_blue.flowrep_recipe)
 
-            # get_type_hints resolves in the defining module's globals, not here
-            get_blue.__globals__["SeabornColors"] = SeabornColors
-            try:
-                data = datastructures.AtomicData.from_recipe(get_blue.flowrep_recipe)
-                self.assertIs(data.input_ports["colors"].annotation, SeabornColors)
-            finally:
-                del get_blue.__globals__["SeabornColors"]
+        from pyiron_snippets.colors import SeabornColors
+
+        # get_type_hints resolves in the defining module's globals, not here
+        get_blue.__globals__["SeabornColors"] = SeabornColors
+        try:
+            data = datastructures.AtomicData.from_recipe(get_blue.flowrep_recipe)
+            self.assertIs(data.input_ports["colors"].annotation, SeabornColors)
+        finally:
+            del get_blue.__globals__["SeabornColors"]
 
 
 class TestWorkflowFromRecipe(unittest.TestCase):

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -1,9 +1,11 @@
 """Tests for the retrospective data model and the minimal WfMS."""
 
+from __future__ import annotations
+
 import dataclasses
 import pickle
 import unittest
-from typing import get_origin
+from typing import TYPE_CHECKING, get_origin
 
 from pyiron_snippets import versions
 
@@ -22,6 +24,20 @@ from flowrep.retrospective import datastructures
 from flowrep.retrospective.datastructures import NOT_DATA
 
 from flowrep_static import library
+
+if TYPE_CHECKING:
+    from pyiron_snippets.colors import SeabornColors
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Unavailable annotation node
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@atomic_parser.atomic
+def get_blue(colors: SeabornColors) -> str:
+    return colors.blue
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helper factories for manual recipe construction
@@ -617,6 +633,18 @@ class TestAtomicFromRecipe(unittest.TestCase):
         self.assertIn(
             "(n=3) do not match length of return annotation", str(ctx.exception)
         )
+
+    def test_unavailable_annotation(self):
+        with self.assertRaisesRegex(NameError, "name 'SeabornColors' is not defined"):
+            datastructures.AtomicData.from_recipe(get_blue.flowrep_recipe)
+
+            # get_type_hints resolves in the defining module's globals, not here
+            get_blue.__globals__["SeabornColors"] = SeabornColors
+            try:
+                data = datastructures.AtomicData.from_recipe(get_blue.flowrep_recipe)
+                self.assertIs(data.input_ports["colors"].annotation, SeabornColors)
+            finally:
+                del get_blue.__globals__["SeabornColors"]
 
 
 class TestWorkflowFromRecipe(unittest.TestCase):


### PR DESCRIPTION
By resolving the strings to objects when making `NodeData` instances.

Closes #260 

In the process of closing the basic case, I added `from __future__ import annotation` to the unit test file, which stringified other hints and uncovered that they need destringification too.

If the forward references _aren't_ available, it is up to the user to simply import them in whatever scope they're hoping to instantiate the data object. I tried to make the error message as useful as possible to facilitate this, and added an aside demonstrating the process in the user guide.