### PR TITLE
Parsing constants

### DIFF
--- a/src/flowrep/api/schemas.py
+++ b/src/flowrep/api/schemas.py
@@ -23,6 +23,8 @@ from flowrep.edge_models import SourceHandle as SourceHandle
 from flowrep.edge_models import TargetHandle as TargetHandle
 from flowrep.prospective.atomic_recipe import AtomicRecipe as AtomicRecipe
 from flowrep.prospective.atomic_recipe import UnpackMode as UnpackMode
+from flowrep.prospective.constant_recipe import JSON as JSON
+from flowrep.prospective.constant_recipe import ConstantRecipe as ConstantRecipe
 from flowrep.prospective.for_recipe import ForEachRecipe as ForEachRecipe
 from flowrep.prospective.helper_models import ConditionalCase as ConditionalCase
 from flowrep.prospective.helper_models import ExceptionCase as ExceptionCase

--- a/src/flowrep/api/schemas.py
+++ b/src/flowrep/api/schemas.py
@@ -38,6 +38,7 @@ from flowrep.prospective.workflow_recipe import WorkflowRecipe as WorkflowRecipe
 from flowrep.retrospective.datastructures import NOT_DATA as NOT_DATA
 from flowrep.retrospective.datastructures import AtomicData as AtomicData
 from flowrep.retrospective.datastructures import CompositeData as CompositeData
+from flowrep.retrospective.datastructures import ConstantData as ConstantData
 from flowrep.retrospective.datastructures import DagData as DagData
 from flowrep.retrospective.datastructures import FlowControlData as FlowControlData
 from flowrep.retrospective.datastructures import ForEachData as ForEachData

--- a/src/flowrep/base_models.py
+++ b/src/flowrep/base_models.py
@@ -18,6 +18,7 @@ class RecipeElementType(StrEnum):
     WHILE = "while"
     IF = "if"
     TRY = "try"
+    CONSTANT = "constant"
 
 
 class IOTypes(StrEnum):

