### PR TITLE
Unpacking dataclasses on recipe call

### DIFF
--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -482,6 +482,20 @@
    "execution_count": 9
   },
   {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "This unpacking mode is an instruction for flowrep and WfMS -- it doesn't impact the decorated function. The decorated function still just returns the dataclass instance:",
+   "id": "95a09d3e500b1b87"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "make_point(1, 2)",
+   "id": "bebb33c6345c3ab9"
+  },
+  {
    "cell_type": "markdown",
    "id": "637a194b",
    "metadata": {},
@@ -804,6 +818,20 @@
     }
    ],
    "execution_count": 15
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Recall: atomic-decorated functions with `unpack_mode=\"dataclass\"`  still just returned the raw dataclass their python code suggests. When we call the _recipe_ for `\"dataclass\"`-unpacked functions, we'll get the decomposed values:",
+   "id": "396728243a8a212e"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "make_point(1, 2), make_point.flowrep_recipe(1, 2)",
+   "id": "5e2b36c02de9cb22"
   },
   {
    "metadata": {},

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -37,8 +37,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.158975Z",
-     "start_time": "2026-06-15T20:20:47.831494Z"
+     "end_time": "2026-07-08T19:18:06.940948Z",
+     "start_time": "2026-07-08T19:18:06.702976Z"
     }
    },
    "cell_type": "code",
@@ -103,8 +103,8 @@
    "id": "8590ac6e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.212985Z",
-     "start_time": "2026-06-15T20:20:48.162764Z"
+     "end_time": "2026-07-08T19:18:06.965078Z",
+     "start_time": "2026-07-08T19:18:06.954273Z"
     }
    },
    "source": [
@@ -163,8 +163,8 @@
    "id": "fbb2ac82",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.260749Z",
-     "start_time": "2026-06-15T20:20:48.226095Z"
+     "end_time": "2026-07-08T19:18:07.010508Z",
+     "start_time": "2026-07-08T19:18:06.976085Z"
     }
    },
    "source": [
@@ -204,8 +204,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.306323Z",
-     "start_time": "2026-06-15T20:20:48.273183Z"
+     "end_time": "2026-07-08T19:18:07.105791Z",
+     "start_time": "2026-07-08T19:18:07.025150Z"
     }
    },
    "cell_type": "code",
@@ -240,8 +240,8 @@
    "id": "4ce6917d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.327777Z",
-     "start_time": "2026-06-15T20:20:48.317933Z"
+     "end_time": "2026-07-08T19:18:07.139145Z",
+     "start_time": "2026-07-08T19:18:07.108196Z"
     }
    },
    "source": [
@@ -313,8 +313,8 @@
    "id": "cac0a1bd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.354255Z",
-     "start_time": "2026-06-15T20:20:48.337505Z"
+     "end_time": "2026-07-08T19:18:07.167112Z",
+     "start_time": "2026-07-08T19:18:07.141157Z"
     }
    },
    "source": [
@@ -354,8 +354,8 @@
    "id": "9f659bd7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.394894Z",
-     "start_time": "2026-06-15T20:20:48.368596Z"
+     "end_time": "2026-07-08T19:18:07.196374Z",
+     "start_time": "2026-07-08T19:18:07.169167Z"
     }
    },
    "source": [
@@ -394,8 +394,8 @@
    "id": "467bd6b8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.416075Z",
-     "start_time": "2026-06-15T20:20:48.405917Z"
+     "end_time": "2026-07-08T19:18:07.226225Z",
+     "start_time": "2026-07-08T19:18:07.198296Z"
     }
    },
    "source": [
@@ -448,8 +448,8 @@
    "id": "0d46e437",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.443122Z",
-     "start_time": "2026-06-15T20:20:48.426590Z"
+     "end_time": "2026-07-08T19:18:07.253676Z",
+     "start_time": "2026-07-08T19:18:07.228131Z"
     }
    },
    "source": [
@@ -488,12 +488,28 @@
    "id": "95a09d3e500b1b87"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-08T19:18:07.282755Z",
+     "start_time": "2026-07-08T19:18:07.255656Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": "make_point(1, 2)",
-   "id": "bebb33c6345c3ab9"
+   "id": "bebb33c6345c3ab9",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point(x=1, y=2)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",
@@ -512,8 +528,8 @@
    "id": "77276c40",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.486595Z",
-     "start_time": "2026-06-15T20:20:48.454920Z"
+     "end_time": "2026-07-08T19:18:07.313205Z",
+     "start_time": "2026-07-08T19:18:07.285100Z"
     }
    },
    "source": [
@@ -544,7 +560,7 @@
      ]
     }
    ],
-   "execution_count": 10
+   "execution_count": 11
   },
   {
    "cell_type": "markdown",
@@ -563,8 +579,8 @@
    "id": "a4019caa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.503829Z",
-     "start_time": "2026-06-15T20:20:48.488676Z"
+     "end_time": "2026-07-08T19:18:07.335662Z",
+     "start_time": "2026-07-08T19:18:07.326044Z"
     }
    },
    "source": [
@@ -591,7 +607,7 @@
      ]
     }
    ],
