### PR TITLE
Parse variable reassignment

### DIFF
--- a/src/flowrep/parsers/case_helpers.py
+++ b/src/flowrep/parsers/case_helpers.py
@@ -149,6 +149,11 @@ def wire_outputs(
                 seen.add(sym)
                 outputs.append(sym)
 
+    for branch in branches:
+        parser_helpers.reject_input_alias_outputs(
+            branch.walker.symbol_map, outputs, "branch"
+        )
+
     # Build prospective output edges: each output maps to the list of branch
     # body nodes that can source it.
     prospective_output_edges: subgraph_validation.ProspectiveOutputEdges = {}

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -4,7 +4,7 @@ import ast
 import dataclasses
 import inspect
 import textwrap
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from types import FunctionType
 from typing import Any, cast
 
@@ -219,3 +219,26 @@ def _bind_condition_constant(
     scope.consume_input_source(
         edge_models.InputSource(port=synthetic_port), child.label, consumer_port
     )
+
+
+def reject_input_alias_outputs(
+    body_symbol_map: symbol_scope.SymbolScope,
+    candidate_outputs: Iterable[str],
+    control_kind: str,
+) -> None:
+    """Raise if a flow-control body tries to surface an input-alias as an output.
+
+    A symbol aliased directly to a workflow input keeps an ``InputSource`` rather
+    than a node ``SourceHandle``. Such a symbol cannot be represented as a
+    ``{control_kind}`` output, so we reject it with a clear error instead of
+    emitting an invalid recipe.
+    """
+    offending = sorted(
+        s for s in candidate_outputs if body_symbol_map.is_input_alias(s)
+    )
+    if offending:
+        raise ValueError(
+            f"A {control_kind} body assigns workflow input(s) directly to symbol(s) "
+            f"{offending} that must become {control_kind} outputs. Route the value "
+            f"through a node instead of aliasing an input."
+        )

--- a/src/flowrep/parsers/symbol_scope.py
+++ b/src/flowrep/parsers/symbol_scope.py
@@ -48,6 +48,7 @@ class SymbolScope(Mapping[str, edge_models.InputSource | edge_models.SourceHandl
         self._consumptions: list[SymbolConsumption] = []
         self._productions: list[SymbolProduction] = []
         self.reassigned_symbols: list[str] = []
+        self.input_aliases: set[str] = set()
         self.declared_accumulators: set[str] = set()
         self.available_accumulators: set[str] = (
             set() if available_accumulators is None else available_accumulators
@@ -59,14 +60,15 @@ class SymbolScope(Mapping[str, edge_models.InputSource | edge_models.SourceHandl
 
     @property
     def inputs(self) -> list[str]:
-        """Ordered unique symbols consumed from InputSources."""
+        """Ordered unique input ports consumed from InputSources."""
         seen: set[str] = set()
         result: list[str] = []
         for c in self._consumptions:
-            if isinstance(c.source, edge_models.InputSource) and c.symbol not in seen:
-                seen.add(c.symbol)
-                result.append(c.symbol)
-            # TODO: Just set.add it?
+            if isinstance(c.source, edge_models.InputSource):
+                port = c.source.port
+                if port not in seen:
+                    seen.add(port)
+                    result.append(port)
         return result
 
     @property
@@ -169,6 +171,37 @@ class SymbolScope(Mapping[str, edge_models.InputSource | edge_models.SourceHandl
                 for sym, port in zip(new_symbols, child.node.outputs, strict=True)
             }
         )
+
+    def alias(self, new_symbol: str, existing_symbol: str) -> None:
+        """Bind *new_symbol* to the same source as *existing_symbol* (``y = x``).
+
+        No node is created; the source is copied. Re-assigning a symbol that was
+        declared as an accumulator de-registers it. Aliasing *from* an
+        accumulator is rejected, since accumulators are name-tracked rather than
+        sourced.
+        """
+        if existing_symbol in self.all_accumulators:
+            raise ValueError(
+                f"Cannot alias accumulator '{existing_symbol}'. Accumulators are "
+                f"declared directly with `name = []`; hanging a second name on one "
+                f"is not supported."
+            )
+        try:
+            source = self[existing_symbol]
+        except KeyError as error:
+            raise ValueError(str(error)) from None
+        self.declared_accumulators.discard(new_symbol)
+        if new_symbol in self._sources and new_symbol not in self.reassigned_symbols:
+            self.reassigned_symbols.append(new_symbol)
+        self._sources[new_symbol] = source
+        if isinstance(source, edge_models.InputSource):
+            self.input_aliases.add(new_symbol)
+        else:
+            self.input_aliases.discard(new_symbol)
+
+    def is_input_alias(self, symbol: str) -> bool:
+        """True if *symbol* was aliased directly to a workflow input."""
+        return symbol in self.input_aliases
 
     def register_accumulator(self, new: str) -> None:
         if new in self._sources:

--- a/src/flowrep/parsers/while_parser.py
+++ b/src/flowrep/parsers/while_parser.py
@@ -4,7 +4,7 @@ import ast
 from ast import While
 
 from flowrep import edge_models
-from flowrep.parsers import case_helpers, parser_protocol
+from flowrep.parsers import case_helpers, parser_helpers, parser_protocol
 from flowrep.prospective import constant_recipe, helper_models, while_recipe
 
 WHILE_CONDITION_LABEL: str = "condition"
@@ -41,6 +41,9 @@ def parse_while_node(
     reassigned_symbols = body_walker.symbol_map.reassigned_symbols
 
     _validate_some_output_exists(reassigned_symbols)
+    parser_helpers.reject_input_alias_outputs(
+        body_walker.symbol_map, reassigned_symbols, "while-loop"
+    )
     body_walker.symbol_map.produce_symbols(reassigned_symbols)
 
     inputs, input_edges = _wire_inputs(

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -300,6 +300,14 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             self.symbol_map.register(
                 new_symbols, helper_models.LabeledRecipe(label=label, node=node)
             )
+        elif isinstance(rhs, ast.Name):
+            if len(new_symbols) != 1:
+                raise ValueError(
+                    f"Alias assignment must target exactly one symbol, "
+                    f"got {new_symbols}. Try breaking apart declaration -- "
+                    f"`a, b = c, d` --> `a = c; b = d`."
+                )
+            self.symbol_map.alias(new_symbols[0], rhs.id)
         else:
             raise ValueError(
                 f"Workflow python definitions can only interpret assignments with "

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -303,9 +303,8 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         elif isinstance(rhs, ast.Name):
             if len(new_symbols) != 1:
                 raise ValueError(
-                    f"Alias assignment must target exactly one symbol, "
-                    f"got {new_symbols}. Try breaking apart declaration -- "
-                    f"`a, b = c, d` --> `a = c; b = d`."
+                    f"Alias assignment must target exactly one symbol -- no unpacking "
+                    f"raw symbols -- got {new_symbols}."
                 )
             self.symbol_map.alias(new_symbols[0], rhs.id)
         else:

--- a/tests/integration/parsers/test_parsing_reassignment.py
+++ b/tests/integration/parsers/test_parsing_reassignment.py
@@ -1,0 +1,286 @@
+import unittest
+
+from flowrep import edge_models
+from flowrep.parsers import workflow_parser
+
+from flowrep_static import library
+
+
+def _parse(func):
+    return workflow_parser.parse_workflow(func)
+
+
+class TestAliasHappyPath(unittest.TestCase):
+    def test_alias_of_input_matches_direct_return_but_relabels(self):
+        def direct(x):
+            return x
+
+        def aliased(x):
+            y = x
+            return y
+
+        direct_recipe = _parse(direct)
+        aliased_recipe = _parse(aliased)
+
+        self.assertEqual(direct_recipe.outputs, ["x"])
+        self.assertEqual(aliased_recipe.outputs, ["y"])
+        # The only difference is the output port label: both pass input `x`
+        # straight through to their single output.
+        self.assertEqual(
+            list(direct_recipe.output_edges.values()),
+            list(aliased_recipe.output_edges.values()),
+        )
+        self.assertEqual(aliased_recipe.nodes, {})
+
+    def test_chained_alias_resolves_to_original_input(self):
+        def macro(x):
+            y = x
+            z = y
+            return z
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["z"])
+        self.assertEqual(recipe.nodes, {})
+        # Sole output edge sources from input `x`.
+        (source,) = recipe.output_edges.values()
+        self.assertEqual(source.port, "x")
+
+    def test_alias_of_node_output(self):
+        def macro(a, b):
+            y = library.my_add(a, b)
+            z = y
+            return z
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["z"])
+        (source,) = recipe.output_edges.values()
+        self.assertEqual((source.node, source.port), ("my_add_0", "output_0"))
+
+    def test_local_alias_then_consumed(self):
+        def macro(a, b):
+            y = a
+            z = library.my_add(y, b)
+            return z
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["z"])
+        # my_add's `a` input is fed by workflow input `a` (through the alias).
+        add_a = recipe.input_edges[edge_models.TargetHandle(node="my_add_0", port="a")]
+        self.assertEqual(add_a.port, "a")
+
+    def test_self_alias_is_noop(self):
+        def macro(x):
+            x = x
+            return x
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["x"])
+        self.assertEqual(recipe.nodes, {})
+
+    def test_alias_with_explicit_output_label(self):
+        def macro(x):
+            y = x
+            return y
+
+        recipe = workflow_parser.parse_workflow(macro, "out")
+        self.assertEqual(recipe.outputs, ["out"])
+
+
+class TestAliasNonRegression(unittest.TestCase):
+    def test_binop_rhs_still_raises(self):
+        def macro(x):
+            y = x + 1
+            return y
+
+        with self.assertRaises(ValueError):
+            _parse(macro)
+
+    def test_attribute_rhs_still_raises(self):
+        def macro(x):
+            y = x.real
+            return y
+
+        with self.assertRaises(ValueError):
+            _parse(macro)
+
+    def test_alias_to_undefined_symbol_raises(self):
+        def macro(x):
+            y = w  # noqa: F821
+            return y
+
+        with self.assertRaises(ValueError):
+            _parse(macro)
+
+    def test_constant_rebinding(self):
+        def macro():
+            y = 5
+            y = 6
+            return y
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["y"])
+        # Two constant nodes exist; the output sources from the second.
+        self.assertEqual(len(recipe.nodes), 2)
+
+
+class TestAliasAccumulatorInteractions(unittest.TestCase):
+    def test_reassigning_accumulator_breaks_later_append(self):
+        def macro(xs, shift=1):
+            ys = []
+            ys = shift  # de-registers the accumulator
+            for x in xs:
+                y = library.my_add(x, shift)  # noqa: F841
+                ys.append(x)
+            return ys
+
+        with self.assertRaises(ValueError) as ctx:
+            _parse(macro)
+        self.assertIn("accumulator", str(ctx.exception).lower())
+
+    def test_deregister_allows_independent_accumulator(self):
+        def macro(xs, shift=1):
+            ys = []
+            ys = shift  # ys becomes a plain alias of `shift`
+            zs = []
+            for x in xs:
+                z = library.my_add(x, shift)
+                zs.append(z)
+            return zs, ys
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["zs", "ys"])
+
+    def test_alias_from_accumulator_is_rejected(self):
+        def macro(xs):
+            ys = []
+            zs = ys  # aliasing an accumulator -> error
+            for x in xs:
+                zs.append(x)
+            return zs
+
+        with self.assertRaises(ValueError) as ctx:
+            _parse(macro)
+        self.assertIn("accumulator", str(ctx.exception).lower())
+
+    def test_appending_to_input_alias_is_rejected(self):
+        def macro(xs):
+            ys = xs  # plain input alias, NOT an accumulator
+            for x in xs:
+                ys.append(x)
+            return ys
+
+        with self.assertRaises(ValueError):
+            _parse(macro)
+
+
+class TestAliasForLoopInteractions(unittest.TestCase):
+    def test_alias_the_iterable(self):
+        def macro(xs):
+            zs = xs
+            acc = []
+            for x in zs:
+                y = library.identity(x)
+                acc.append(y)
+            return acc
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["acc"])
+        # The for-node's iterated input resolves back to workflow input `xs`.
+        (for_label,) = [k for k, v in recipe.nodes.items() if k.startswith("for_each")]
+        edge = recipe.edges | recipe.input_edges  # noqa: F841
+        iterated = [
+            src for tgt, src in recipe.input_edges.items() if tgt.node == for_label
+        ]
+        self.assertTrue(any(getattr(s, "port", None) == "xs" for s in iterated))
+
+    def test_new_symbol_alias_inside_body(self):
+        def macro(xs):
+            acc = []
+            for x in xs:
+                y = x
+                z = library.identity(y)
+                acc.append(z)
+            return acc
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["acc"])
+
+    def test_alias_rebinding_enclosing_symbol_is_leaked_reassignment(self):
+        def macro(xs, w):
+            acc = []
+            for x in xs:
+                w = x  # noqa: F841
+                # ^^ reassigns an enclosing symbol via alias -> leak
+                z = library.identity(x)
+                acc.append(z)
+            return acc
+
+        with self.assertRaises(ValueError) as ctx:
+            _parse(macro)
+        self.assertIn("reassign", str(ctx.exception).lower())
+
+
+class TestAliasWhileLoopInteractions(unittest.TestCase):
+    def test_alias_rebind_of_loop_carried_variable(self):
+        def macro(y):
+            while library.is_positive(y):
+                z = library.decrement(y)
+                y = z  # loop-carried via alias to a node output
+            return y
+
+        recipe = _parse(macro)
+        (while_label,) = [k for k in recipe.nodes if k.startswith("while")]
+        self.assertEqual(recipe.nodes[while_label].outputs, ["y"])
+
+    def test_new_symbol_alias_not_a_loop_output(self):
+        def macro(x):
+            while library.is_positive(x):
+                x = library.decrement(x)
+                y = x  # noqa: F841
+                # ^^ new alias, not reassigned -> not a loop output
+            return x
+
+        recipe = _parse(macro)
+        (while_label,) = [k for k in recipe.nodes if k.startswith("while")]
+        self.assertEqual(recipe.nodes[while_label].outputs, ["x"])
+
+    def test_input_alias_as_loop_output_raises(self):
+        def macro(x, seed):
+            while library.is_positive(x):
+                x = library.decrement(x)
+                x = seed  # rebinds loop-carried x to a broadcast input
+            return x
+
+        with self.assertRaises(ValueError) as ctx:
+            _parse(macro)
+        self.assertIn("input", str(ctx.exception).lower())
+
+
+class TestAliasBranchInteractions(unittest.TestCase):
+    def test_local_alias_in_branch_consumed_downstream(self):
+        def macro(a, x):
+            if library.is_positive(a):
+                w = x  # local alias, consumed -> never a branch output
+                y = library.identity(w)
+            else:
+                y = library.decrement(x)
+            return y
+
+        recipe = _parse(macro)
+        self.assertEqual(recipe.outputs, ["y"])
+
+    def test_cross_branch_input_alias_output_raises(self):
+        def macro(a, x, z):
+            if library.is_positive(a):  # noqa: SIM108
+                y = library.identity(x)  # node output
+            else:
+                y = z  # input alias -> would-be output disagrees across branches
+            return y
+
+        with self.assertRaises(ValueError) as ctx:
+            _parse(macro)
+        self.assertIn("input", str(ctx.exception).lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/parsers/test_parsing_reassignment.py
+++ b/tests/integration/parsers/test_parsing_reassignment.py
@@ -87,6 +87,14 @@ class TestAliasHappyPath(unittest.TestCase):
 
 
 class TestAliasNonRegression(unittest.TestCase):
+    def test_unpacking_rhs_raises(self):
+        def macro(x):
+            a, b = x
+            return a, b
+
+        with self.assertRaisesRegex(ValueError, "no unpacking raw symbols"):
+            _parse(macro)
+
     def test_binop_rhs_still_raises(self):
         def macro(x):
             y = x + 1

--- a/tests/unit/parsers/test_symbol_scope.py
+++ b/tests/unit/parsers/test_symbol_scope.py
@@ -290,5 +290,79 @@ class TestSymbolScopeErrors(unittest.TestCase):
         )
 
 
+class TestSymbolScopeAlias(unittest.TestCase):
+    def test_alias_copies_input_source(self):
+        scope = SymbolScope({"x": _make_input("x")})
+        scope.alias("y", "x")
+        self.assertEqual(scope["y"], _make_input("x"))
+        self.assertTrue(scope.is_input_alias("y"))
+
+    def test_alias_copies_source_handle(self):
+        scope = SymbolScope({"a": _make_source("node_0", "out")})
+        scope.alias("b", "a")
+        self.assertEqual(scope["b"], _make_source("node_0", "out"))
+        self.assertFalse(scope.is_input_alias("b"))
+
+    def test_alias_chain_follows_original_source(self):
+        scope = SymbolScope({"x": _make_input("x")})
+        scope.alias("y", "x")
+        scope.alias("z", "y")
+        self.assertEqual(scope["z"], _make_input("x"))
+        self.assertTrue(scope.is_input_alias("z"))
+
+    def test_alias_unknown_symbol_raises(self):
+        scope = SymbolScope({})
+        with self.assertRaises(ValueError) as ctx:
+            scope.alias("y", "missing")
+        self.assertIn("missing", str(ctx.exception))
+
+    def test_alias_reassignment_is_tracked(self):
+        scope = SymbolScope({"a": _make_input("a"), "b": _make_source("n0", "o")})
+        scope.alias("a", "b")
+        self.assertIn("a", scope.reassigned_symbols)
+        self.assertEqual(scope["a"], _make_source("n0", "o"))
+
+    def test_alias_over_declared_accumulator_deregisters_it(self):
+        scope = SymbolScope({"shift": _make_input("shift")})
+        scope.register_accumulator("ys")
+        scope.alias("ys", "shift")
+        self.assertNotIn("ys", scope.declared_accumulators)
+        self.assertEqual(scope["ys"], _make_input("shift"))
+
+    def test_alias_from_declared_accumulator_raises(self):
+        scope = SymbolScope({})
+        scope.register_accumulator("ys")
+        with self.assertRaises(ValueError) as ctx:
+            scope.alias("zs", "ys")
+        self.assertIn("accumulator", str(ctx.exception).lower())
+
+    def test_alias_from_available_accumulator_raises(self):
+        scope = SymbolScope({}, available_accumulators={"ys"})
+        with self.assertRaises(ValueError) as ctx:
+            scope.alias("zs", "ys")
+        self.assertIn("accumulator", str(ctx.exception).lower())
+
+    def test_realias_to_source_handle_clears_input_alias_flag(self):
+        scope = SymbolScope({"x": _make_input("x"), "n": _make_source("n0", "o")})
+        scope.alias("y", "x")
+        self.assertTrue(scope.is_input_alias("y"))
+        scope.alias("y", "n")
+        self.assertFalse(scope.is_input_alias("y"))
+
+    def test_fork_does_not_propagate_input_aliases(self):
+        scope = SymbolScope({"x": _make_input("x")})
+        scope.alias("y", "x")
+        child = scope.fork()
+        self.assertFalse(child.is_input_alias("y"))
+        self.assertEqual(child.input_aliases, set())
+
+    def test_inputs_reports_source_port_not_alias_name(self):
+        scope = SymbolScope({"x": _make_input("x")})
+        scope.alias("y", "x")
+        scope.consume("y", "node_0", "arg")
+        # The consumed input is workflow input `x`, not the local alias `y`.
+        self.assertEqual(scope.inputs, ["x"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
With safeguards against interactions in flow controls: no reassigning to accumulators; no conditionals leaking input sources.

I.e. this is now allowed

```python
import flowrep as fr

@fr.workflow
def macro(x):
    y = x
    return y
```

The compiler even nicely catches the name change while simplifying the code

```python
print(
    fr.tools.flowrep2python(
        macro.flowrep_recipe.model_copy(
            update={"reference": None}
        )
    ).source
)
```

```python
from __future__ import annotations

import flowrep
import typing

@flowrep.workflow("y")
def compiled_from_workflow_recipe(x):
    return x
```