--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -232,7 +232,7 @@ def emit_workflow_body(
     # Flow-control nodes derive their input port names from the enclosing symbols
     # feeding them, so each such source must be named after the port for the port
     # names (and while-loop reassignments) to round-trip. A constant peer feeding a
-    # flow-control input is normal now (Part 2: a literal condition argument injects
+    # flow-control input is normal now (a literal condition argument injects
     # a constant peer routed through a synthetic flow-control input port). Such a
     # peer is never also a workflow-output source, so its required_by_handle entry
     # stays inert and it is inlined in the topo loop below -- which is why the

--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -10,6 +10,7 @@ from flowrep import base_models, edge_models, subgraph_validation
 from flowrep.compiler import flow_control, function
 from flowrep.prospective import (
     atomic_recipe,
+    constant_recipe,
     union_types,
     workflow_recipe,
 )
@@ -195,6 +196,9 @@ def emit_workflow_body(
     def resolve(source) -> str:
         if isinstance(source, edge_models.InputSource):
             return in_syms[source.port]
+        source_node = recipe.nodes[source.node]
+        if isinstance(source_node, constant_recipe.ConstantRecipe):
+            return repr(source_node.constant)
         return produced[(source.node, source.port)]
 
     # Map (node, port) -> required symbol name for outputs the parent pins.
@@ -231,6 +235,8 @@ def emit_workflow_body(
 
     for label in _topological_nodes(recipe):
         node = recipe.nodes[label]
+        if isinstance(node, constant_recipe.ConstantRecipe):
+            continue  # constants are inlined at the consumer call site by `resolve`
 
         call_path = node_call_path(node, label, emitter, alloc)
         if call_path is not None:

--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -218,7 +218,11 @@ def emit_workflow_body(
 
     # Flow-control nodes derive their input port names from the enclosing symbols
     # feeding them, so each such source must be named after the port for the port
-    # names (and while-loop reassignments) to round-trip.
+    # names (and while-loop reassignments) to round-trip. A constant node's handle
+    # never reaches this dict in practice (constants never feed flow-control inputs,
+    # and even a hand-built recipe violating that would have its handle skipped
+    # below, since constants are never emitted -- see the `continue` in the emit
+    # loop), so any such entry here would be inert.
     for handle, name in _flow_control_input_requirements(recipe).items():
         if (  # pragma: no cover - twin of the output-edge guard above; only a
             # hand-built recipe (one a parser never emits) can name a source for

--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -231,12 +231,13 @@ def emit_workflow_body(
 
     # Flow-control nodes derive their input port names from the enclosing symbols
     # feeding them, so each such source must be named after the port for the port
-    # names (and while-loop reassignments) to round-trip. A constant node's handle
-    # never reaches this dict in practice (a parser never wires a constant directly
-    # into a flow-control input); a hand-built recipe violating that would only see
-    # the requirement honoured if the same constant also happens to be materialized
-    # (i.e. it also feeds a workflow output) -- otherwise it stays inlined and the
-    # entry here is inert.
+    # names (and while-loop reassignments) to round-trip. A constant peer feeding a
+    # flow-control input is normal now (Part 2: a literal condition argument injects
+    # a constant peer routed through a synthetic flow-control input port). Such a
+    # peer is never also a workflow-output source, so its required_by_handle entry
+    # stays inert and it is inlined in the topo loop below -- which is why the
+    # conflict branch immediately below remains unreachable in parser-produced
+    # recipes.
     for handle, name in _flow_control_input_requirements(recipe).items():
         if (  # pragma: no cover - twin of the output-edge guard above; only a
             # hand-built recipe (one a parser never emits) can name a source for

--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -193,11 +193,24 @@ def emit_workflow_body(
     produced: dict[tuple[str, str], str] = {}
     lines: list[str] = []
 
+    # Constants feeding a workflow output cannot be inlined (a bare `return <literal>`
+    # is not re-parseable), so they are materialized as `sym = repr(value)` below and
+    # resolved to that symbol everywhere.
+    materialized_constants = {
+        src.node
+        for src in recipe.output_edges.values()
+        if isinstance(src, edge_models.SourceHandle)
+        and isinstance(recipe.nodes.get(src.node), constant_recipe.ConstantRecipe)
+    }
+
     def resolve(source) -> str:
         if isinstance(source, edge_models.InputSource):
             return in_syms[source.port]
         source_node = recipe.nodes[source.node]
-        if isinstance(source_node, constant_recipe.ConstantRecipe):
+        if (
+            isinstance(source_node, constant_recipe.ConstantRecipe)
+            and source.node not in materialized_constants
+        ):
             return repr(source_node.constant)
         return produced[(source.node, source.port)]
 
@@ -219,10 +232,11 @@ def emit_workflow_body(
     # Flow-control nodes derive their input port names from the enclosing symbols
     # feeding them, so each such source must be named after the port for the port
     # names (and while-loop reassignments) to round-trip. A constant node's handle
-    # never reaches this dict in practice (constants never feed flow-control inputs,
-    # and even a hand-built recipe violating that would have its handle skipped
-    # below, since constants are never emitted -- see the `continue` in the emit
-    # loop), so any such entry here would be inert.
+    # never reaches this dict in practice (a parser never wires a constant directly
+    # into a flow-control input); a hand-built recipe violating that would only see
+    # the requirement honoured if the same constant also happens to be materialized
+    # (i.e. it also feeds a workflow output) -- otherwise it stays inlined and the
+    # entry here is inert.
     for handle, name in _flow_control_input_requirements(recipe).items():
         if (  # pragma: no cover - twin of the output-edge guard above; only a
             # hand-built recipe (one a parser never emits) can name a source for
@@ -240,7 +254,14 @@ def emit_workflow_body(
     for label in _topological_nodes(recipe):
         node = recipe.nodes[label]
         if isinstance(node, constant_recipe.ConstantRecipe):
-            continue  # constants are inlined at the consumer call site by `resolve`
+            if label not in materialized_constants:
+                continue  # inline at the consumer call site via `resolve`
+            name = required_by_handle.get((label, "constant")) or alloc.fresh(
+                _output_name_suggestion(label, "constant", 1)
+            )
+            produced[(label, "constant")] = name
+            lines.append(f"{name} = {repr(node.constant)}")
+            continue
 
         call_path = node_call_path(node, label, emitter, alloc)
         if call_path is not None:
@@ -292,6 +313,11 @@ def emit_body(
         return flow_control.emit_flow_control_body(
             recipe, label, in_syms, required, emitter, alloc
         )
+    if isinstance(recipe, constant_recipe.ConstantRecipe):
+        name = required.get("constant") or alloc.fresh(
+            _output_name_suggestion(label, "constant", 1)
+        )
+        return [f"{name} = {repr(recipe.constant)}"], {"constant": name}
     return _emit_single_node_body(recipe, label, in_syms, required, alloc, emitter)
 
 

--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -257,10 +257,11 @@ def emit_workflow_body(
         if isinstance(node, constant_recipe.ConstantRecipe):
             if label not in materialized_constants:
                 continue  # inline at the consumer call site via `resolve`
-            name = required_by_handle.get((label, "constant")) or alloc.fresh(
-                _output_name_suggestion(label, "constant", 1)
+            constant_label = constant_recipe.ConstantRecipe.std_label
+            name = required_by_handle.get((label, constant_label)) or alloc.fresh(
+                _output_name_suggestion(label, constant_label, 1)
             )
-            produced[(label, "constant")] = name
+            produced[(label, constant_label)] = name
             lines.append(f"{name} = {repr(node.constant)}")
             continue
 
@@ -315,10 +316,11 @@ def emit_body(
             recipe, label, in_syms, required, emitter, alloc
         )
     if isinstance(recipe, constant_recipe.ConstantRecipe):
-        name = required.get("constant") or alloc.fresh(
-            _output_name_suggestion(label, "constant", 1)
+        constant_label = constant_recipe.ConstantRecipe.std_label
+        name = required.get(constant_label) or alloc.fresh(
+            _output_name_suggestion(label, constant_label, 1)
         )
-        return [f"{name} = {repr(recipe.constant)}"], {"constant": name}
+        return [f"{name} = {repr(recipe.constant)}"], {constant_label: name}
     return _emit_single_node_body(recipe, label, in_syms, required, alloc, emitter)
 
 

--- a/src/flowrep/parsers/case_helpers.py
+++ b/src/flowrep/parsers/case_helpers.py
@@ -13,7 +13,7 @@ from flowrep.parsers import (
     parser_protocol,
     symbol_scope,
 )
-from flowrep.prospective import helper_models
+from flowrep.prospective import helper_models, union_types
 
 
 def parse_case(
@@ -22,6 +22,7 @@ def parse_case(
     symbol_map: symbol_scope.SymbolScope,
     info_factory: versions.VersionInfoFactory,
     label: str,
+    nodes: union_types.Recipes,
 ) -> tuple[helper_models.LabeledRecipe, edge_models.InputEdges]:
     """
     Parse a conditional expression.
@@ -42,7 +43,7 @@ def parse_case(
         )
 
     scope_copy = symbol_map.fork()
-    parser_helpers.consume_call_arguments(scope_copy, test, condition)
+    parser_helpers.consume_call_arguments(scope_copy, test, condition, nodes)
     return _relabel_node_data(condition, scope_copy.input_edges, label)
 
 

--- a/src/flowrep/parsers/case_helpers.py
+++ b/src/flowrep/parsers/case_helpers.py
@@ -43,7 +43,9 @@ def parse_case(
         )
 
     scope_copy = symbol_map.fork()
-    parser_helpers.consume_call_arguments(scope_copy, test, condition, nodes)
+    parser_helpers.consume_call_arguments(
+        scope_copy, test, condition, nodes, allow_constants=False
+    )
     return _relabel_node_data(condition, scope_copy.input_edges, label)
 
 

--- a/src/flowrep/parsers/case_helpers.py
+++ b/src/flowrep/parsers/case_helpers.py
@@ -13,7 +13,7 @@ from flowrep.parsers import (
     parser_protocol,
     symbol_scope,
 )
-from flowrep.prospective import helper_models, union_types
+from flowrep.prospective import constant_recipe, helper_models, union_types
 
 
 def parse_case(
@@ -23,7 +23,12 @@ def parse_case(
     info_factory: versions.VersionInfoFactory,
     label: str,
     nodes: union_types.Recipes,
-) -> tuple[helper_models.LabeledRecipe, edge_models.InputEdges]:
+    reserved_ports: set[str] | None = None,
+) -> tuple[
+    helper_models.LabeledRecipe,
+    edge_models.InputEdges,
+    dict[str, constant_recipe.ConstantRecipe],
+]:
     """
     Parse a conditional expression.
 
@@ -43,10 +48,19 @@ def parse_case(
         )
 
     scope_copy = symbol_map.fork()
+    condition_bindings: dict[str, constant_recipe.ConstantRecipe] = {}
     parser_helpers.consume_call_arguments(
-        scope_copy, test, condition, nodes, allow_constants=False
+        scope_copy,
+        test,
+        condition,
+        nodes,
+        condition_bindings=condition_bindings,
+        reserved_ports=reserved_ports,
     )
-    return _relabel_node_data(condition, scope_copy.input_edges, label)
+    relabeled_node, relabeled_inputs = _relabel_node_data(
+        condition, scope_copy.input_edges, label
+    )
+    return relabeled_node, relabeled_inputs, condition_bindings
 
 
 def _relabel_node_data(

--- a/src/flowrep/parsers/constant_parser.py
+++ b/src/flowrep/parsers/constant_parser.py
@@ -53,14 +53,15 @@ def inject_constant(
     (e.g. a tuple) surfaces here as a ``ValidationError`` and is re-raised with the
     consuming node/port for context.
     """
-    label = label_helpers.unique_suffix("constant", nodes)
+    constant_label = constant_recipe.ConstantRecipe.std_label
+    label = label_helpers.unique_suffix(constant_label, nodes)
     recipe = make_constant(
         value,
         f"Argument for input '{consumer_port}' of node '{consumer_label}'",
     )
     nodes[label] = recipe
     scope.consume_source(
-        edge_models.SourceHandle(node=label, port="constant"),
+        edge_models.SourceHandle(node=label, port=constant_label),
         consumer_label,
         consumer_port,
     )

--- a/src/flowrep/parsers/constant_parser.py
+++ b/src/flowrep/parsers/constant_parser.py
@@ -24,6 +24,21 @@ def try_parse_constant(arg: ast.expr) -> tuple[bool, Any]:
         return False, None
 
 
+def make_constant(value: Any, context: str) -> constant_recipe.ConstantRecipe:
+    """Build a ``ConstantRecipe`` for *value*, re-raising the model's
+    ``ValidationError`` as a ``ConstantParseError`` prefixed with *context*.
+
+    The ``ConstantRecipe`` model is the single source of truth for the JSON/finite
+    invariant; this only adds call-site context to the error.
+    """
+    try:
+        return constant_recipe.ConstantRecipe(constant=value)
+    except pydantic.ValidationError as error:
+        raise ConstantParseError(
+            f"{context} is not a JSON-serializable constant: {value!r}"
+        ) from error
+
+
 def inject_constant(
     nodes: union_types.Recipes,
     scope: symbol_scope.SymbolScope,
@@ -39,13 +54,10 @@ def inject_constant(
     consuming node/port for context.
     """
     label = label_helpers.unique_suffix("constant", nodes)
-    try:
-        recipe = constant_recipe.ConstantRecipe(constant=value)
-    except pydantic.ValidationError as error:
-        raise ConstantParseError(
-            f"Argument for input '{consumer_port}' of node '{consumer_label}' is not "
-            f"a JSON-serializable constant: {value!r}"
-        ) from error
+    recipe = make_constant(
+        value,
+        f"Argument for input '{consumer_port}' of node '{consumer_label}'",
+    )
     nodes[label] = recipe
     scope.consume_source(
         edge_models.SourceHandle(node=label, port="constant"),

--- a/src/flowrep/parsers/constant_parser.py
+++ b/src/flowrep/parsers/constant_parser.py
@@ -1,0 +1,54 @@
+import ast
+from typing import Any
+
+import pydantic
+
+from flowrep import edge_models
+from flowrep.parsers import label_helpers, symbol_scope
+from flowrep.prospective import constant_recipe, union_types
+
+
+class ConstantParseError(ValueError):
+    """Raised when a literal call argument cannot become a constant node."""
+
+
+def try_parse_constant(arg: ast.expr) -> tuple[bool, Any]:
+    """Return ``(True, value)`` if *arg* is a Python literal, else ``(False, None)``.
+
+    Uses ``ast.literal_eval``, so it accepts scalars, lists, dicts, and negatives,
+    and returns ``(False, None)`` for names, calls, lambdas, comprehensions, etc.
+    """
+    try:
+        return True, ast.literal_eval(arg)
+    except (ValueError, SyntaxError, TypeError):
+        return False, None
+
+
+def inject_constant(
+    nodes: union_types.Recipes,
+    scope: symbol_scope.SymbolScope,
+    value: Any,
+    consumer_label: str,
+    consumer_port: str,
+) -> None:
+    """Create a ``ConstantRecipe`` for *value*, register it in *nodes*, and wire its
+    output into ``(consumer_label, consumer_port)`` as a peer edge.
+
+    The ``ConstantRecipe`` model enforces the JSON invariant; a non-JSON literal
+    (e.g. a tuple) surfaces here as a ``ValidationError`` and is re-raised with the
+    consuming node/port for context.
+    """
+    label = label_helpers.unique_suffix("constant", nodes)
+    try:
+        recipe = constant_recipe.ConstantRecipe(constant=value)
+    except pydantic.ValidationError as error:
+        raise ConstantParseError(
+            f"Argument for input '{consumer_port}' of node '{consumer_label}' is not "
+            f"a JSON-serializable constant: {value!r}"
+        ) from error
+    nodes[label] = recipe
+    scope.consume_source(
+        edge_models.SourceHandle(node=label, port="constant"),
+        consumer_label,
+        consumer_port,
+    )

--- a/src/flowrep/parsers/if_parser.py
+++ b/src/flowrep/parsers/if_parser.py
@@ -5,7 +5,7 @@ import dataclasses
 
 from flowrep import edge_models
 from flowrep.parsers import case_helpers, parser_protocol
-from flowrep.prospective import helper_models, if_recipe
+from flowrep.prospective import constant_recipe, helper_models, if_recipe
 
 IF_CONDITION_LABEL_PREFIX: str = "condition"
 IF_BODY_LABEL_PREFIX: str = "body"
@@ -19,11 +19,12 @@ class _CaseComponents:
     condition: helper_models.LabeledRecipe
     condition_input_edges: edge_models.InputEdges
     body: case_helpers.WalkedBranch
+    condition_bindings: dict[str, constant_recipe.ConstantRecipe]
 
 
 def parse_if_node(
     walker: parser_protocol.BodyWalker, tree: ast.If
-) -> if_recipe.IfRecipe:
+) -> tuple[if_recipe.IfRecipe, dict[str, constant_recipe.ConstantRecipe]]:
     """
     Walk an if/elif/else chain.
 
@@ -36,19 +37,21 @@ def parse_if_node(
     else_branch: case_helpers.WalkedBranch | None = None
 
     ast_cases, else_stmts = _parse_if_elif_chain(tree)
+    reserved_ports: set[str] = set()
 
     # --- process each if / elif case ---
     for idx, (test_expr, body_stmts) in enumerate(ast_cases):
         cond_label = f"{IF_CONDITION_LABEL_PREFIX}_{idx}"
         body_label = f"{IF_BODY_LABEL_PREFIX}_{idx}"
 
-        labeled_cond, cond_inputs = case_helpers.parse_case(
+        labeled_cond, cond_inputs, cond_bindings = case_helpers.parse_case(
             test_expr,
             walker.scope,
             walker.symbol_map,
             walker.info_factory,
             cond_label,
             walker.nodes,
+            reserved_ports=reserved_ports,
         )
         body = case_helpers.walk_branch(walker, body_label, body_stmts)
         cases.append(
@@ -56,6 +59,7 @@ def parse_if_node(
                 condition=labeled_cond,
                 condition_input_edges=cond_inputs,
                 body=body,
+                condition_bindings=cond_bindings,
             )
         )
 
@@ -79,13 +83,20 @@ def parse_if_node(
         for cc in cases
     ]
 
-    return if_recipe.IfRecipe(
-        inputs=inputs,
-        outputs=outputs,
-        cases=model_cases,
-        input_edges=input_edges,
-        prospective_output_edges=prospective_output_edges,
-        else_case=else_branch.to_labeled_node() if else_branch else None,
+    condition_bindings: dict[str, constant_recipe.ConstantRecipe] = {}
+    for cc in cases:
+        condition_bindings.update(cc.condition_bindings)
+
+    return (
+        if_recipe.IfRecipe(
+            inputs=inputs,
+            outputs=outputs,
+            cases=model_cases,
+            input_edges=input_edges,
+            prospective_output_edges=prospective_output_edges,
+            else_case=else_branch.to_labeled_node() if else_branch else None,
+        ),
+        condition_bindings,
     )
 
 

--- a/src/flowrep/parsers/if_parser.py
+++ b/src/flowrep/parsers/if_parser.py
@@ -48,6 +48,7 @@ def parse_if_node(
             walker.symbol_map,
             walker.info_factory,
             cond_label,
+            walker.nodes,
         )
         body = case_helpers.walk_branch(walker, body_label, body_stmts)
         cases.append(

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -8,9 +8,9 @@ from collections.abc import Callable
 from types import FunctionType
 from typing import Any, cast
 
-from flowrep import base_models
-from flowrep.parsers import constant_parser, symbol_scope
-from flowrep.prospective import helper_models, union_types
+from flowrep import base_models, edge_models
+from flowrep.parsers import constant_parser, label_helpers, symbol_scope
+from flowrep.prospective import constant_recipe, helper_models, union_types
 
 
 class SourceCodeUnavailableError(ValueError): ...
@@ -141,19 +141,23 @@ def consume_call_arguments(
     child: helper_models.LabeledRecipe,
     nodes: union_types.Recipes,
     *,
-    allow_constants: bool = True,
+    condition_bindings: dict[str, constant_recipe.ConstantRecipe] | None = None,
+    reserved_ports: set[str] | None = None,
 ) -> None:
     """Record all argument->port consumptions for a node-creating call.
 
     ``ast.Name`` arguments consume an existing symbol; any other argument must be a
-    Python literal, which is injected as a ``ConstantRecipe`` source node into
-    *nodes* and wired to the consuming port -- unless *allow_constants* is
-    ``False``, in which case a literal argument raises ``TypeError`` instead of
-    being injected. Flow-control conditions pass ``allow_constants=False``: a
-    constant node is only ever safe as a consumer node's input, never as a
-    flow-control condition's input, so this keeps that invariant true by
-    construction rather than relying on downstream validation to catch it.
+    Python literal. In the default (non-condition) mode a literal is injected as a
+    ``ConstantRecipe`` source node into *nodes* and wired to the consuming port. In
+    condition mode -- selected by passing a *condition_bindings* dict -- a literal is
+    instead routed to a synthetic flow-control input port and recorded in
+    *condition_bindings* (``{synthetic_port: ConstantRecipe}``) for the enclosing
+    walker to satisfy with a constant peer. A flow-control node has no room to host a
+    constant peer inside it, so the peer lives one level up. *reserved_ports* carries
+    synthetic port names already allocated for this flow-control chain so that
+    multiple literals -- across an if/elif chain -- get distinct, deterministic ports.
     """
+    reserved = set() if reserved_ports is None else reserved_ports
 
     def _consume(arg_node: ast.expr, consumer_port: str) -> None:
         if isinstance(arg_node, ast.Name):
@@ -167,13 +171,11 @@ def consume_call_arguments(
                 f"node '{child.label}' found un-parseable "
                 f"{type(arg_node).__name__}."
             )
-        if not allow_constants:
-            raise TypeError(
-                f"Literal constants are not supported in flow-control conditions; "
-                f"for input '{consumer_port}' of condition node '{child.label}' "
-                f"found a literal {value!r}. Bind the value to a symbol first, e.g. "
-                f"assign it to a variable before using it in the condition."
+        if condition_bindings is not None:
+            _bind_condition_constant(
+                scope, child, consumer_port, value, condition_bindings, reserved
             )
+            return
         constant_parser.inject_constant(nodes, scope, value, child.label, consumer_port)
 
     for i, arg in enumerate(ast_call.args):
@@ -186,3 +188,34 @@ def consume_call_arguments(
                 "this. Please raise a GitHub issue."
             )
         _consume(kw.value, kw.arg)
+
+
+def _bind_condition_constant(
+    scope: symbol_scope.SymbolScope,
+    child: helper_models.LabeledRecipe,
+    consumer_port: str,
+    value: Any,
+    condition_bindings: dict[str, constant_recipe.ConstantRecipe],
+    reserved_ports: set[str],
+) -> None:
+    """Expose a literal condition argument as a synthetic flow-input port.
+
+    The synthetic port name is unique across the condition's real argument symbols
+    (``scope.inputs``) and every synthetic port already allocated for this
+    flow-control chain (*reserved_ports*), so it is a deterministic function of the
+    source and round-trips exactly. The ``ConstantRecipe`` is built eagerly (so a
+    non-JSON literal such as a tuple raises ``ConstantParseError`` with call-site
+    context here, matching non-condition timing) and handed up for the enclosing
+    walker to attach as a peer.
+    """
+    synthetic_port = label_helpers.unique_suffix(
+        "constant", set(scope.inputs) | reserved_ports
+    )
+    reserved_ports.add(synthetic_port)
+    condition_bindings[synthetic_port] = constant_parser.make_constant(
+        value,
+        f"Condition argument for input '{consumer_port}' of node '{child.label}'",
+    )
+    scope.consume_input_source(
+        edge_models.InputSource(port=synthetic_port), child.label, consumer_port
+    )

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -9,8 +9,8 @@ from types import FunctionType
 from typing import Any, cast
 
 from flowrep import base_models
-from flowrep.parsers import symbol_scope
-from flowrep.prospective import helper_models
+from flowrep.parsers import constant_parser, symbol_scope
+from flowrep.prospective import helper_models, union_types
 
 
 class SourceCodeUnavailableError(ValueError): ...
@@ -139,28 +139,36 @@ def consume_call_arguments(
     scope: symbol_scope.SymbolScope,
     ast_call: ast.Call,
     child: helper_models.LabeledRecipe,
+    nodes: union_types.Recipes,
 ) -> None:
-    """Record all argument->port consumptions for a node-creating call."""
+    """Record all argument->port consumptions for a node-creating call.
 
-    def _validate_is_ast_name(node: ast.expr) -> ast.Name:
-        if not isinstance(node, ast.Name):
+    ``ast.Name`` arguments consume an existing symbol; any other argument must be a
+    Python literal, which is injected as a ``ConstantRecipe`` source node into
+    *nodes* and wired to the consuming port.
+    """
+
+    def _consume(arg_node: ast.expr, consumer_port: str) -> None:
+        if isinstance(arg_node, ast.Name):
+            scope.consume(arg_node.id, child.label, consumer_port)
+            return
+        is_literal, value = constant_parser.try_parse_constant(arg_node)
+        if not is_literal:
             raise TypeError(
-                f"Workflow python definitions can only interpret function "
-                f"calls with symbolic input, and thus expected to find an "
-                f"ast.Name, but when parsing input for {child.label}, found a "
-                f"type {type(node)}"
+                f"Workflow python definitions can only interpret function calls with "
+                f"symbolic input or literal constants; for input '{consumer_port}' of "
+                f"node '{child.label}' found un-parseable "
+                f"{type(arg_node).__name__}."
             )
-        return node
+        constant_parser.inject_constant(nodes, scope, value, child.label, consumer_port)
 
     for i, arg in enumerate(ast_call.args):
-        name_arg = _validate_is_ast_name(arg)
-        scope.consume(name_arg.id, child.label, child.node.inputs[i])
+        _consume(arg, child.node.inputs[i])
     for kw in ast_call.keywords:
-        name_arg = _validate_is_ast_name(kw.value)
         if not isinstance(kw.arg, str):  # pragma: no cover
             raise TypeError(
                 "How did you get here? A `None` value should be possible for "
                 "**kwargs, but variadics should have been excluded before "
                 "this. Please raise a GitHub issue."
             )
-        scope.consume(name_arg.id, child.label, kw.arg)
+        _consume(kw.value, kw.arg)

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -140,12 +140,19 @@ def consume_call_arguments(
     ast_call: ast.Call,
     child: helper_models.LabeledRecipe,
     nodes: union_types.Recipes,
+    *,
+    allow_constants: bool = True,
 ) -> None:
     """Record all argument->port consumptions for a node-creating call.
 
     ``ast.Name`` arguments consume an existing symbol; any other argument must be a
     Python literal, which is injected as a ``ConstantRecipe`` source node into
-    *nodes* and wired to the consuming port.
+    *nodes* and wired to the consuming port -- unless *allow_constants* is
+    ``False``, in which case a literal argument raises ``TypeError`` instead of
+    being injected. Flow-control conditions pass ``allow_constants=False``: a
+    constant node is only ever safe as a consumer node's input, never as a
+    flow-control condition's input, so this keeps that invariant true by
+    construction rather than relying on downstream validation to catch it.
     """
 
     def _consume(arg_node: ast.expr, consumer_port: str) -> None:
@@ -159,6 +166,13 @@ def consume_call_arguments(
                 f"symbolic input or literal constants; for input '{consumer_port}' of "
                 f"node '{child.label}' found un-parseable "
                 f"{type(arg_node).__name__}."
+            )
+        if not allow_constants:
+            raise TypeError(
+                f"Literal constants are not supported in flow-control conditions; "
+                f"for input '{consumer_port}' of condition node '{child.label}' "
+                f"found a literal {value!r}. Bind the value to a symbol first, e.g. "
+                f"assign it to a variable before using it in the condition."
             )
         constant_parser.inject_constant(nodes, scope, value, child.label, consumer_port)
 

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -209,7 +209,7 @@ def _bind_condition_constant(
     walker to attach as a peer.
     """
     synthetic_port = label_helpers.unique_suffix(
-        "constant", set(scope.inputs) | reserved_ports
+        constant_recipe.ConstantRecipe.std_label, set(scope.inputs) | reserved_ports
     )
     reserved_ports.add(synthetic_port)
     condition_bindings[synthetic_port] = constant_parser.make_constant(

--- a/src/flowrep/parsers/symbol_scope.py
+++ b/src/flowrep/parsers/symbol_scope.py
@@ -192,6 +192,24 @@ class SymbolScope(Mapping[str, edge_models.InputSource | edge_models.SourceHandl
             )
         )
 
+    def consume_source(
+        self,
+        source: edge_models.SourceHandle,
+        consumer_node: str,
+        consumer_port: str,
+    ) -> None:
+        """Record a consumption whose source is a fixed ``SourceHandle`` (e.g. an
+        injected constant node), bypassing symbol lookup so no synthetic symbol
+        enters ``_sources`` and risks colliding with a user symbol."""
+        self._consumptions.append(
+            SymbolConsumption(
+                symbol=source.node,  # unused for SourceHandle sources; kept for debugging
+                consumer_node=consumer_node,
+                consumer_port=consumer_port,
+                source=source,
+            )
+        )
+
     def produce(self, output_port: str, symbol: str | None = None) -> None:
         """Record that `output_port` is sourced from `symbol`."""
         produced_symbol = output_port if symbol is None else symbol

--- a/src/flowrep/parsers/symbol_scope.py
+++ b/src/flowrep/parsers/symbol_scope.py
@@ -210,6 +210,26 @@ class SymbolScope(Mapping[str, edge_models.InputSource | edge_models.SourceHandl
             )
         )
 
+    def consume_input_source(
+        self,
+        source: edge_models.InputSource,
+        consumer_node: str,
+        consumer_port: str,
+    ) -> None:
+        """Record a consumption whose source is a fixed ``InputSource`` (e.g. a
+        synthetic flow-control input port fed by an injected constant peer),
+        bypassing symbol lookup so no synthetic symbol enters ``_sources`` and
+        risks colliding with a user symbol. The ``InputSource`` twin of
+        :meth:`consume_source`."""
+        self._consumptions.append(
+            SymbolConsumption(
+                symbol=source.port,
+                consumer_node=consumer_node,
+                consumer_port=consumer_port,
+                source=source,
+            )
+        )
+
     def produce(self, output_port: str, symbol: str | None = None) -> None:
         """Record that `output_port` is sourced from `symbol`."""
         produced_symbol = output_port if symbol is None else symbol

--- a/src/flowrep/parsers/while_parser.py
+++ b/src/flowrep/parsers/while_parser.py
@@ -30,6 +30,7 @@ def parse_while_node(
         walker.symbol_map,
         walker.info_factory,
         WHILE_CONDITION_LABEL,
+        walker.nodes,
     )
 
     body_walker = walker.fork(

--- a/src/flowrep/parsers/while_parser.py
+++ b/src/flowrep/parsers/while_parser.py
@@ -5,7 +5,7 @@ from ast import While
 
 from flowrep import edge_models
 from flowrep.parsers import case_helpers, parser_protocol
-from flowrep.prospective import helper_models, while_recipe
+from flowrep.prospective import constant_recipe, helper_models, while_recipe
 
 WHILE_CONDITION_LABEL: str = "condition"
 WHILE_BODY_LABEL: str = "body"
@@ -13,7 +13,7 @@ WHILE_BODY_LABEL: str = "body"
 
 def parse_while_node(
     walker: parser_protocol.BodyWalker, tree: ast.While
-) -> while_recipe.WhileRecipe:
+) -> tuple[while_recipe.WhileRecipe, dict[str, constant_recipe.ConstantRecipe]]:
     """
     Walk a while-loop.
 
@@ -24,7 +24,7 @@ def parse_while_node(
     _validate_syntax_is_supported(tree)
 
     # Parse the loop condition — pure AST, no parser state needed
-    labeled_condition, condition_inputs = case_helpers.parse_case(
+    labeled_condition, condition_inputs, condition_bindings = case_helpers.parse_case(
         tree.test,
         walker.scope,
         walker.symbol_map,
@@ -55,12 +55,15 @@ def parse_while_node(
         ),
     )
 
-    return while_recipe.WhileRecipe(
-        inputs=inputs,
-        outputs=outputs,
-        case=case,
-        input_edges=input_edges,
-        output_edges=output_edges,
+    return (
+        while_recipe.WhileRecipe(
+            inputs=inputs,
+            outputs=outputs,
+            case=case,
+            input_edges=input_edges,
+            output_edges=output_edges,
+        ),
+        condition_bindings,
     )
 
 

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -290,7 +290,9 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
                     f"got {new_symbols}"
                 )
             value = parsed[1]
-            label = label_helpers.unique_suffix("constant", self.nodes)
+            label = label_helpers.unique_suffix(
+                constant_recipe.ConstantRecipe.std_label, self.nodes
+            )
             node: constant_recipe.ConstantRecipe = constant_parser.make_constant(
                 value, f"Assignment to '{new_symbols[0]}'"
             )
@@ -324,10 +326,11 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         bindings = condition_bindings or {}
         for port in node.inputs:
             if port in bindings:
-                peer_label = label_helpers.unique_suffix("constant", self.nodes)
+                constant_label = constant_recipe.ConstantRecipe.std_label
+                peer_label = label_helpers.unique_suffix(constant_label, self.nodes)
                 self.nodes[peer_label] = bindings[port]
                 self.symbol_map.consume_source(
-                    edge_models.SourceHandle(node=peer_label, port="constant"),
+                    edge_models.SourceHandle(node=peer_label, port=constant_label),
                     label,
                     port,
                 )

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -12,6 +12,7 @@ from pyiron_snippets import versions
 from flowrep import base_models, edge_models
 from flowrep.parsers import (
     atomic_parser,
+    constant_parser,
     for_parser,
     if_parser,
     label_helpers,
@@ -22,7 +23,12 @@ from flowrep.parsers import (
     try_parser,
     while_parser,
 )
-from flowrep.prospective import helper_models, union_types, workflow_recipe
+from flowrep.prospective import (
+    constant_recipe,
+    helper_models,
+    union_types,
+    workflow_recipe,
+)
 
 
 def workflow(
@@ -277,6 +283,21 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
                     f"got {new_symbols}"
                 )
             self.symbol_map.register_accumulator(new_symbols[0])
+        elif (parsed := constant_parser.try_parse_constant(rhs))[0]:
+            if len(new_symbols) != 1:
+                raise ValueError(
+                    f"Literal constant assignment must target exactly one symbol, "
+                    f"got {new_symbols}"
+                )
+            value = parsed[1]
+            label = label_helpers.unique_suffix("constant", self.nodes)
+            node: constant_recipe.ConstantRecipe = constant_parser.make_constant(
+                value, f"Assignment to '{new_symbols[0]}'"
+            )
+            self.nodes[label] = node
+            self.symbol_map.register(
+                new_symbols, helper_models.LabeledRecipe(label=label, node=node)
+            )
         else:
             raise ValueError(
                 f"Workflow python definitions can only interpret assignments with "

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -266,7 +266,9 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
                 self.info_factory,
             )
             self.nodes[child.label] = child.node
-            parser_helpers.consume_call_arguments(self.symbol_map, rhs, child)
+            parser_helpers.consume_call_arguments(
+                self.symbol_map, rhs, child, self.nodes
+            )
             self.symbol_map.register(new_symbols, child)
         elif isinstance(rhs, ast.List) and len(rhs.elts) == 0:
             if len(new_symbols) != 1:

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -306,17 +306,33 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             )
 
     def _digest_flow_control(
-        self, label_prefix: str, node: union_types.RecipeDiscrimination
+        self,
+        label_prefix: str,
+        node: union_types.RecipeDiscrimination,
+        condition_bindings: dict[str, constant_recipe.ConstantRecipe] | None = None,
     ) -> None:
         label = label_helpers.unique_suffix(label_prefix, self.nodes)
         self.nodes[label] = node
-        self._connect_node_to_enclosing_scope(label, node)
+        self._connect_node_to_enclosing_scope(label, node, condition_bindings)
 
     def _connect_node_to_enclosing_scope(
-        self, label: str, node: union_types.RecipeDiscrimination
+        self,
+        label: str,
+        node: union_types.RecipeDiscrimination,
+        condition_bindings: dict[str, constant_recipe.ConstantRecipe] | None = None,
     ):
+        bindings = condition_bindings or {}
         for port in node.inputs:
-            self.symbol_map.consume(port, label, port)
+            if port in bindings:
+                peer_label = label_helpers.unique_suffix("constant", self.nodes)
+                self.nodes[peer_label] = bindings[port]
+                self.symbol_map.consume_source(
+                    edge_models.SourceHandle(node=peer_label, port="constant"),
+                    label,
+                    port,
+                )
+            else:
+                self.symbol_map.consume(port, label, port)
 
         labeled_node = helper_models.LabeledRecipe(label=label, node=node)
         self.symbol_map.register(new_symbols=node.outputs, child=labeled_node)
@@ -328,12 +344,12 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         self._digest_flow_control("for_each", for_recipe)
 
     def visit_While(self, tree: ast.While) -> None:
-        while_recipe = while_parser.parse_while_node(self, tree)
-        self._digest_flow_control("while", while_recipe)
+        while_recipe, condition_bindings = while_parser.parse_while_node(self, tree)
+        self._digest_flow_control("while", while_recipe, condition_bindings)
 
     def visit_If(self, tree: ast.If) -> None:
-        if_recipe = if_parser.parse_if_node(self, tree)
-        self._digest_flow_control("if", if_recipe)
+        if_recipe, condition_bindings = if_parser.parse_if_node(self, tree)
+        self._digest_flow_control("if", if_recipe, condition_bindings)
 
     def visit_Try(self, tree: ast.Try) -> None:
         try_recipe = try_parser.parse_try_node(self, tree)

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -283,7 +283,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
                     f"got {new_symbols}"
                 )
             self.symbol_map.register_accumulator(new_symbols[0])
-        elif (parsed := constant_parser.try_parse_constant(rhs))[0]:
+        elif rhs is not None and (parsed := constant_parser.try_parse_constant(rhs))[0]:
             if len(new_symbols) != 1:
                 raise ValueError(
                     f"Literal constant assignment must target exactly one symbol, "

--- a/src/flowrep/prospective/constant_recipe.py
+++ b/src/flowrep/prospective/constant_recipe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any, Literal
 
 import pydantic
@@ -20,6 +21,11 @@ def _strict_json(value: Any) -> Any:
     non-``str`` dict keys that pydantic's lax coercion would otherwise silently
     turn into lists / coerced keys.
     """
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(
+            f"Constant values must be JSON-serializable, but got a non-finite "
+            f"float: {value!r}"
+        )
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
     if isinstance(value, list):

--- a/src/flowrep/prospective/constant_recipe.py
+++ b/src/flowrep/prospective/constant_recipe.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pydantic
+from typing_extensions import TypeAliasType
+
+from flowrep import base_models
+
+JSON = TypeAliasType(
+    "JSON",
+    "dict[str, JSON] | list[JSON] | str | int | float | bool | None",
+)
+
+
+def _strict_json(value: Any) -> Any:
+    """Return *value* unchanged if it is strictly JSON, else raise ``ValueError``.
+
+    Runs on the RAW input (``mode="before"``), so it rejects tuples, sets, and
+    non-``str`` dict keys that pydantic's lax coercion would otherwise silently
+    turn into lists / coerced keys.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, list):
+        for element in value:
+            _strict_json(element)
+        return value
+    if isinstance(value, dict):
+        for key, element in value.items():
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"JSON object keys must be str, got {type(key).__name__}: {key!r}"
+                )
+            _strict_json(element)
+        return value
+    raise ValueError(
+        f"Constant values must be JSON-serializable, but got a "
+        f"{type(value).__name__}: {value!r}"
+    )
+
+
+class ConstantRecipe(base_models.NodeRecipe):
+    """A source node emitting a fixed, JSON-serializable value.
+
+    Has no inputs and a single output port named ``constant``. Unlike a defaulted
+    input (whose value lives only on the referenced function), the value is stored
+    directly in the recipe, so it survives serialization with no Python import.
+    """
+
+    type: Literal[base_models.RecipeElementType.CONSTANT] = pydantic.Field(
+        default=base_models.RecipeElementType.CONSTANT, frozen=True
+    )
+    inputs: base_models.Labels = pydantic.Field(default_factory=list)
+    outputs: base_models.Labels = pydantic.Field(default_factory=lambda: ["constant"])
+    constant: JSON
+
+    @pydantic.field_validator("constant", mode="before")
+    @classmethod
+    def _reject_non_json(cls, v: Any) -> Any:
+        return _strict_json(v)
+
+    @pydantic.model_validator(mode="after")
+    def _check_ports(self) -> ConstantRecipe:
+        if self.inputs != []:
+            raise ValueError(f"ConstantRecipe takes no inputs, got {self.inputs}")
+        if self.outputs != ["constant"]:
+            raise ValueError(
+                f"ConstantRecipe must have a single output named 'constant', "
+                f"got {self.outputs}"
+            )
+        return self
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.constant

--- a/src/flowrep/prospective/constant_recipe.py
+++ b/src/flowrep/prospective/constant_recipe.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import pydantic
 from typing_extensions import TypeAliasType
@@ -54,11 +54,16 @@ class ConstantRecipe(base_models.NodeRecipe):
     directly in the recipe, so it survives serialization with no Python import.
     """
 
+    std_label: ClassVar[str] = "constant"
+    # Standardized node label root, and exclusive output port label
+
     type: Literal[base_models.RecipeElementType.CONSTANT] = pydantic.Field(
         default=base_models.RecipeElementType.CONSTANT, frozen=True
     )
     inputs: base_models.Labels = pydantic.Field(default_factory=list)
-    outputs: base_models.Labels = pydantic.Field(default_factory=lambda: ["constant"])
+    outputs: base_models.Labels = pydantic.Field(
+        default_factory=lambda: [ConstantRecipe.std_label]
+    )
     constant: JSON
 
     @pydantic.field_validator("constant", mode="before")
@@ -70,9 +75,9 @@ class ConstantRecipe(base_models.NodeRecipe):
     def _check_ports(self) -> ConstantRecipe:
         if self.inputs != []:
             raise ValueError(f"ConstantRecipe takes no inputs, got {self.inputs}")
-        if self.outputs != ["constant"]:
+        if self.outputs != [self.std_label]:
             raise ValueError(
-                f"ConstantRecipe must have a single output named 'constant', "
+                f"ConstantRecipe must have a single output named {self.std_label}, "
                 f"got {self.outputs}"
             )
         return self

--- a/src/flowrep/prospective/union_types.py
+++ b/src/flowrep/prospective/union_types.py
@@ -5,6 +5,7 @@ import pydantic
 from flowrep import base_models
 from flowrep.prospective import (
     atomic_recipe,
+    constant_recipe,
     for_recipe,
     if_recipe,
     try_recipe,
@@ -15,6 +16,7 @@ from flowrep.prospective import (
 # Discriminated Union
 RecipeDiscrimination = Annotated[
     atomic_recipe.AtomicRecipe
+    | constant_recipe.ConstantRecipe
     | for_recipe.ForEachRecipe
     | if_recipe.IfRecipe
     | try_recipe.TryRecipe

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -25,6 +25,7 @@ from pyiron_snippets import retrieve, singleton
 from flowrep import base_models, edge_models
 from flowrep.prospective import (
     atomic_recipe,
+    constant_recipe,
     for_recipe,
     if_recipe,
     try_recipe,
@@ -106,6 +107,8 @@ def recipe2data(
             return AtomicData.from_recipe(
                 recipe, allow_variadic_inputs=allow_variadic_inputs
             )
+        case constant_recipe.ConstantRecipe():
+            return ConstantData.from_recipe(recipe)
         case for_recipe.ForEachRecipe():
             return ForEachData.from_recipe(recipe)
         case if_recipe.IfRecipe():
@@ -142,6 +145,22 @@ class AtomicData(NodeData[atomic_recipe.AtomicRecipe]):
             input_ports=dict(input_ports),
             output_ports=dict(output_ports),
             function=function,
+        )
+
+
+@dataclasses.dataclass(frozen=False)
+class ConstantData(NodeData[constant_recipe.ConstantRecipe]):
+    @classmethod
+    def from_recipe(cls, recipe: constant_recipe.ConstantRecipe) -> ConstantData:
+        return cls(
+            recipe=recipe,
+            input_ports={},
+            output_ports={
+                "constant": OutputDataPort(
+                    value=recipe.constant,
+                    annotation=type(recipe.constant),
+                )
+            },
         )
 
 

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -156,7 +156,7 @@ class ConstantData(NodeData[constant_recipe.ConstantRecipe]):
             recipe=recipe,
             input_ports={},
             output_ports={
-                "constant": OutputDataPort(
+                constant_recipe.ConstantRecipe.std_label: OutputDataPort(
                     value=recipe.constant,
                     annotation=type(recipe.constant),
                 )

--- a/src/flowrep/wfms.py
+++ b/src/flowrep/wfms.py
@@ -19,6 +19,7 @@ from flowrep import base_models, edge_models, subgraph_validation
 from flowrep.parsers import label_helpers
 from flowrep.prospective import (
     atomic_recipe,
+    constant_recipe,
     for_recipe,
     helper_models,
     if_recipe,
@@ -41,6 +42,8 @@ def run_recipe(
     match recipe:
         case atomic_recipe.AtomicRecipe():
             return _run_atomic(recipe, **kwargs)
+        case constant_recipe.ConstantRecipe():
+            return _run_constant(recipe, **kwargs)
         case workflow_recipe.WorkflowRecipe():
             return _run_workflow(recipe, **kwargs)
         case for_recipe.ForEachRecipe():
@@ -68,6 +71,13 @@ def _run_atomic(
     result = _call_atomic(node)
     _store_atomic_outputs(node, result)
     return node
+
+
+def _run_constant(
+    recipe: constant_recipe.ConstantRecipe, **kwargs: Any
+) -> datastructures.ConstantData:
+    # A constant has no inputs; its output value is fixed and pre-filled by from_recipe.
+    return datastructures.ConstantData.from_recipe(recipe)
 
 
 def _call_atomic(node: datastructures.AtomicData) -> Any:

--- a/tests/integration/parsers/test_parsing_constants.py
+++ b/tests/integration/parsers/test_parsing_constants.py
@@ -24,9 +24,7 @@ class TestConstantEndToEnd(unittest.TestCase):
         # 1. Serializes and round-trips through the discriminated union.
         adapter = pydantic.TypeAdapter(union_types.RecipeDiscrimination)
         restored = adapter.validate_python(adapter.dump_python(recipe, mode="json"))
-        self.assertEqual(
-            makers.dump_no_refs(restored), makers.dump_no_refs(recipe)
-        )
+        self.assertEqual(makers.dump_no_refs(restored), makers.dump_no_refs(recipe))
 
         # 2. Runs to the correct number.
         result = wfms.run_recipe(recipe, mass=2.0, velocity=3.0)

--- a/tests/integration/parsers/test_parsing_constants.py
+++ b/tests/integration/parsers/test_parsing_constants.py
@@ -28,7 +28,7 @@ class TestConstantEndToEnd(unittest.TestCase):
 
         # 2. Runs to the correct number.
         result = wfms.run_recipe(recipe, mass=2.0, velocity=3.0)
-        self.assertEqual(result.output_ports["ke"].value, 9.0)
+        self.assertAlmostEqual(result.output_ports["ke"].value, 9.0)
 
         # 3. Compiles back to source, re-parses to an equal recipe.
         free = makers.reference_free(kinetic_energy)

--- a/tests/integration/parsers/test_parsing_constants.py
+++ b/tests/integration/parsers/test_parsing_constants.py
@@ -1,0 +1,44 @@
+import unittest
+
+import pydantic
+
+from flowrep import wfms
+from flowrep.compiler import source
+from flowrep.parsers import workflow_parser
+from flowrep.prospective import union_types
+
+from flowrep_static import library, makers
+
+
+def kinetic_energy(mass, velocity):
+    v_2 = library.my_mul(velocity, velocity)
+    mv_2 = library.my_mul(mass, v_2)
+    ke = library.my_mul(0.5, mv_2)
+    return ke
+
+
+class TestConstantEndToEnd(unittest.TestCase):
+    def test_parse_serialize_run_compile(self):
+        recipe = workflow_parser.parse_workflow(kinetic_energy)
+
+        # 1. Serializes and round-trips through the discriminated union.
+        adapter = pydantic.TypeAdapter(union_types.RecipeDiscrimination)
+        restored = adapter.validate_python(adapter.dump_python(recipe, mode="json"))
+        self.assertEqual(
+            makers.dump_no_refs(restored), makers.dump_no_refs(recipe)
+        )
+
+        # 2. Runs to the correct number.
+        result = wfms.run_recipe(recipe, mass=2.0, velocity=3.0)
+        self.assertEqual(result.output_ports["ke"].value, 9.0)
+
+        # 3. Compiles back to source, re-parses to an equal recipe.
+        free = makers.reference_free(kinetic_energy)
+        fn = source._workflow2python(free).build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -2114,5 +2114,89 @@ class TestLiteralAssignRoundTrip(unittest.TestCase):
         self.assertEqual(fn(4), 4 * 0.5)
 
 
+def _return_constant(a):
+    y = 5
+    return y
+
+
+def _if_body_constant(a):
+    if library.is_positive(a):  # noqa: SIM108
+        y = 5
+    else:
+        y = library.identity(a)
+    return y
+
+
+class TestConstantMaterialize(unittest.TestCase):
+    def test_return_constant_materializes_and_round_trips(self):
+        free = makers.reference_free(_return_constant)
+        rendered = source._workflow2python(free)
+        self.assertIn("= 5", rendered.source)
+        self.assertNotIn("return 5", rendered.source)  # materialized, not inlined
+        fn = rendered.build()
+        self.assertEqual(fn(99), 5)
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+    def test_constant_in_if_branch_body_materializes_and_round_trips(self):
+        free = makers.reference_free(_if_body_constant)
+        fn = source._workflow2python(free).build()
+        self.assertEqual(fn(5), 5)  # is_positive -> y = 5
+        self.assertEqual(fn(-3), -3)  # else -> identity(a)
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+    def test_bare_constant_flow_control_body_compiles_and_executes(self):
+        # Hand-built `if is_positive(n): m = 42 else: m = -1` with BARE ConstantRecipe
+        # bodies (a shape only hand-construction produces). Round-trip canonicalizes
+        # (parser wraps bodies in workflows), so we assert source + execution, not
+        # dump_no_refs equality.
+        TH, IS, SH, OT = (
+            edge_models.TargetHandle,
+            edge_models.InputSource,
+            edge_models.SourceHandle,
+            edge_models.OutputTarget,
+        )
+        if_node = if_recipe.IfRecipe(
+            inputs=["n"],
+            outputs=["m"],
+            cases=[
+                helper_models.ConditionalCase(
+                    condition=helper_models.LabeledRecipe(
+                        label="cond", node=library.is_positive.flowrep_recipe
+                    ),
+                    body=helper_models.LabeledRecipe(
+                        label="body", node=constant_recipe.ConstantRecipe(constant=42)
+                    ),
+                )
+            ],
+            input_edges={TH(node="cond", port="n"): IS(port="n")},
+            prospective_output_edges={
+                OT(port="m"): [
+                    SH(node="body", port="constant"),
+                    SH(node="else_body", port="constant"),
+                ]
+            },
+            else_case=helper_models.LabeledRecipe(
+                label="else_body", node=constant_recipe.ConstantRecipe(constant=-1)
+            ),
+        )
+        wf = workflow_recipe.WorkflowRecipe(
+            inputs=["n"],
+            outputs=["m"],
+            nodes={"if_0": if_node},
+            input_edges={TH(node="if_0", port="n"): IS(port="n")},
+            edges={},
+            output_edges={OT(port="m"): SH(node="if_0", port="m")},
+        )
+        rendered = source._workflow2python(wf, function_name="branchy")
+        self.assertIn("= 42", rendered.source)
+        fn = rendered.build()
+        self.assertEqual(fn(5), 42)
+        self.assertEqual(fn(-3), -1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -16,6 +16,7 @@ from flowrep.compiler import flow_control, function, source, statements
 from flowrep.parsers import atomic_parser, workflow_parser
 from flowrep.prospective import (
     atomic_recipe,
+    constant_recipe,
     for_recipe,
     helper_models,
     if_recipe,
@@ -2084,6 +2085,33 @@ class TestConstantInlining(unittest.TestCase):
         reparsed_const = fn.flowrep_recipe.nodes["constant_0"].constant
         self.assertIs(type(reparsed_const[0]), float)
         self.assertIs(type(reparsed_const[1]), int)
+
+
+def _rt_inline_const(a):
+    half = 0.5
+    r = library.my_mul(a, half)
+    return r
+
+
+class TestLiteralAssignRoundTrip(unittest.TestCase):
+    def test_inline_path_round_trips(self):
+        free = makers.reference_free(_rt_inline_const)
+        self.assertTrue(
+            any(
+                isinstance(n, constant_recipe.ConstantRecipe)
+                for n in free.nodes.values()
+            ),
+            msg="Literal assignment should have injected a ConstantRecipe node",
+        )
+        fn = source._workflow2python(free).build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+    def test_inline_path_executes(self):
+        free = makers.reference_free(_rt_inline_const)
+        fn = source._workflow2python(free).build()
+        self.assertEqual(fn(4), 4 * 0.5)
 
 
 if __name__ == "__main__":

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -2042,5 +2042,49 @@ class TestSymbolNaming(unittest.TestCase):
         self.assertIn("loop_inc = ", lines[0])
 
 
+class TestConstantInlining(unittest.TestCase):
+    def _ke_recipe(self):
+        def kinetic_energy(mass, velocity):
+            v_2 = library.my_mul(velocity, velocity)
+            mv_2 = library.my_mul(mass, v_2)
+            ke = library.my_mul(0.5, mv_2)
+            return ke
+
+        return kinetic_energy, makers.reference_free(kinetic_energy)
+
+    def test_inlines_literal_and_omits_assignment(self):
+        _, free = self._ke_recipe()
+        rendered = source._workflow2python(free)
+        self.assertIn("0.5", rendered.source)
+        self.assertNotIn("constant_0 =", rendered.source)
+
+    def test_executes_with_inlined_constant(self):
+        original, free = self._ke_recipe()
+        fn = source._workflow2python(free).build()
+        self.assertEqual(fn(2.0, 3.0), original(2.0, 3.0))
+
+    def test_round_trips(self):
+        _, free = self._ke_recipe()
+        fn = source._workflow2python(free).build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+    def test_compound_and_type_fidelity_round_trip(self):
+        def uses_compound(x):
+            y = library.my_mul(x, [1.0, 1, "1", {"key": [42]}])
+            return y
+
+        free = makers.reference_free(uses_compound)
+        fn = source._workflow2python(free).build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+        # int/float distinction survives the source round-trip
+        reparsed_const = fn.flowrep_recipe.nodes["constant_0"].constant
+        self.assertIs(type(reparsed_const[0]), float)
+        self.assertIs(type(reparsed_const[1]), int)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -2062,7 +2062,7 @@ class TestConstantInlining(unittest.TestCase):
     def test_executes_with_inlined_constant(self):
         original, free = self._ke_recipe()
         fn = source._workflow2python(free).build()
-        self.assertEqual(fn(2.0, 3.0), original(2.0, 3.0))
+        self.assertAlmostEqual(fn(2.0, 3.0), original(2.0, 3.0))
 
     def test_round_trips(self):
         _, free = self._ke_recipe()
@@ -2111,7 +2111,7 @@ class TestLiteralAssignRoundTrip(unittest.TestCase):
     def test_inline_path_executes(self):
         free = makers.reference_free(_rt_inline_const)
         fn = source._workflow2python(free).build()
-        self.assertEqual(fn(4), 4 * 0.5)
+        self.assertAlmostEqual(fn(4), 4 * 0.5)
 
 
 def _return_constant(a):
@@ -2205,7 +2205,7 @@ class TestConstantsInConditions(unittest.TestCase):
         free = makers.reference_free(fn)
         rendered = source._workflow2python(free)
         built = rendered.build()
-        self.assertEqual(built(*call_args), fn(*call_args))
+        self.assertAlmostEqual(built(*call_args), fn(*call_args))
         self.assertEqual(
             makers.dump_no_refs(built.flowrep_recipe), makers.dump_no_refs(free)
         )

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -2198,5 +2198,82 @@ class TestConstantMaterialize(unittest.TestCase):
         self.assertEqual(fn(-3), -1)
 
 
+class TestConstantsInConditions(unittest.TestCase):
+    """Literal constants in if/elif/while conditions: execution + exact round-trip."""
+
+    def _round_trip(self, fn, *call_args):
+        free = makers.reference_free(fn)
+        rendered = source._workflow2python(free)
+        built = rendered.build()
+        self.assertEqual(built(*call_args), fn(*call_args))
+        self.assertEqual(
+            makers.dump_no_refs(built.flowrep_recipe), makers.dump_no_refs(free)
+        )
+        return free
+
+    def test_if_condition_literal_round_trips_and_executes(self):
+        def wf(m):
+            if library.my_condition(m, 0.5):
+                y = library.identity(m)
+            else:
+                y = library.identity(m)
+            return y
+
+        free = self._round_trip(wf, 0.2)
+        # the inlined literal appears in the rendered condition, not a bare symbol
+        rendered_src = source._workflow2python(free).source
+        self.assertIn("0.5", rendered_src)
+
+    def test_elif_condition_literal_round_trips_and_executes(self):
+        def wf(x, y):
+            if library.my_condition(x, y):
+                z = library.identity(x)
+            elif library.my_condition(x, 5):
+                z = library.identity(y)
+            else:
+                z = library.identity(x)
+            return z
+
+        self._round_trip(wf, 10, 3)
+        self._round_trip(wf, 3, 10)
+
+    def test_while_condition_literal_round_trips_and_executes(self):
+        def wf(x):
+            while library.my_condition(x, 5):
+                x = library.my_add(x, 1)
+            return x
+
+        self._round_trip(wf, 0)
+
+    def test_multiple_literals_in_one_condition_round_trip(self):
+        def wf(m):
+            if library.my_condition(0.3, 0.5):
+                y = library.identity(m)
+            else:
+                y = library.identity(m)
+            return y
+
+        free = self._round_trip(wf, 7)
+        constant_values = sorted(
+            node.constant
+            for node in free.nodes.values()
+            if isinstance(node, constant_recipe.ConstantRecipe)
+        )
+        self.assertEqual(constant_values, [0.3, 0.5])
+
+    def test_nested_condition_literal_round_trips(self):
+        def wf(m):
+            if library.my_condition(m, 0.5):
+                if library.my_condition(m, 0.7):
+                    y = library.identity(m)
+                else:
+                    y = library.identity(m)
+            else:
+                y = library.identity(m)
+            return y
+
+        self._round_trip(wf, 0.2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/parsers/test_constant_parser.py
+++ b/tests/unit/parsers/test_constant_parser.py
@@ -1,0 +1,84 @@
+import unittest
+
+from flowrep import edge_models
+from flowrep.parsers import symbol_scope, workflow_parser
+from flowrep.prospective import constant_recipe
+
+from flowrep_static import library
+
+
+def kinetic_energy(mass, velocity):
+    v_2 = library.my_mul(velocity, velocity)
+    mv_2 = library.my_mul(mass, v_2)
+    ke = library.my_mul(0.5, mv_2)
+    return ke
+
+
+def keyword_constant(x):
+    y = library.increment(x, step=3)
+    return y
+
+
+def compound_constant(x):
+    y = library.my_mul(x, [1.0, 1, "1", {"key": [42]}])
+    return y
+
+
+def tuple_arg(x):
+    y = library.my_mul(x, (1, 2))
+    return y
+
+
+def lambda_arg(x):
+    y = library.my_mul(x, lambda z: z)
+    return y
+
+
+class TestConstantParsing(unittest.TestCase):
+    def test_positional_literal_injects_constant(self):
+        recipe = workflow_parser.parse_workflow(kinetic_energy)
+        self.assertIn("constant_0", recipe.nodes)
+        const = recipe.nodes["constant_0"]
+        self.assertIsInstance(const, constant_recipe.ConstantRecipe)
+        self.assertEqual(const.constant, 0.5)
+        # The 3rd my_mul consumes the constant on its first port 'a'
+        edge = recipe.edges[edge_models.TargetHandle(node="my_mul_2", port="a")]
+        self.assertEqual(
+            edge, edge_models.SourceHandle(node="constant_0", port="constant")
+        )
+
+    def test_keyword_literal_injects_constant(self):
+        recipe = workflow_parser.parse_workflow(keyword_constant)
+        self.assertEqual(recipe.nodes["constant_0"].constant, 3)
+        edge = recipe.edges[edge_models.TargetHandle(node="increment_0", port="step")]
+        self.assertEqual(edge.node, "constant_0")
+
+    def test_compound_literal(self):
+        recipe = workflow_parser.parse_workflow(compound_constant)
+        self.assertEqual(
+            recipe.nodes["constant_0"].constant, [1.0, 1, "1", {"key": [42]}]
+        )
+
+    def test_tuple_arg_rejected(self):
+        with self.assertRaises(Exception) as ctx:
+            workflow_parser.parse_workflow(tuple_arg)
+        self.assertIn("my_mul_0", str(ctx.exception))
+
+    def test_lambda_arg_rejected(self):
+        with self.assertRaises(TypeError):
+            workflow_parser.parse_workflow(lambda_arg)
+
+
+class TestConsumeSource(unittest.TestCase):
+    def test_consume_source_creates_peer_edge(self):
+        scope = symbol_scope.SymbolScope({})
+        source = edge_models.SourceHandle(node="constant_0", port="constant")
+        scope.consume_source(source, "consumer", "a")
+        edges = scope.edges
+        self.assertEqual(
+            edges[edge_models.TargetHandle(node="consumer", port="a")], source
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/parsers/test_constant_parser.py
+++ b/tests/unit/parsers/test_constant_parser.py
@@ -69,6 +69,21 @@ class TestConstantParsing(unittest.TestCase):
             workflow_parser.parse_workflow(lambda_arg)
 
 
+class TestMakeConstant(unittest.TestCase):
+    def test_builds_recipe(self):
+        from flowrep.parsers import constant_parser
+
+        c = constant_parser.make_constant(0.5, "ctx")
+        self.assertEqual(c.constant, 0.5)
+
+    def test_wraps_validation_error_with_context(self):
+        from flowrep.parsers import constant_parser
+
+        with self.assertRaises(constant_parser.ConstantParseError) as ctx:
+            constant_parser.make_constant((1, 2), "while assigning to 'x'")
+        self.assertIn("while assigning to 'x'", str(ctx.exception))
+
+
 class TestConsumeSource(unittest.TestCase):
     def test_consume_source_creates_peer_edge(self):
         scope = symbol_scope.SymbolScope({})

--- a/tests/unit/parsers/test_for_parser.py
+++ b/tests/unit/parsers/test_for_parser.py
@@ -264,6 +264,10 @@ class TestForParserErrors(unittest.TestCase):
         self.assertIn("results", str(ctx.exception))
 
     def test_assigning_non_empty_list_raises(self):
+        """A non-empty list literal is a valid ``ConstantRecipe`` assignment (not an
+        accumulator), so ``results`` is never registered as an accumulator and the
+        later ``.append()`` is what raises."""
+
         def wf(xs):
             results = [0]
             for x in xs:
@@ -273,7 +277,10 @@ class TestForParserErrors(unittest.TestCase):
 
         with self.assertRaises(ValueError) as ctx:
             workflow_parser.parse_workflow(wf)
-        self.assertIn("or empty list", str(ctx.exception))
+        self.assertIn(
+            "not found among available accumulator symbols", str(ctx.exception)
+        )
+        self.assertIn("results", str(ctx.exception))
 
     def test_accumulator_reassigned_in_nested_while_raises(self):
         """Reassigning an accumulator symbol inside a nested while is rejected."""

--- a/tests/unit/parsers/test_if_parser.py
+++ b/tests/unit/parsers/test_if_parser.py
@@ -7,7 +7,7 @@ import textwrap
 import unittest
 
 from flowrep import edge_models
-from flowrep.parsers import if_parser, workflow_parser
+from flowrep.parsers import constant_parser, if_parser, workflow_parser
 from flowrep.prospective import (
     constant_recipe,
     for_recipe,
@@ -209,6 +209,46 @@ class TestParseIfConditionErrors(unittest.TestCase):
             if isinstance(node, constant_recipe.ConstantRecipe)
         )
         self.assertEqual(constant_values, [5])
+
+    def test_multiple_literals_get_distinct_synthetic_ports(self):
+        """Two literals in one condition get distinct, deterministic ports/peers."""
+
+        def wf(m):
+            if library.my_condition(0.3, 0.5):
+                y = library.identity(m)
+            else:
+                y = library.identity(m)
+            return y
+
+        recipe = workflow_parser.parse_workflow(wf)
+        (if_node,) = [
+            node
+            for node in recipe.nodes.values()
+            if isinstance(node, if_recipe.IfRecipe)
+        ]
+        self.assertIn("constant_0", if_node.inputs)
+        self.assertIn("constant_1", if_node.inputs)
+        peer_values = sorted(
+            node.constant
+            for node in recipe.nodes.values()
+            if isinstance(node, constant_recipe.ConstantRecipe)
+        )
+        self.assertEqual(peer_values, [0.3, 0.5])
+
+    def test_non_json_literal_in_condition_raises_with_context(self):
+        """A non-JSON literal (tuple) in a condition raises ConstantParseError with
+        the consuming node/port context, at parse time."""
+
+        def wf(m):
+            if library.my_condition(m, (1, 2)):
+                y = library.identity(m)
+            else:
+                y = library.identity(m)
+            return y
+
+        with self.assertRaises(constant_parser.ConstantParseError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("Condition argument", str(ctx.exception))
 
 
 # ===================================================================

--- a/tests/unit/parsers/test_if_parser.py
+++ b/tests/unit/parsers/test_if_parser.py
@@ -151,6 +151,38 @@ class TestParseIfConditionErrors(unittest.TestCase):
             workflow_parser.parse_workflow(wf)
         self.assertIn("function call", str(ctx.exception))
 
+    def test_literal_in_condition_raises(self):
+        """A literal argument in an if-condition must raise cleanly, not inject a
+        constant node."""
+
+        def wf(x):
+            if library.my_condition(x, 5):
+                y = library.identity(x)
+            else:
+                y = library.identity(x)
+            return y
+
+        with self.assertRaises(TypeError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("flow-control", str(ctx.exception))
+        self.assertIn("condition", str(ctx.exception))
+
+    def test_literal_in_elif_condition_raises_type_error(self):
+        """A literal argument in an elif-condition raises the flow-control error."""
+
+        def wf(x, y):
+            if library.my_condition(x, y):
+                z = library.identity(x)
+            elif library.my_condition(x, 5):
+                z = library.identity(y)
+            else:
+                z = library.identity(x)
+            return z
+
+        with self.assertRaises(TypeError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("flow-control", str(ctx.exception))
+
 
 # ===================================================================
 # Body-level errors (tested via parse_workflow)

--- a/tests/unit/parsers/test_if_parser.py
+++ b/tests/unit/parsers/test_if_parser.py
@@ -9,6 +9,7 @@ import unittest
 from flowrep import edge_models
 from flowrep.parsers import if_parser, workflow_parser
 from flowrep.prospective import (
+    constant_recipe,
     for_recipe,
     if_recipe,
     try_recipe,
@@ -151,9 +152,9 @@ class TestParseIfConditionErrors(unittest.TestCase):
             workflow_parser.parse_workflow(wf)
         self.assertIn("function call", str(ctx.exception))
 
-    def test_literal_in_condition_raises(self):
-        """A literal argument in an if-condition must raise cleanly, not inject a
-        constant node."""
+    def test_literal_in_condition_parses_to_constant_peer(self):
+        """A literal argument in an if-condition injects a constant peer routed
+        through a synthetic flow-control input port (no longer raises)."""
 
         def wf(x):
             if library.my_condition(x, 5):
@@ -162,13 +163,35 @@ class TestParseIfConditionErrors(unittest.TestCase):
                 y = library.identity(x)
             return y
 
-        with self.assertRaises(TypeError) as ctx:
-            workflow_parser.parse_workflow(wf)
-        self.assertIn("flow-control", str(ctx.exception))
-        self.assertIn("condition", str(ctx.exception))
+        recipe = workflow_parser.parse_workflow(wf)
 
-    def test_literal_in_elif_condition_raises_type_error(self):
-        """A literal argument in an elif-condition raises the flow-control error."""
+        # A constant peer node holding 5 sits beside the if node.
+        constant_nodes = {
+            label: node
+            for label, node in recipe.nodes.items()
+            if isinstance(node, constant_recipe.ConstantRecipe)
+        }
+        self.assertEqual(len(constant_nodes), 1)
+        self.assertEqual(next(iter(constant_nodes.values())).constant, 5)
+
+        # The if node has a synthetic "constant_0" input port fed by that peer.
+        ((if_label, if_node),) = [
+            (label, node)
+            for label, node in recipe.nodes.items()
+            if isinstance(node, if_recipe.IfRecipe)
+        ]
+        self.assertIn("constant_0", if_node.inputs)
+        peer_label = next(iter(constant_nodes))
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node=if_label, port="constant_0")],
+            edge_models.SourceHandle(node=peer_label, port="constant"),
+        )
+        # The synthetic port is NOT an input of the enclosing workflow.
+        self.assertNotIn("constant_0", recipe.inputs)
+
+    def test_literal_in_elif_condition_parses(self):
+        """A literal argument in an elif-condition parses; its synthetic port is
+        distinct from the if-condition's (shared reserved_ports across the chain)."""
 
         def wf(x, y):
             if library.my_condition(x, y):
@@ -179,9 +202,13 @@ class TestParseIfConditionErrors(unittest.TestCase):
                 z = library.identity(x)
             return z
 
-        with self.assertRaises(TypeError) as ctx:
-            workflow_parser.parse_workflow(wf)
-        self.assertIn("flow-control", str(ctx.exception))
+        recipe = workflow_parser.parse_workflow(wf)
+        constant_values = sorted(
+            node.constant
+            for node in recipe.nodes.values()
+            if isinstance(node, constant_recipe.ConstantRecipe)
+        )
+        self.assertEqual(constant_values, [5])
 
 
 # ===================================================================

--- a/tests/unit/parsers/test_parser_helpers.py
+++ b/tests/unit/parsers/test_parser_helpers.py
@@ -507,6 +507,19 @@ class TestConsumeCallArguments(unittest.TestCase):
             edge_models.SourceHandle(node="constant_0", port="constant"),
         )
 
+    def test_partial_consumption_before_error(self):
+        """An earlier valid symbol arg is still consumed before a later
+        genuinely-unparseable arg raises."""
+        scope = self._make_scope(["x"])
+        call = self._parse_call("func(x, other_func(y))")
+        node = self._make_labeled_node("func_0", inputs=["a", "b"])
+
+        with self.assertRaises(TypeError) as ctx:
+            parser_helpers.consume_call_arguments(scope, call, node, {})
+
+        self.assertIn("symbolic input", str(ctx.exception))
+        self.assertEqual(self._consumed_pairs(scope), [("x", "a")])
+
     def test_preserves_underscore_names(self):
         scope = self._make_scope(["_private", "__dunder__"])
         call = self._parse_call("func(_private, __dunder__)")

--- a/tests/unit/parsers/test_parser_helpers.py
+++ b/tests/unit/parsers/test_parser_helpers.py
@@ -2,7 +2,7 @@ import ast
 import unittest
 
 from flowrep import base_models, edge_models
-from flowrep.parsers import parser_helpers, symbol_scope
+from flowrep.parsers import constant_parser, parser_helpers, symbol_scope
 from flowrep.prospective import atomic_recipe, helper_models
 
 from flowrep_static import makers
@@ -335,7 +335,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(x)")
         node = self._make_labeled_node("func_0", inputs=["a"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(self._consumed_pairs(scope), [("x", "a")])
 
@@ -344,7 +344,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(x, y, z)")
         node = self._make_labeled_node("func_0", inputs=["a", "b", "c"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(
             self._consumed_pairs(scope), [("x", "a"), ("y", "b"), ("z", "c")]
@@ -355,7 +355,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(a=x)")
         node = self._make_labeled_node("func_0", inputs=["a"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(self._consumed_pairs(scope), [("x", "a")])
 
@@ -364,7 +364,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(a=x, b=y)")
         node = self._make_labeled_node("func_0", inputs=["a", "b"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(self._consumed_pairs(scope), [("x", "a"), ("y", "b")])
 
@@ -373,7 +373,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(x, b=y)")
         node = self._make_labeled_node("func_0", inputs=["a", "b"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(self._consumed_pairs(scope), [("x", "a"), ("y", "b")])
 
@@ -382,7 +382,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(b=y, a=x)")
         node = self._make_labeled_node("func_0", inputs=["a", "b"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         # Keywords consumed in call order, not definition order
         self.assertEqual(self._consumed_pairs(scope), [("y", "b"), ("x", "a")])
@@ -392,30 +392,39 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func()")
         node = self._make_labeled_node("func_0", inputs=[])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(self._consumed_pairs(scope), [])
 
-    def test_literal_positional_raises_type_error(self):
+    def test_literal_positional_injects_constant(self):
+        """A JSON-compatible literal positional arg is no longer an error; it is
+        injected as a ConstantRecipe source node and wired as a sibling edge."""
         scope = self._make_scope([])
         call = self._parse_call("func(42)")
         node = self._make_labeled_node("func_0", inputs=["a"])
+        nodes: dict = {}
 
-        with self.assertRaises(TypeError) as ctx:
-            parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, nodes)
 
-        self.assertIn("symbolic input", str(ctx.exception))
-        self.assertIn("func_0", str(ctx.exception))
+        self.assertEqual(nodes["constant_0"].constant, 42)
+        self.assertEqual(
+            scope.edges[edge_models.TargetHandle(node="func_0", port="a")],
+            edge_models.SourceHandle(node="constant_0", port="constant"),
+        )
 
-    def test_literal_keyword_raises_type_error(self):
+    def test_literal_keyword_injects_constant(self):
         scope = self._make_scope([])
         call = self._parse_call("func(a=42)")
         node = self._make_labeled_node("func_0", inputs=["a"])
+        nodes: dict = {}
 
-        with self.assertRaises(TypeError) as ctx:
-            parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, nodes)
 
-        self.assertIn("symbolic input", str(ctx.exception))
+        self.assertEqual(nodes["constant_0"].constant, 42)
+        self.assertEqual(
+            scope.edges[edge_models.TargetHandle(node="func_0", port="a")],
+            edge_models.SourceHandle(node="constant_0", port="constant"),
+        )
 
     def test_expression_positional_raises_type_error(self):
         scope = self._make_scope(["x", "y"])
@@ -423,7 +432,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         node = self._make_labeled_node("func_0", inputs=["a"])
 
         with self.assertRaises(TypeError) as ctx:
-            parser_helpers.consume_call_arguments(scope, call, node)
+            parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertIn("symbolic input", str(ctx.exception))
 
@@ -433,7 +442,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         node = self._make_labeled_node("func_0", inputs=["a"])
 
         with self.assertRaises(TypeError) as ctx:
-            parser_helpers.consume_call_arguments(scope, call, node)
+            parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertIn("symbolic input", str(ctx.exception))
 
@@ -443,7 +452,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         node = self._make_labeled_node("func_0", inputs=["a"])
 
         with self.assertRaises(TypeError) as ctx:
-            parser_helpers.consume_call_arguments(scope, call, node)
+            parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertIn("symbolic input", str(ctx.exception))
 
@@ -453,38 +462,57 @@ class TestConsumeCallArguments(unittest.TestCase):
         node = self._make_labeled_node("func_0", inputs=["a"])
 
         with self.assertRaises(TypeError) as ctx:
-            parser_helpers.consume_call_arguments(scope, call, node)
+            parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertIn("symbolic input", str(ctx.exception))
 
-    def test_string_literal_keyword_raises_type_error(self):
+    def test_string_literal_keyword_injects_constant(self):
         scope = self._make_scope([])
         call = self._parse_call("func(a='hello')")
         node = self._make_labeled_node("func_0", inputs=["a"])
+        nodes: dict = {}
 
-        with self.assertRaises(TypeError) as ctx:
-            parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, nodes)
 
-        self.assertIn("symbolic input", str(ctx.exception))
+        self.assertEqual(nodes["constant_0"].constant, "hello")
 
-    def test_partial_consumption_before_error(self):
-        """Valid args are consumed before hitting an invalid one."""
+    def test_tuple_literal_raises_constant_parse_error(self):
+        """A syntactic literal that ast.literal_eval accepts but is not
+        JSON-compatible (e.g. a tuple) surfaces as a ConstantParseError, naming the
+        consuming node/port."""
+        scope = self._make_scope([])
+        call = self._parse_call("func((1, 2))")
+        node = self._make_labeled_node("func_0", inputs=["a"])
+
+        with self.assertRaises(constant_parser.ConstantParseError) as ctx:
+            parser_helpers.consume_call_arguments(scope, call, node, {})
+
+        self.assertIn("func_0", str(ctx.exception))
+        self.assertIn("a", str(ctx.exception))
+
+    def test_partial_consumption_before_constant_injection(self):
+        """Valid symbolic args are consumed alongside literal args injected as
+        constants, in call order."""
         scope = self._make_scope(["x"])
         call = self._parse_call("func(x, 42)")
         node = self._make_labeled_node("func_0", inputs=["a", "b"])
+        nodes: dict = {}
 
-        with self.assertRaises(TypeError):
-            parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, nodes)
 
-        # First arg was consumed before the error
-        self.assertEqual(self._consumed_pairs(scope), [("x", "a")])
+        self.assertEqual(self._consumed_pairs(scope), [("x", "a"), ("constant_0", "b")])
+        self.assertEqual(nodes["constant_0"].constant, 42)
+        self.assertEqual(
+            scope.edges[edge_models.TargetHandle(node="func_0", port="b")],
+            edge_models.SourceHandle(node="constant_0", port="constant"),
+        )
 
     def test_preserves_underscore_names(self):
         scope = self._make_scope(["_private", "__dunder__"])
         call = self._parse_call("func(_private, __dunder__)")
         node = self._make_labeled_node("func_0", inputs=["a", "b"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(
             self._consumed_pairs(scope), [("_private", "a"), ("__dunder__", "b")]
@@ -496,7 +524,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(x)")
         node = self._make_labeled_node("func_0", inputs=["a"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         c = scope._consumptions[0]
         self.assertEqual(c.symbol, "x")
@@ -510,7 +538,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(x, b=y)")
         node = self._make_labeled_node("func_0", inputs=["a", "b"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(
             scope.input_edges,
@@ -532,7 +560,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         call = self._parse_call("func(x)")
         node = self._make_labeled_node("func_0", inputs=["a"])
 
-        parser_helpers.consume_call_arguments(scope, call, node)
+        parser_helpers.consume_call_arguments(scope, call, node, {})
 
         self.assertEqual(scope.input_edges, {})
         self.assertEqual(

--- a/tests/unit/parsers/test_symbol_scope.py
+++ b/tests/unit/parsers/test_symbol_scope.py
@@ -170,6 +170,27 @@ class TestSymbolScopeFork(unittest.TestCase):
         self.assertEqual(result.port, "a")
 
 
+class TestSymbolScopeConsumeInputSource(unittest.TestCase):
+    def test_consume_input_source_records_fixed_input_source(self):
+        scope = SymbolScope({})
+        scope.consume_input_source(
+            edge_models.InputSource(port="constant_0"), "condition_0", "n"
+        )
+        # Surfaces as an input edge keyed by the consumer handle...
+        self.assertEqual(
+            scope.input_edges,
+            {
+                edge_models.TargetHandle(
+                    node="condition_0", port="n"
+                ): edge_models.InputSource(port="constant_0")
+            },
+        )
+        # ...contributes the synthetic port to inputs...
+        self.assertEqual(scope.inputs, ["constant_0"])
+        # ...and does NOT register a symbol in _sources.
+        self.assertNotIn("constant_0", scope)
+
+
 class TestSymbolScopeErrors(unittest.TestCase):
     """Cover all ValueError/KeyError raise paths in SymbolScope."""
 

--- a/tests/unit/parsers/test_while_parser.py
+++ b/tests/unit/parsers/test_while_parser.py
@@ -3,6 +3,7 @@ import unittest
 from flowrep import edge_models
 from flowrep.parsers import while_parser, workflow_parser
 from flowrep.prospective import (
+    constant_recipe,
     for_recipe,
     if_recipe,
     try_recipe,
@@ -52,19 +53,29 @@ class TestParseWhileConditionErrors(unittest.TestCase):
             workflow_parser.parse_workflow(wf)
         self.assertIn("exactly one", str(ctx.exception))
 
-    def test_literal_in_condition_raises(self):
-        """A literal argument in a while-condition must raise cleanly, not inject a
-        constant node."""
+    def test_literal_in_condition_parses_to_constant_peer(self):
+        """A literal argument in a while-condition injects a constant peer routed
+        through a synthetic flow-control input port (no longer raises)."""
 
         def wf(x):
             while library.my_condition(x, 5):
                 x = library.identity(x)
             return x
 
-        with self.assertRaises(TypeError) as ctx:
-            workflow_parser.parse_workflow(wf)
-        self.assertIn("flow-control", str(ctx.exception))
-        self.assertIn("condition", str(ctx.exception))
+        recipe = workflow_parser.parse_workflow(wf)
+        constant_nodes = [
+            node
+            for node in recipe.nodes.values()
+            if isinstance(node, constant_recipe.ConstantRecipe)
+        ]
+        self.assertEqual(len(constant_nodes), 1)
+        self.assertEqual(constant_nodes[0].constant, 5)
+        (while_node,) = [
+            node
+            for node in recipe.nodes.values()
+            if isinstance(node, while_recipe.WhileRecipe)
+        ]
+        self.assertIn("constant_0", while_node.inputs)
 
 
 class TestWhileParserErrors(unittest.TestCase):

--- a/tests/unit/parsers/test_while_parser.py
+++ b/tests/unit/parsers/test_while_parser.py
@@ -52,6 +52,20 @@ class TestParseWhileConditionErrors(unittest.TestCase):
             workflow_parser.parse_workflow(wf)
         self.assertIn("exactly one", str(ctx.exception))
 
+    def test_literal_in_condition_raises(self):
+        """A literal argument in a while-condition must raise cleanly, not inject a
+        constant node."""
+
+        def wf(x):
+            while library.my_condition(x, 5):
+                x = library.identity(x)
+            return x
+
+        with self.assertRaises(TypeError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("flow-control", str(ctx.exception))
+        self.assertIn("condition", str(ctx.exception))
+
 
 class TestWhileParserErrors(unittest.TestCase):
     """

--- a/tests/unit/parsers/test_workflow_parser.py
+++ b/tests/unit/parsers/test_workflow_parser.py
@@ -15,7 +15,7 @@ from flowrep.parsers import (
     symbol_scope,
     workflow_parser,
 )
-from flowrep.prospective import atomic_recipe, workflow_recipe
+from flowrep.prospective import atomic_recipe, constant_recipe, workflow_recipe
 
 from flowrep_static import library
 
@@ -1161,6 +1161,78 @@ class TestNestedDescriptions(unittest.TestCase):
         self.assertEqual(
             recipe.nodes["inner_macro_0"].nodes["add_0"].description, add.__doc__
         )
+
+
+def _assign_scalar_constant(a):
+    half = 0.5
+    r = library.my_mul(a, half)
+    return r
+
+
+def _assign_list_constant(seed):
+    data = [1, 2, 3]
+    r = library.identity(data)
+    return r
+
+
+def _assign_tuple_constant(a):
+    bad = (1, 2)
+    r = library.identity(bad)
+    return r
+
+
+def _assign_non_literal(a):
+    bad = a + 1
+    r = library.identity(bad)
+    return r
+
+
+def _accumulator_wf(items):
+    acc = []
+    for x in items:
+        y = library.identity(x)
+        acc.append(y)
+    return acc
+
+
+def _assign_literal_to_multiple_targets(a):
+    x, y = 1, 2  # noqa: F841
+    return a
+
+
+class TestLiteralAssignment(unittest.TestCase):
+    def _constants(self, recipe):
+        return [
+            n
+            for n in recipe.nodes.values()
+            if isinstance(n, constant_recipe.ConstantRecipe)
+        ]
+
+    def test_scalar_literal_injects_constant(self):
+        recipe = workflow_parser.parse_workflow(_assign_scalar_constant)
+        self.assertTrue(any(c.constant == 0.5 for c in self._constants(recipe)))
+
+    def test_list_literal_injects_constant(self):
+        recipe = workflow_parser.parse_workflow(_assign_list_constant)
+        self.assertTrue(any(c.constant == [1, 2, 3] for c in self._constants(recipe)))
+
+    def test_tuple_literal_assignment_raises(self):
+        with self.assertRaises(ValueError):
+            workflow_parser.parse_workflow(_assign_tuple_constant)
+
+    def test_non_literal_expr_assignment_still_raises(self):
+        with self.assertRaises(ValueError):
+            workflow_parser.parse_workflow(_assign_non_literal)
+
+    def test_empty_list_remains_accumulator(self):
+        recipe = workflow_parser.parse_workflow(_accumulator_wf)
+        # `acc = []` must NOT have become a constant [] node
+        self.assertFalse(any(c.constant == [] for c in self._constants(recipe)))
+
+    def test_literal_assigned_to_multiple_targets_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(_assign_literal_to_multiple_targets)
+        self.assertIn("exactly one symbol", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/unit/prospective/test_constant_recipe.py
+++ b/tests/unit/prospective/test_constant_recipe.py
@@ -36,6 +36,11 @@ class TestConstantRecipe(unittest.TestCase):
             with self.subTest(bad=bad), self.assertRaises(pydantic.ValidationError):
                 constant_recipe.ConstantRecipe(constant=bad)
 
+    def test_rejects_non_finite_float(self):
+        for bad in [float("nan"), float("inf"), float("-inf")]:
+            with self.subTest(bad=bad), self.assertRaises(pydantic.ValidationError):
+                constant_recipe.ConstantRecipe(constant=bad)
+
     def test_bad_ports_rejected(self):
         with self.assertRaises(pydantic.ValidationError):
             constant_recipe.ConstantRecipe(constant=1, inputs=["x"])

--- a/tests/unit/prospective/test_constant_recipe.py
+++ b/tests/unit/prospective/test_constant_recipe.py
@@ -1,0 +1,60 @@
+import unittest
+
+import pydantic
+
+from flowrep import base_models
+from flowrep.prospective import constant_recipe, union_types
+
+
+class TestConstantRecipe(unittest.TestCase):
+    def test_defaults_and_call(self):
+        c = constant_recipe.ConstantRecipe(constant=0.5)
+        self.assertEqual(c.type, base_models.RecipeElementType.CONSTANT)
+        self.assertEqual(c.inputs, [])
+        self.assertEqual(c.outputs, ["constant"])
+        self.assertEqual(c.constant, 0.5)
+        self.assertEqual(c(), 0.5)  # __call__ returns the value
+
+    def test_type_fidelity_preserved(self):
+        for value, expected_type in [
+            (1, int),
+            (1.0, float),
+            (True, bool),
+            (None, type(None)),
+        ]:
+            with self.subTest(value=value):
+                c = constant_recipe.ConstantRecipe(constant=value)
+                self.assertIs(type(c.constant), expected_type)
+
+    def test_compound_value(self):
+        value = [1.0, 1, "1", {"key": [42]}]
+        c = constant_recipe.ConstantRecipe(constant=value)
+        self.assertEqual(c.constant, value)
+
+    def test_rejects_non_json(self):
+        for bad in [(1, 2), {1, 2}, [1, (2, 3)], {1: "int-key"}, {"k": (1,)}]:
+            with self.subTest(bad=bad), self.assertRaises(pydantic.ValidationError):
+                constant_recipe.ConstantRecipe(constant=bad)
+
+    def test_bad_ports_rejected(self):
+        with self.assertRaises(pydantic.ValidationError):
+            constant_recipe.ConstantRecipe(constant=1, inputs=["x"])
+        with self.assertRaises(pydantic.ValidationError):
+            constant_recipe.ConstantRecipe(constant=1, outputs=["wrong"])
+
+    def test_discriminated_union_roundtrip(self):
+        adapter = pydantic.TypeAdapter(union_types.RecipeDiscrimination)
+        data = {
+            "type": "constant",
+            "inputs": [],
+            "outputs": ["constant"],
+            "constant": [1.0, 1, "1", {"key": [42]}],
+        }
+        node = adapter.validate_python(data)
+        self.assertIsInstance(node, constant_recipe.ConstantRecipe)
+        restored = adapter.validate_python(adapter.dump_python(node, mode="json"))
+        self.assertEqual(node, restored)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_base_models.py
+++ b/tests/unit/test_base_models.py
@@ -181,7 +181,7 @@ class TestRecipeElementType(unittest.TestCase):
     """Tests for RecipeElementType enum."""
 
     def test_all_expected_values_exist(self):
-        expected = {"atomic", "workflow", "for_each", "while", "if", "try"}
+        expected = {"atomic", "workflow", "for_each", "while", "if", "try", "constant"}
         actual = {e.value for e in base_models.RecipeElementType}
         self.assertEqual(expected, actual)
 

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -13,6 +13,7 @@ from flowrep import base_models, edge_models, wfms
 from flowrep.parsers import atomic_parser, workflow_parser
 from flowrep.prospective import (
     atomic_recipe,
+    constant_recipe,
     for_recipe,
     helper_models,
     if_recipe,
@@ -1180,6 +1181,22 @@ class TestProvenanceWalk(unittest.TestCase):
         self.assertEqual(mul_node.input_ports["a"].value, 8)
         self.assertEqual(mul_node.input_ports["b"].value, 2)
         self.assertEqual(mul_node.output_ports["output_0"].value, 16)
+
+
+class TestConstantData(unittest.TestCase):
+    def test_from_recipe_prefills_value(self):
+        recipe = constant_recipe.ConstantRecipe(constant=0.5)
+        node = datastructures.ConstantData.from_recipe(recipe)
+        self.assertEqual(node.input_ports, {})
+        port = node.output_ports["constant"]
+        self.assertEqual(port.value, 0.5)
+        self.assertIs(port.annotation, float)
+
+    def test_recipe2data_dispatches_constant(self):
+        recipe = constant_recipe.ConstantRecipe(constant=[1, 2])
+        node = datastructures.recipe2data(recipe)
+        self.assertIsInstance(node, datastructures.ConstantData)
+        self.assertEqual(node.output_ports["constant"].value, [1, 2])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -1212,16 +1212,10 @@ def _kinetic_energy(mass, velocity):
 
 class TestWfMSConstants(unittest.TestCase):
     def test_run_recipe_on_constant(self):
-        from flowrep import wfms
-        from flowrep.prospective import constant_recipe
-
         node = wfms.run_recipe(constant_recipe.ConstantRecipe(constant=7))
         self.assertEqual(node.output_ports["constant"].value, 7)
 
     def test_end_to_end_kinetic_energy(self):
-        from flowrep import wfms
-        from flowrep.parsers import workflow_parser
-
         recipe = workflow_parser.parse_workflow(_kinetic_energy)
         result = wfms.run_recipe(recipe, mass=2.0, velocity=3.0)
         self.assertEqual(result.output_ports["ke"].value, 0.5 * 2.0 * 3.0 * 3.0)

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -1199,5 +1199,33 @@ class TestConstantData(unittest.TestCase):
         self.assertEqual(node.output_ports["constant"].value, [1, 2])
 
 
+def _kinetic_energy(mass, velocity):
+    # Module-level (not nested in a test method): DagData.from_recipe resolves a
+    # workflow's own reference by importing it, which requires the function be
+    # reachable by its fully-qualified name -- a `<locals>` qualname (as produced
+    # by a function nested inside a test method) cannot be imported.
+    v_2 = library.my_mul(velocity, velocity)
+    mv_2 = library.my_mul(mass, v_2)
+    ke = library.my_mul(0.5, mv_2)
+    return ke
+
+
+class TestWfMSConstants(unittest.TestCase):
+    def test_run_recipe_on_constant(self):
+        from flowrep import wfms
+        from flowrep.prospective import constant_recipe
+
+        node = wfms.run_recipe(constant_recipe.ConstantRecipe(constant=7))
+        self.assertEqual(node.output_ports["constant"].value, 7)
+
+    def test_end_to_end_kinetic_energy(self):
+        from flowrep import wfms
+        from flowrep.parsers import workflow_parser
+
+        recipe = workflow_parser.parse_workflow(_kinetic_energy)
+        result = wfms.run_recipe(recipe, mass=2.0, velocity=3.0)
+        self.assertEqual(result.output_ports["ke"].value, 0.5 * 2.0 * 3.0 * 3.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #268 

With this PR, JSONifiable constants (`type JSON = dict[str, JSON] | list[JSON] | str | int | float | bool | None`) can be parsed from workflows. This is valid for both constant assignments to call input, and constant assignments to variables (but only one at a time, still no `a, b = 1, 2`, need instead `a = 1; b = 2`). 

This example could just be an atomic node, but it demonstrates things nicely:

```python
import flowrep as fr

def greater(a, b):
    return a > b

@fr.workflow
def uses_constants(x):
    if greater(x, 0):
        y = [1.0, 1.0]
    else:
        y = [-1.0, -1.0]
    return y

```

You can look at the raw recipe, where the new `ConstantRecipe` appears in the JSON, but it's probably more succinctly convincing to see that this round-trips back to python again quite nicely:

```python
print(
    fr.tools.flowrep2python(
        uses_constants.flowrep_recipe.model_copy(
            update={"reference": None}
        )
    ).source
)
```

```python
from __future__ import annotations

import __main__
import flowrep
import typing

@flowrep.workflow("y")
def compiled_from_workflow_recipe(x):
    if __main__.greater(a=x, b=0):
        y = [1.0, 1.0]
    else:
        y = [-1.0, -1.0]
    return y
```


Claude was apparently super hit-or-miss with adding itself as co-author, but in case it isn't clear from the commit message style, that's where the actual commits came from except for the last few.