-   "execution_count": 11
+   "execution_count": 12
   },
   {
    "cell_type": "markdown",
@@ -613,8 +629,8 @@
    "id": "b8f03ee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.546452Z",
-     "start_time": "2026-06-15T20:20:48.516323Z"
+     "end_time": "2026-07-08T19:18:07.375880Z",
+     "start_time": "2026-07-08T19:18:07.347813Z"
     }
    },
    "source": [
@@ -641,7 +657,7 @@
      ]
     }
    ],
-   "execution_count": 12
+   "execution_count": 13
   },
   {
    "cell_type": "markdown",
@@ -691,8 +707,8 @@
    "id": "9ac92af2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.638142Z",
-     "start_time": "2026-06-15T20:20:48.590450Z"
+     "end_time": "2026-07-08T19:18:07.408408Z",
+     "start_time": "2026-07-08T19:18:07.377892Z"
     }
    },
    "source": [
@@ -721,7 +737,7 @@
      ]
     }
    ],
-   "execution_count": 13
+   "execution_count": 14
   },
   {
    "cell_type": "markdown",
@@ -740,8 +756,8 @@
    "id": "1037ac27",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.654226Z",
-     "start_time": "2026-06-15T20:20:48.640322Z"
+     "end_time": "2026-07-08T19:18:07.437181Z",
+     "start_time": "2026-07-08T19:18:07.410908Z"
     }
    },
    "source": [
@@ -770,7 +786,7 @@
      ]
     }
    ],
-   "execution_count": 14
+   "execution_count": 15
   },
   {
    "cell_type": "markdown",
@@ -798,8 +814,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.681626Z",
-     "start_time": "2026-06-15T20:20:48.666365Z"
+     "end_time": "2026-07-08T19:18:07.491519Z",
+     "start_time": "2026-07-08T19:18:07.439249Z"
     }
    },
    "cell_type": "code",
@@ -812,12 +828,12 @@
        "array([1])"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 15
+   "execution_count": 16
   },
   {
    "metadata": {},
@@ -826,12 +842,28 @@
    "id": "396728243a8a212e"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-08T19:18:07.525444Z",
+     "start_time": "2026-07-08T19:18:07.492679Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": "make_point(1, 2), make_point.flowrep_recipe(1, 2)",
-   "id": "5e2b36c02de9cb22"
+   "id": "5e2b36c02de9cb22",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Point(x=1, y=2), (1, 2))"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 17
   },
   {
    "metadata": {},
@@ -846,8 +878,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.711518Z",
-     "start_time": "2026-06-15T20:20:48.692678Z"
+     "end_time": "2026-07-08T19:18:07.617696Z",
+     "start_time": "2026-07-08T19:18:07.539352Z"
     }
    },
    "cell_type": "code",
@@ -880,13 +912,13 @@
      ]
     }
    ],
-   "execution_count": 16
+   "execution_count": 18
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.747165Z",
-     "start_time": "2026-06-15T20:20:48.721212Z"
+     "end_time": "2026-07-08T19:18:07.652983Z",
+     "start_time": "2026-07-08T19:18:07.620246Z"
     }
    },
    "cell_type": "code",
@@ -899,12 +931,12 @@
        "{'this': 1, 'that': 2, 'the_other': 3}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 17
+   "execution_count": 19
   },
   {
    "metadata": {},
@@ -915,8 +947,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.777397Z",
-     "start_time": "2026-06-15T20:20:48.750521Z"
+     "end_time": "2026-07-08T19:18:07.681796Z",
+     "start_time": "2026-07-08T19:18:07.663308Z"
     }
    },
    "cell_type": "code",
@@ -953,13 +985,13 @@
      ]
     }
    ],
-   "execution_count": 18
+   "execution_count": 20
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.804059Z",
-     "start_time": "2026-06-15T20:20:48.777886Z"
+     "end_time": "2026-07-08T19:18:07.709264Z",
+     "start_time": "2026-07-08T19:18:07.684206Z"
     }
    },
    "cell_type": "code",
@@ -972,12 +1004,12 @@
        "6"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 19
+   "execution_count": 21
   },
   {
    "metadata": {},
@@ -1014,8 +1046,8 @@
    "id": "d39608c2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.823762Z",
-     "start_time": "2026-06-15T20:20:48.813134Z"
+     "end_time": "2026-07-08T19:18:07.749940Z",
+     "start_time": "2026-07-08T19:18:07.711386Z"
     }
    },
    "source": [
@@ -1059,12 +1091,12 @@
        "WorkflowRecipe(type=<RecipeElementType.WORKFLOW: 'workflow'>, inputs=['x', 'slope', 'intercept'], outputs=['result'], description='y = slope * x + intercept', nodes={'multiply_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>), 'add_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>)}, input_edges={TargetHandle(node='multiply_0', port='x'): InputSource(node=None, port='x'), TargetHandle(node='multiply_0', port='y'): InputSource(node=None, port='slope'), TargetHandle(node='add_0', port='b'): InputSource(node=None, port='intercept')}, edges={TargetHandle(node='add_0', port='a'): SourceHandle(node='multiply_0', port='product')}, output_edges={OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result')}, reference=PythonReference(info=VersionInfo(module='__main__', qualname='linear', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 20
+   "execution_count": 22
   },
   {
    "cell_type": "markdown",
@@ -1094,8 +1126,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.863427Z",
-     "start_time": "2026-06-15T20:20:48.833581Z"
+     "end_time": "2026-07-08T19:18:07.786325Z",
+     "start_time": "2026-07-08T19:18:07.752388Z"
     }
    },
    "cell_type": "code",
@@ -1108,12 +1140,12 @@
        "7"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 21
+   "execution_count": 23
   },
   {
    "cell_type": "markdown",
@@ -1151,8 +1183,8 @@
    "id": "55716aa9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.886634Z",
-     "start_time": "2026-06-15T20:20:48.875473Z"
+     "end_time": "2026-07-08T19:18:07.812555Z",
+     "start_time": "2026-07-08T19:18:07.788375Z"
     }
    },
    "source": [
@@ -1190,7 +1222,7 @@
      ]
     }
    ],
-   "execution_count": 22
+   "execution_count": 24
   },
   {
    "cell_type": "markdown",
@@ -1224,8 +1256,8 @@
    "id": "cd45cbb2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.922552Z",
-     "start_time": "2026-06-15T20:20:48.895931Z"
+     "end_time": "2026-07-08T19:18:07.840312Z",
+     "start_time": "2026-07-08T19:18:07.814638Z"
     }
    },
    "source": [
@@ -1251,7 +1283,7 @@
      ]
     }
    ],
-   "execution_count": 23
+   "execution_count": 25
   },
   {
    "cell_type": "markdown",
@@ -1279,8 +1311,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.934468Z",
-     "start_time": "2026-06-15T20:20:48.924770Z"
+     "end_time": "2026-07-08T19:18:07.854769Z",
+     "start_time": "2026-07-08T19:18:07.843738Z"
     }
    },
    "cell_type": "code",
@@ -1299,7 +1331,7 @@
    ],
    "id": "de18e624974cf3e2",
    "outputs": [],
-   "execution_count": 24
+   "execution_count": 26
   },
   {
    "metadata": {},
@@ -1313,8 +1345,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.968168Z",
-     "start_time": "2026-06-15T20:20:48.943975Z"
+     "end_time": "2026-07-08T19:18:07.890815Z",
+     "start_time": "2026-07-08T19:18:07.866052Z"
     }
    },
    "cell_type": "code",
@@ -1333,7 +1365,7 @@
      ]
     }
    ],
-   "execution_count": 25
+   "execution_count": 27
   },
   {
    "metadata": {},
@@ -1354,8 +1386,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:48.984846Z",
-     "start_time": "2026-06-15T20:20:48.970172Z"
+     "end_time": "2026-07-08T19:18:07.922858Z",
+     "start_time": "2026-07-08T19:18:07.894413Z"
     }
    },
    "cell_type": "code",
@@ -1368,12 +1400,12 @@
        "{'this': 'this default', 'that': 'that default', 'the_other': array([0, 2])}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 26
+   "execution_count": 28
   },
   {
    "cell_type": "markdown",
@@ -1429,8 +1461,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.022304Z",
-     "start_time": "2026-06-15T20:20:48.995786Z"
+     "end_time": "2026-07-08T19:18:07.946727Z",
+     "start_time": "2026-07-08T19:18:07.924997Z"
     }
    },
    "cell_type": "code",
@@ -1443,12 +1475,12 @@
        "(None, None)"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 27
+   "execution_count": 29
   },
   {
    "cell_type": "markdown",
@@ -1463,8 +1495,8 @@
    "id": "06c2b2eb",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.050883Z",
-     "start_time": "2026-06-15T20:20:49.024532Z"
+     "end_time": "2026-07-08T19:18:07.974037Z",
+     "start_time": "2026-07-08T19:18:07.948875Z"
     }
    },
    "source": [
@@ -1500,7 +1532,7 @@
      ]
     }
    ],
-   "execution_count": 28
+   "execution_count": 30
   },
   {
    "cell_type": "markdown",
@@ -1519,8 +1551,8 @@
    "id": "6d7a6e2a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.142150Z",
-     "start_time": "2026-06-15T20:20:49.063193Z"
+     "end_time": "2026-07-08T19:18:08.008550Z",
+     "start_time": "2026-07-08T19:18:07.977759Z"
     }
    },
    "source": [
@@ -1612,7 +1644,7 @@
      ]
     }
    ],
-   "execution_count": 29
+   "execution_count": 31
   },
   {
    "cell_type": "markdown",
@@ -1629,8 +1661,8 @@
    "id": "53e8f09d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.169528Z",
-     "start_time": "2026-06-15T20:20:49.144143Z"
+     "end_time": "2026-07-08T19:18:08.039342Z",
+     "start_time": "2026-07-08T19:18:08.011058Z"
     }
    },
    "source": [
@@ -1649,7 +1681,7 @@
      ]
     }
    ],
-   "execution_count": 30
+   "execution_count": 32
   },
   {
    "cell_type": "markdown",
@@ -1682,8 +1714,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.184912Z",
-     "start_time": "2026-06-15T20:20:49.171340Z"
+     "end_time": "2026-07-08T19:18:08.060200Z",
+     "start_time": "2026-07-08T19:18:08.041728Z"
     }
    },
    "cell_type": "code",
@@ -1734,7 +1766,7 @@
      ]
     }
    ],
-   "execution_count": 31
+   "execution_count": 33
   },
   {
    "cell_type": "markdown",
@@ -1849,8 +1881,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.238550Z",
-     "start_time": "2026-06-15T20:20:49.195654Z"
+     "end_time": "2026-07-08T19:18:08.154739Z",
+     "start_time": "2026-07-08T19:18:08.108368Z"
     }
    },
    "cell_type": "code",
@@ -1902,7 +1934,7 @@
      ]
     }
    ],
-   "execution_count": 32
+   "execution_count": 34
   },
   {
    "cell_type": "markdown",
@@ -1933,8 +1965,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.250846Z",
-     "start_time": "2026-06-15T20:20:49.240738Z"
+     "end_time": "2026-07-08T19:18:08.185661Z",
+     "start_time": "2026-07-08T19:18:08.157120Z"
     }
    },
    "cell_type": "code",
@@ -1975,7 +2007,7 @@
      ]
     }
    ],
-   "execution_count": 33
+   "execution_count": 35
   },
   {
    "cell_type": "markdown",
@@ -2002,8 +2034,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.284595Z",
-     "start_time": "2026-06-15T20:20:49.260898Z"
+     "end_time": "2026-07-08T19:18:08.213361Z",
+     "start_time": "2026-07-08T19:18:08.187848Z"
     }
    },
    "cell_type": "code",
@@ -2032,7 +2064,7 @@
      ]
     }
    ],
-   "execution_count": 34
+   "execution_count": 36
   },
   {
    "metadata": {},
@@ -2048,8 +2080,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.302533Z",
-     "start_time": "2026-06-15T20:20:49.294333Z"
+     "end_time": "2026-07-08T19:18:08.254347Z",
+     "start_time": "2026-07-08T19:18:08.223930Z"
     }
    },
    "cell_type": "code",
@@ -2083,7 +2115,7 @@
      ]
     }
    ],
-   "execution_count": 35
+   "execution_count": 37
   },
   {
    "cell_type": "markdown",
@@ -2139,8 +2171,8 @@
    "id": "0a285891",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.338953Z",
-     "start_time": "2026-06-15T20:20:49.312165Z"
+     "end_time": "2026-07-08T19:18:08.282551Z",
+     "start_time": "2026-07-08T19:18:08.256506Z"
     }
    },
    "source": [
@@ -2184,7 +2216,7 @@
      ]
     }
    ],
-   "execution_count": 36
+   "execution_count": 38
   },
   {
    "cell_type": "markdown",
@@ -2235,8 +2267,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.372302Z",
-     "start_time": "2026-06-15T20:20:49.341179Z"
+     "end_time": "2026-07-08T19:18:08.311135Z",
+     "start_time": "2026-07-08T19:18:08.284995Z"
     }
    },
    "cell_type": "code",
@@ -2275,16 +2307,16 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_14836/3477409776.py\", line 16, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_92383/3477409776.py\", line 16, in <module>\n",
       "    conditional_availability(-1)\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_14836/3477409776.py\", line 9, in conditional_availability\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_92383/3477409776.py\", line 9, in conditional_availability\n",
       "    downstream = identity(result)\n",
       "                          ^^^^^^\n",
       "UnboundLocalError: cannot access local variable 'result' where it is not associated with a value\n"
      ]
     }
    ],
-   "execution_count": 37
+   "execution_count": 39
   },
   {
    "cell_type": "markdown",
@@ -2317,8 +2349,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.387841Z",
-     "start_time": "2026-06-15T20:20:49.382926Z"
+     "end_time": "2026-07-08T19:18:08.327185Z",
+     "start_time": "2026-07-08T19:18:08.313278Z"
     }
    },
    "source": [
@@ -2334,7 +2366,7 @@
     "    return result"
    ],
    "outputs": [],
-   "execution_count": 38
+   "execution_count": 40
   },
   {
    "cell_type": "markdown",
@@ -2364,8 +2396,8 @@
    "id": "52ab25e4",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.406059Z",
-     "start_time": "2026-06-15T20:20:49.388431Z"
+     "end_time": "2026-07-08T19:18:08.362190Z",
+     "start_time": "2026-07-08T19:18:08.339328Z"
     }
    },
    "source": [
@@ -2402,15 +2434,15 @@
      ]
     }
    ],
-   "execution_count": 39
+   "execution_count": 41
   },
   {
    "cell_type": "code",
    "id": "79c1d339",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.421062Z",
-     "start_time": "2026-06-15T20:20:49.408411Z"
+     "end_time": "2026-07-08T19:18:08.389181Z",
+     "start_time": "2026-07-08T19:18:08.364295Z"
     }
    },
    "source": [
@@ -2435,7 +2467,7 @@
      ]
     }
    ],
-   "execution_count": 40
+   "execution_count": 42
   },
   {
    "cell_type": "markdown",
@@ -2483,8 +2515,8 @@
    "id": "d76836d6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.449218Z",
-     "start_time": "2026-06-15T20:20:49.433062Z"
+     "end_time": "2026-07-08T19:18:08.416380Z",
+     "start_time": "2026-07-08T19:18:08.391480Z"
     }
    },
    "source": [
@@ -2539,7 +2571,7 @@
      ]
     }
    ],
-   "execution_count": 41
+   "execution_count": 43
   },
   {
    "cell_type": "markdown",
@@ -2572,8 +2604,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.485038Z",
-     "start_time": "2026-06-15T20:20:49.460470Z"
+     "end_time": "2026-07-08T19:18:08.442259Z",
+     "start_time": "2026-07-08T19:18:08.418776Z"
     }
    },
    "cell_type": "code",
@@ -2591,7 +2623,7 @@
      ]
     }
    ],
-   "execution_count": 42
+   "execution_count": 44
   },
   {
    "metadata": {},
@@ -2602,8 +2634,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.501381Z",
-     "start_time": "2026-06-15T20:20:49.486896Z"
+     "end_time": "2026-07-08T19:18:08.470068Z",
+     "start_time": "2026-07-08T19:18:08.444457Z"
     }
    },
    "cell_type": "code",
@@ -2621,7 +2653,7 @@
      ]
     }
    ],
-   "execution_count": 43
+   "execution_count": 45
   },
   {
    "cell_type": "markdown",
@@ -2651,8 +2683,8 @@
    "id": "3efa3180",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.538282Z",
-     "start_time": "2026-06-15T20:20:49.511684Z"
+     "end_time": "2026-07-08T19:18:08.497189Z",
+     "start_time": "2026-07-08T19:18:08.472269Z"
     }
    },
    "source": [
@@ -2673,7 +2705,7 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_14836/3041652459.py\", line 4, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_92383/3041652459.py\", line 4, in <module>\n",
       "    @fr.atomic(forbid_main=True)\n",
       "     ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/parser_helpers.py\", line 44, in decorator\n",
@@ -2690,7 +2722,7 @@
      ]
     }
    ],
-   "execution_count": 44
+   "execution_count": 46
   },
   {
    "cell_type": "markdown",
@@ -2725,8 +2757,8 @@
    "id": "82468383",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.568712Z",
-     "start_time": "2026-06-15T20:20:49.540444Z"
+     "end_time": "2026-07-08T19:18:08.526175Z",
+     "start_time": "2026-07-08T19:18:08.499553Z"
     }
    },
    "source": [
@@ -2746,7 +2778,7 @@
      ]
     }
    ],
-   "execution_count": 45
+   "execution_count": 47
   },
   {
    "metadata": {},
@@ -2764,8 +2796,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.601318Z",
-     "start_time": "2026-06-15T20:20:49.570723Z"
+     "end_time": "2026-07-08T19:18:08.569735Z",
+     "start_time": "2026-07-08T19:18:08.537192Z"
     }
    },
    "cell_type": "code",
@@ -2790,7 +2822,7 @@
      ]
     }
    ],
-   "execution_count": 46
+   "execution_count": 48
   },
   {
    "metadata": {},
@@ -2805,8 +2837,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.649999Z",
-     "start_time": "2026-06-15T20:20:49.602021Z"
+     "end_time": "2026-07-08T19:18:08.620312Z",
+     "start_time": "2026-07-08T19:18:08.570694Z"
     }
    },
    "cell_type": "code",
@@ -2816,7 +2848,7 @@
    ],
    "id": "664078176aceb6e0",
    "outputs": [],
-   "execution_count": 47
+   "execution_count": 49
   },
   {
    "metadata": {},
@@ -2827,8 +2859,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.680862Z",
-     "start_time": "2026-06-15T20:20:49.670652Z"
+     "end_time": "2026-07-08T19:18:08.672899Z",
+     "start_time": "2026-07-08T19:18:08.646534Z"
     }
    },
    "cell_type": "code",
@@ -2854,7 +2886,7 @@
      ]
     }
    ],
-   "execution_count": 48
+   "execution_count": 50
   },
   {
    "metadata": {},
@@ -2865,8 +2897,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.717671Z",
-     "start_time": "2026-06-15T20:20:49.692204Z"
+     "end_time": "2026-07-08T19:18:08.703691Z",
+     "start_time": "2026-07-08T19:18:08.675081Z"
     }
    },
    "cell_type": "code",
@@ -2882,12 +2914,12 @@
        "3"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 49
+   "execution_count": 51
   },
   {
    "metadata": {},
@@ -2902,8 +2934,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.745335Z",
-     "start_time": "2026-06-15T20:20:49.719551Z"
+     "end_time": "2026-07-08T19:18:08.731114Z",
+     "start_time": "2026-07-08T19:18:08.705876Z"
     }
    },
    "cell_type": "code",
@@ -2943,7 +2975,7 @@
      ]
     }
    ],
-   "execution_count": 50
+   "execution_count": 52
   },
   {
    "metadata": {},
@@ -2958,8 +2990,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.762454Z",
-     "start_time": "2026-06-15T20:20:49.747275Z"
+     "end_time": "2026-07-08T19:18:08.759647Z",
+     "start_time": "2026-07-08T19:18:08.733623Z"
     }
    },
    "cell_type": "code",
@@ -3008,7 +3040,7 @@
      ]
     }
    ],
-   "execution_count": 51
+   "execution_count": 53
   },
   {
    "metadata": {},
@@ -3023,8 +3055,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.797072Z",
-     "start_time": "2026-06-15T20:20:49.775805Z"
+     "end_time": "2026-07-08T19:18:08.793444Z",
+     "start_time": "2026-07-08T19:18:08.769827Z"
     }
    },
    "cell_type": "code",
@@ -3039,12 +3071,12 @@
        " '_default_y': 4}"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 52
+   "execution_count": 54
   },
   {
    "metadata": {},
@@ -3055,8 +3087,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.824947Z",
-     "start_time": "2026-06-15T20:20:49.809289Z"
+     "end_time": "2026-07-08T19:18:08.818820Z",
+     "start_time": "2026-07-08T19:18:08.795508Z"
     }
    },
    "cell_type": "code",
@@ -3072,12 +3104,12 @@
        "3"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 53
+   "execution_count": 55
   },
   {
    "metadata": {},
@@ -3117,8 +3149,8 @@
    "id": "cabe9313",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.864816Z",
-     "start_time": "2026-06-15T20:20:49.835479Z"
+     "end_time": "2026-07-08T19:18:08.849049Z",
+     "start_time": "2026-07-08T19:18:08.820823Z"
     }
    },
    "source": [
@@ -3160,7 +3192,7 @@
      ]
     }
    ],
-   "execution_count": 54
+   "execution_count": 56
   },
   {
    "cell_type": "markdown",
@@ -3171,8 +3203,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.885473Z",
-     "start_time": "2026-06-15T20:20:49.875587Z"
+     "end_time": "2026-07-08T19:18:08.876142Z",
+     "start_time": "2026-07-08T19:18:08.851524Z"
     }
    },
    "cell_type": "code",
@@ -3206,7 +3238,7 @@
      ]
     }
    ],
-   "execution_count": 55
+   "execution_count": 57
   },
   {
    "cell_type": "markdown",
@@ -3250,8 +3282,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.908116Z",
-     "start_time": "2026-06-15T20:20:49.895676Z"
+     "end_time": "2026-07-08T19:18:08.903633Z",
+     "start_time": "2026-07-08T19:18:08.878269Z"
     }
    },
    "cell_type": "code",
@@ -3284,26 +3316,26 @@
    ],
    "id": "7ca53a662f660901",
    "outputs": [],
-   "execution_count": 56
+   "execution_count": 58
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.938676Z",
-     "start_time": "2026-06-15T20:20:49.917880Z"
+     "end_time": "2026-07-08T19:18:08.928421Z",
+     "start_time": "2026-07-08T19:18:08.913668Z"
     }
    },
    "cell_type": "code",
    "source": "node_data = fr.tools.recipe2data(scaled_range.flowrep_recipe)",
    "id": "f044f5954e57507c",
    "outputs": [],
-   "execution_count": 57
+   "execution_count": 59
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.953938Z",
-     "start_time": "2026-06-15T20:20:49.940590Z"
+     "end_time": "2026-07-08T19:18:08.954693Z",
+     "start_time": "2026-07-08T19:18:08.930062Z"
     }
    },
    "cell_type": "code",
@@ -3316,12 +3348,12 @@
        "flowrep.prospective.workflow_recipe.WorkflowRecipe"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 58
+   "execution_count": 60
   },
   {
    "metadata": {},
@@ -3337,8 +3369,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:49.978245Z",
-     "start_time": "2026-06-15T20:20:49.963378Z"
+     "end_time": "2026-07-08T19:18:08.982109Z",
+     "start_time": "2026-07-08T19:18:08.956836Z"
     }
    },
    "cell_type": "code",
@@ -3365,7 +3397,7 @@
      ]
     }
    ],
-   "execution_count": 59
+   "execution_count": 61
   },
   {
    "metadata": {},
@@ -3385,8 +3417,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.013054Z",
-     "start_time": "2026-06-15T20:20:49.988270Z"
+     "end_time": "2026-07-08T19:18:09.007894Z",
+     "start_time": "2026-07-08T19:18:08.984483Z"
     }
    },
    "cell_type": "code",
@@ -3399,12 +3431,12 @@
        "NOT_DATA"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 60
+   "execution_count": 62
   },
   {
    "metadata": {},
@@ -3415,8 +3447,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.029465Z",
-     "start_time": "2026-06-15T20:20:50.014910Z"
+     "end_time": "2026-07-08T19:18:09.035506Z",
+     "start_time": "2026-07-08T19:18:09.011016Z"
     }
    },
    "cell_type": "code",
@@ -3429,12 +3461,12 @@
        "1.0"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 61
+   "execution_count": 63
   },
   {
    "metadata": {},
@@ -3445,8 +3477,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.053963Z",
-     "start_time": "2026-06-15T20:20:50.039390Z"
+     "end_time": "2026-07-08T19:18:09.063681Z",
+     "start_time": "2026-07-08T19:18:09.037690Z"
     }
    },
    "cell_type": "code",
@@ -3464,12 +3496,12 @@
        "(float, list[float])"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 62
+   "execution_count": 64
   },
   {
    "metadata": {},
@@ -3480,8 +3512,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.080783Z",
-     "start_time": "2026-06-15T20:20:50.066061Z"
+     "end_time": "2026-07-08T19:18:09.129593Z",
+     "start_time": "2026-07-08T19:18:09.067368Z"
     }
    },
    "cell_type": "code",
@@ -3502,12 +3534,12 @@
        "(NOT_DATA, NOT_DATA, int, NOT_DATA, list[int])"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 63
+   "execution_count": 65
   },
   {
    "metadata": {},
@@ -3523,8 +3555,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.112147Z",
-     "start_time": "2026-06-15T20:20:50.093356Z"
+     "end_time": "2026-07-08T19:18:09.188804Z",
+     "start_time": "2026-07-08T19:18:09.131690Z"
     }
    },
    "cell_type": "code",
@@ -3543,13 +3575,13 @@
      ]
     }
    ],
-   "execution_count": 64
+   "execution_count": 66
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.188571Z",
-     "start_time": "2026-06-15T20:20:50.112852Z"
+     "end_time": "2026-07-08T19:18:09.215578Z",
+     "start_time": "2026-07-08T19:18:09.191182Z"
     }
    },
    "cell_type": "code",
@@ -3567,13 +3599,13 @@
      ]
     }
    ],
-   "execution_count": 65
+   "execution_count": 67
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.206549Z",
-     "start_time": "2026-06-15T20:20:50.190916Z"
+     "end_time": "2026-07-08T19:18:09.243104Z",
+     "start_time": "2026-07-08T19:18:09.218133Z"
     }
    },
    "cell_type": "code",
@@ -3591,7 +3623,7 @@
      ]
     }
    ],
-   "execution_count": 66
+   "execution_count": 68
   },
   {
    "metadata": {},
@@ -3611,8 +3643,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.232137Z",
-     "start_time": "2026-06-15T20:20:50.217169Z"
+     "end_time": "2026-07-08T19:18:09.279014Z",
+     "start_time": "2026-07-08T19:18:09.254695Z"
     }
    },
    "cell_type": "code",
@@ -3635,12 +3667,12 @@
        "(<RecipeElementType.FOR_EACH: 'for_each'>, {}, {}, {}, {})"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 67
+   "execution_count": 69
   },
   {
    "metadata": {},
@@ -3657,8 +3689,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.258258Z",
-     "start_time": "2026-06-15T20:20:50.243150Z"
+     "end_time": "2026-07-08T19:18:09.303156Z",
+     "start_time": "2026-07-08T19:18:09.281255Z"
     }
    },
    "cell_type": "code",
@@ -3676,7 +3708,7 @@
    ],
    "id": "ca0292eb59cf963a",
    "outputs": [],
-   "execution_count": 68
+   "execution_count": 70
   },
   {
    "metadata": {},
@@ -3687,8 +3719,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.289860Z",
-     "start_time": "2026-06-15T20:20:50.259837Z"
+     "end_time": "2026-07-08T19:18:09.325746Z",
+     "start_time": "2026-07-08T19:18:09.317583Z"
     }
    },
    "cell_type": "code",
@@ -3708,7 +3740,7 @@
      ]
     }
    ],
-   "execution_count": 69
+   "execution_count": 71
   },
   {
    "metadata": {},
@@ -3719,8 +3751,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.333353Z",
-     "start_time": "2026-06-15T20:20:50.292002Z"
+     "end_time": "2026-07-08T19:18:09.360299Z",
+     "start_time": "2026-07-08T19:18:09.336093Z"
     }
    },
    "cell_type": "code",
@@ -3739,12 +3771,12 @@
        "pyiron_snippets.colors.SeabornColors"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 70
+   "execution_count": 72
   },
   {
    "metadata": {},
@@ -3763,15 +3795,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.350392Z",
-     "start_time": "2026-06-15T20:20:50.334412Z"
+     "end_time": "2026-07-08T19:18:09.376084Z",
+     "start_time": "2026-07-08T19:18:09.362358Z"
     }
    },
    "cell_type": "code",
    "source": "ran_node = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=3)",
    "id": "54c1c113638190b8",
    "outputs": [],
-   "execution_count": 71
+   "execution_count": 73
   },
   {
    "metadata": {},
@@ -3785,8 +3817,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.374833Z",
-     "start_time": "2026-06-15T20:20:50.352141Z"
+     "end_time": "2026-07-08T19:18:09.407676Z",
+     "start_time": "2026-07-08T19:18:09.387947Z"
     }
    },
    "cell_type": "code",
@@ -3799,12 +3831,12 @@
        "[0.0, 1.0, 2.0]"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 72
+   "execution_count": 74
   },
   {
    "metadata": {},
@@ -3815,8 +3847,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.398129Z",
-     "start_time": "2026-06-15T20:20:50.376817Z"
+     "end_time": "2026-07-08T19:18:09.437317Z",
+     "start_time": "2026-07-08T19:18:09.410949Z"
     }
    },
    "cell_type": "code",
@@ -3842,7 +3874,7 @@
      ]
     }
    ],
-   "execution_count": 73
+   "execution_count": 75
   },
   {
    "metadata": {},
@@ -3860,8 +3892,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.424487Z",
-     "start_time": "2026-06-15T20:20:50.400958Z"
+     "end_time": "2026-07-08T19:18:09.468815Z",
+     "start_time": "2026-07-08T19:18:09.439496Z"
     }
    },
    "cell_type": "code",
@@ -3903,12 +3935,12 @@
        "{'scaled': OutputDataPort(value=[0.0, 1.0, 2.0, 3.0, 4.0], annotation=list[float])}"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 74
+   "execution_count": 76
   },
   {
    "metadata": {},
@@ -3919,8 +3951,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.790383Z",
-     "start_time": "2026-06-15T20:20:50.426647Z"
+     "end_time": "2026-07-08T19:18:09.845802Z",
+     "start_time": "2026-07-08T19:18:09.471023Z"
     }
    },
    "cell_type": "code",
@@ -3931,7 +3963,7 @@
    ],
    "id": "c4fe9644c6e43a16",
    "outputs": [],
-   "execution_count": 75
+   "execution_count": 77
   },
   {
    "metadata": {},
@@ -3949,8 +3981,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:50.826Z",
-     "start_time": "2026-06-15T20:20:50.794245Z"
+     "end_time": "2026-07-08T19:18:09.886298Z",
+     "start_time": "2026-07-08T19:18:09.849512Z"
     }
    },
    "cell_type": "code",
@@ -4019,12 +4051,12 @@
        " 'rescale_all_0.for_each_0.body_4.rescale_0.outputs.result']"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 76
+   "execution_count": 78
   },
   {
    "metadata": {},
@@ -4035,8 +4067,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:51.167127Z",
-     "start_time": "2026-06-15T20:20:50.828109Z"
+     "end_time": "2026-07-08T19:18:10.250531Z",
+     "start_time": "2026-07-08T19:18:09.888429Z"
     }
    },
    "cell_type": "code",
@@ -4052,12 +4084,12 @@
        "(True, dict_keys(['for_each_0']))"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 77
+   "execution_count": 79
   },
   {
    "metadata": {},
@@ -4068,8 +4100,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:51.210041Z",
-     "start_time": "2026-06-15T20:20:51.182670Z"
+     "end_time": "2026-07-08T19:18:10.289820Z",
+     "start_time": "2026-07-08T19:18:10.255221Z"
     }
    },
    "cell_type": "code",
@@ -4085,12 +4117,12 @@
        "(True, 1)"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 78
+   "execution_count": 80
   },
   {
    "metadata": {},
@@ -4104,8 +4136,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:51.243942Z",
-     "start_time": "2026-06-15T20:20:51.212076Z"
+     "end_time": "2026-07-08T19:18:10.317527Z",
+     "start_time": "2026-07-08T19:18:10.292603Z"
     }
    },
    "cell_type": "code",
@@ -4125,7 +4157,7 @@
      ]
     }
    ],
-   "execution_count": 79
+   "execution_count": 81
   },
   {
    "metadata": {},
@@ -4136,8 +4168,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:51.278858Z",
-     "start_time": "2026-06-15T20:20:51.246052Z"
+     "end_time": "2026-07-08T19:18:10.373247Z",
+     "start_time": "2026-07-08T19:18:10.329201Z"
     }
    },
    "cell_type": "code",
@@ -4155,15 +4187,15 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "d5f4fedb7719457abd1df2956b963a26"
+       "model_id": "598c220874fb4603801b86957bb81977"
       }
      },
-     "execution_count": 80,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 80
+   "execution_count": 82
   },
   {
    "metadata": {},
@@ -4210,15 +4242,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-15T20:20:51.291333Z",
-     "start_time": "2026-06-15T20:20:51.287330Z"
+     "end_time": "2026-07-08T19:18:10.393416Z",
+     "start_time": "2026-07-08T19:18:10.378336Z"
     }
    },
    "cell_type": "code",
    "source": "",
    "id": "f9bf1a0cd6d6913c",
    "outputs": [],
-   "execution_count": 80
+   "execution_count": 82
   }
  ],
  "metadata": {

--- a/src/flowrep/prospective/atomic_recipe.py
+++ b/src/flowrep/prospective/atomic_recipe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from enum import StrEnum
 from typing import Literal
 
@@ -76,4 +77,8 @@ class AtomicRecipe(base_models.NodeRecipe):
 
     def __call__(self, *args, **kwargs):
         func = retrieve.import_from_string(self.reference.info.fully_qualified_name)
-        return func(*args, **kwargs)
+        if self.unpack_mode == UnpackMode.DATACLASS:
+            dc = func(*args, **kwargs)
+            return tuple(getattr(dc, f.name) for f in dataclasses.fields(dc))
+        else:
+            return func(*args, **kwargs)

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -24,6 +24,11 @@ class _TypingProblem:
     x: YouCantFindThis  # noqa: F821
 
 
+@atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.DATACLASS)
+def my_result(result: _Result) -> _Result:
+    return result
+
+
 def _make_func_in_module(module: str, qualname: str) -> FunctionType:
     """Create a trivial function with controlled __module__ and __qualname__."""
 
@@ -691,6 +696,28 @@ class TestParseDataclassReturnLabels(unittest.TestCase):
             NameError, "requires the return annotation to be importable"
         ):
             atomic_parser._parse_dataclass_return_labels(func)
+
+
+class TestParseDataclassCallDifferences(unittest.TestCase):
+    def test_call_differences(self):
+        input = _Result(1, 2)
+        with self.subTest("Direct call"):
+            self.assertIs(
+                input,
+                my_result(input),
+                msg="Unpacking mode should not impack the decorated function -- the "
+                "function should just do what it looks like it does",
+            )
+
+        with self.subTest("Recipe call"):
+            x, y = my_result.flowrep_recipe(input)
+            self.assertEqual(
+                input.x,
+                x,
+                msg="The recipe claims it unpacks things, and it should when used as a "
+                "callable",
+            )
+            self.assertEqual(input.y, y)
 
 
 class TestParseTupleReturnLabelsWithAnnotations(unittest.TestCase):


### PR DESCRIPTION
Modifies the atomic recipe `__call__` method to unpack dataclass returns before returning results when `unpack_mode="dataclass"`.

Closes #264 