### PR TITLE
Parse classes as atomic recipes

### DIFF
--- a/src/flowrep/base_models.py
+++ b/src/flowrep/base_models.py
@@ -62,6 +62,30 @@ def validate_unique(v: list[T], message: str | None = None) -> list[T]:
     return v
 
 
+def ensure_class_signature_from_init(cls: type, context: str) -> None:
+    """Reject classes whose constructor signature comes from ``__new__``.
+
+    Flowrep derives a class's input parameter names and defaults from
+    ``inspect.signature(cls)`` but reads their annotations from
+    ``cls.__init__``. For classes that define their signature via ``__new__``
+    (e.g. :class:`typing.NamedTuple`, or any class overriding ``__new__``
+    without a corresponding ``__init__``), these two sources disagree and
+    annotations would silently be dropped. Fail loudly instead.
+
+    Args:
+        cls: The class being introspected.
+        context: A short label for the caller (e.g. ``"@atomic"`` or a fully
+            qualified name) used in the error message.
+    """
+    if cls.__init__ is object.__init__ and cls.__new__ is not object.__new__:  # type: ignore[misc, comparison-overlap]
+        raise TypeError(
+            f"{context} cannot introspect {cls.__name__!r}: its constructor "
+            f"signature is defined via __new__ (e.g. NamedTuple or a custom "
+            f"__new__), so flowrep cannot read input annotations from __init__. "
+            f"Define an __init__ with annotated parameters instead."
+        )
+
+
 UniqueList = Annotated[list[T], pydantic.AfterValidator(validate_unique)]
 # We want the ordered property of a list -- especially during round-trip serialization
 # But also the "one of each element" property of a list

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -1,9 +1,17 @@
 import ast
 import dataclasses
 import inspect
+import types
 from collections.abc import Callable, Iterable
-from types import FunctionType
-from typing import Annotated, cast, get_args, get_origin, get_type_hints
+from typing import (
+    Annotated,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+    overload,
+)
 
 from pyiron_snippets import versions
 
@@ -12,9 +20,14 @@ from flowrep.parsers import label_helpers, object_scope, parser_helpers
 from flowrep.parsers.label_helpers import default_output_label
 from flowrep.prospective import atomic_recipe, helper_models
 
+_AtomicTarget = TypeVar("_AtomicTarget", bound=types.FunctionType | type)
 
+
+@overload
+def atomic(func: _AtomicTarget, /) -> _AtomicTarget: ...
+@overload
 def atomic(
-    func: FunctionType | str | None = None,
+    func: str | None = None,
     /,
     *output_labels: str,
     unpack_mode: atomic_recipe.UnpackMode = atomic_recipe.UnpackMode.TUPLE,
@@ -22,7 +35,8 @@ def atomic(
     forbid_main: bool = False,
     forbid_locals: bool = False,
     require_version: bool = False,
-) -> FunctionType | Callable[[FunctionType], FunctionType]:
+) -> Callable[[_AtomicTarget], _AtomicTarget]: ...
+def atomic(func=None, /, *output_labels, **kwargs):
     """
     Decorator that attaches a :class:`~flowrep.models.nodes.atomic_recipe.AtomicRecipe`
     to the ``flowrep_recipe`` attribute of a function.
@@ -56,23 +70,21 @@ def atomic(
         :class:`~flowrep.models.nodes.atomic_recipe.AtomicRecipe`.
     """
 
-    def wrap(f: FunctionType, labels: tuple[str, ...]) -> FunctionType:
-        f.flowrep_recipe = parse_atomic(  # type: ignore[attr-defined]
-            f,
-            *labels,
-            unpack_mode=unpack_mode,
-            version_scraping=version_scraping,
-            forbid_main=forbid_main,
-            forbid_locals=forbid_locals,
-            require_version=require_version,
-        )
+    def wrap(f, labels):
+        f.flowrep_recipe = parse_atomic(f, *labels, **kwargs)
         return f
 
-    return parser_helpers.apply_label_decorator(func, output_labels, wrap, "@atomic")
+    return parser_helpers.apply_label_decorator(
+        func,
+        output_labels,
+        wrap=wrap,
+        decorator_name="@atomic",
+        allowed_types=(types.FunctionType, type),
+    )
 
 
 def parse_atomic(
-    func: FunctionType,
+    func: types.FunctionType | type,
     *output_labels: str,
     unpack_mode: atomic_recipe.UnpackMode = atomic_recipe.UnpackMode.TUPLE,
     version_scraping: versions.VersionScrapingMap | None = None,
@@ -118,7 +130,11 @@ def parse_atomic(
     sig_info = parser_helpers.SignatureInfo.of(func)
     docstring = inspect.getdoc(func)
 
-    scraped_output_labels = _get_output_labels(func, unpack_mode)
+    scraped_output_labels = (
+        ["instance"]
+        if isinstance(func, type)
+        else _get_output_labels(func, unpack_mode)
+    )
     if len(output_labels) > 0 and len(output_labels) != len(scraped_output_labels):
         raise ValueError(
             "Explicitly provided output labels must match the function analysis and "
@@ -143,7 +159,7 @@ def parse_atomic(
 
 
 def _get_output_labels(
-    func: FunctionType, unpack_mode: atomic_recipe.UnpackMode
+    func: types.FunctionType, unpack_mode: atomic_recipe.UnpackMode
 ) -> list[str]:
     if unpack_mode == atomic_recipe.UnpackMode.NONE:
         return _parse_return_label_without_unpacking(func)
@@ -157,7 +173,7 @@ def _get_output_labels(
     )
 
 
-def _parse_return_label_without_unpacking(func: FunctionType) -> list[str]:
+def _parse_return_label_without_unpacking(func: types.FunctionType) -> list[str]:
     """
     Get output label for UnpackMode.NONE.
 
@@ -178,7 +194,7 @@ def _parse_return_label_without_unpacking(func: FunctionType) -> list[str]:
     return [label] if label is not None else [label_helpers.default_output_label(0)]
 
 
-def _parse_tuple_return_labels(func: FunctionType) -> list[str]:
+def _parse_tuple_return_labels(func: types.FunctionType) -> list[str]:
     func_node = parser_helpers.get_ast_function_node(func)
     return_labels = _extract_combined_return_labels(func_node)
     if not all(len(ret) == len(return_labels[0]) for ret in return_labels):
@@ -233,7 +249,7 @@ def _extract_return_labels(ret: ast.Return) -> tuple[str, ...]:
         )
 
 
-def _parse_dataclass_return_labels(func: FunctionType) -> list[str]:
+def _parse_dataclass_return_labels(func: types.FunctionType) -> list[str]:
     source_code_return = _parse_tuple_return_labels(func)
     if len(source_code_return) != 1:
         raise ValueError(
@@ -277,8 +293,8 @@ def get_labeled_recipe(
     else:
         # Otherwise we're going to find it has already been parsed as a recipe,
         # or we're going to parse it as a recipe -- either way, it had better be a
-        # FunctionType!
-        function_call = cast(FunctionType, child_call)
+        # types.FunctionType!
+        function_call = cast(types.FunctionType, child_call)
         label_prefix = function_call.__name__
         if hasattr(function_call, "flowrep_recipe"):
             child_recipe = function_call.flowrep_recipe

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -71,6 +71,8 @@ def atomic(func=None, /, *output_labels, **kwargs):
     """
 
     def wrap(f, labels):
+        if isinstance(f, type):
+            _ensure_recipe_attribute_free(f, "@atomic")
         f.flowrep_recipe = parse_atomic(f, *labels, **kwargs)
         return f
 
@@ -81,6 +83,30 @@ def atomic(func=None, /, *output_labels, **kwargs):
         decorator_name="@atomic",
         allowed_types=(types.FunctionType, type),
     )
+
+
+def _ensure_recipe_attribute_free(cls: type, context: str) -> None:
+    """Reject classes that already bind ``flowrep_recipe`` at class level.
+
+    Decorating a class attaches the parsed recipe to its ``flowrep_recipe``
+    attribute. If the class body already defines that name (a class variable,
+    method, etc.), attaching would silently clobber it. Fail loudly instead.
+
+    Only attributes defined directly on ``cls`` are considered, so decorating a
+    subclass of an already-decorated class remains allowed (it simply shadows
+    the inherited recipe with its own).
+
+    Args:
+        cls: The class about to receive the recipe.
+        context: A short label for the caller (e.g. ``"@atomic"``) used in the
+            error message.
+    """
+    if "flowrep_recipe" in cls.__dict__:
+        raise TypeError(
+            f"{context} cannot decorate {cls.__name__!r}: it already defines a "
+            f"class-level 'flowrep_recipe' attribute, which is needed to hold the "
+            f"parsed recipe. Rename that member."
+        )
 
 
 def parse_atomic(

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -120,6 +120,9 @@ def parse_atomic(
         ValueError: If ``output_labels`` length mismatches the inferred output count,
             or if any ``forbid_*`` / ``require_*`` constraint is violated.
     """
+    if isinstance(func, type):
+        base_models.ensure_class_signature_from_init(func, "@atomic")
+
     function_info = versions.VersionInfo.of(
         func,
         version_scraping=version_scraping,

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -6,7 +6,7 @@ import inspect
 import textwrap
 from collections.abc import Callable, Iterable
 from types import FunctionType
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from flowrep import base_models, edge_models
 from flowrep.parsers import constant_parser, label_helpers, symbol_scope
@@ -16,35 +16,56 @@ from flowrep.prospective import constant_recipe, helper_models, union_types
 class SourceCodeUnavailableError(ValueError): ...
 
 
+_D = TypeVar("_D")
+
+
 def apply_label_decorator(
-    func: FunctionType | str | None,
+    func: _D | str | None,
     output_labels: tuple[str, ...],
-    wrap: Callable[[FunctionType, tuple[str, ...]], FunctionType],
+    *,
+    wrap: Callable[[_D, tuple[str, ...]], _D],
     decorator_name: str,
-) -> FunctionType | Callable[[FunctionType], FunctionType]:
-    """Dispatch bare ``@deco`` vs. parametrized ``@deco("label", ...)``.
+    allowed_types: tuple[type, ...],
+) -> _D | Callable[[_D], _D]:
+    if not isinstance(func, str | None):
+        func = _normalize_target(func, decorator_name)
 
-    ``wrap(f, labels)`` attaches the recipe to ``f`` and returns it.
-    """
-    if isinstance(func, FunctionType):
-        return wrap(func, ())
-    if func is not None and not isinstance(func, str):
-        raise TypeError(
-            f"{decorator_name} can only decorate functions, got {type(func).__name__}"
-        )
-    labels = output_labels if func is None else (func, *output_labels)
+    if isinstance(func, allowed_types):
+        return wrap(cast("_D", func), ())
+    elif func is None:
+        labels = output_labels
+    elif isinstance(func, str):
+        labels = (func, *output_labels)
+    else:
+        _ensure_allowed(func, allowed_types, decorator_name)
 
-    def deferred(f: FunctionType) -> FunctionType:
-        ensure_function(f, decorator_name)
+    def deferred(f: _D) -> _D:
+        f = _normalize_target(f, decorator_name)
+        _ensure_allowed(f, allowed_types, decorator_name)
         return wrap(f, labels)
 
     return deferred
 
 
-def ensure_function(f: Any, decorator_name: str) -> None:
-    if not isinstance(f, FunctionType):
+def _normalize_target(f: Any, decorator_name: str) -> Any:
+    if isinstance(f, classmethod):
         raise TypeError(
-            f"{decorator_name} can only decorate functions, got {type(f).__name__}"
+            f"{decorator_name} cannot decorate a classmethod: its `cls` is bound "
+            f"away at access time and won't match the parsed inputs. Apply "
+            f"@classmethod outside {decorator_name}, or use @staticmethod."
+        )
+    if isinstance(f, staticmethod):
+        return f.__func__  # a plain FunctionType — attribute-settable, full signature
+    return f
+
+
+def _ensure_allowed(
+    f: Any, allowed_types: tuple[type, ...], decorator_name: str
+) -> None:
+    if not isinstance(f, allowed_types):
+        allowed = " or ".join(t.__name__ for t in allowed_types)
+        raise TypeError(
+            f"{decorator_name!r} can only decorate {allowed!r}, got {type(f).__name__!r}"
         )
 
 
@@ -89,7 +110,7 @@ class SignatureInfo:
     have_restricted_kinds: dict[str, base_models.RestrictedParamKind]
 
     @classmethod
-    def of(cls, func: FunctionType) -> SignatureInfo:
+    def of(cls, func: FunctionType | type) -> SignatureInfo:
         sig = inspect.signature(func)
         return SignatureInfo(
             names=list(sig.parameters.keys()),

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -55,7 +55,7 @@ def _normalize_target(f: Any, decorator_name: str) -> Any:
             f"@classmethod outside {decorator_name}, or use @staticmethod."
         )
     if isinstance(f, staticmethod):
-        return f.__func__  # a plain FunctionType — attribute-settable, full signature
+        raise TypeError(f"{decorator_name} should be placed beneath `@staticmethod`.")
     return f
 
 

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import ast
 import importlib
 import inspect
+import types
 from collections.abc import Callable, Collection
-from types import FunctionType
-from typing import cast
+from typing import TypeVar, cast, overload
 
 from pyiron_snippets import versions
 
@@ -30,16 +30,22 @@ from flowrep.prospective import (
     workflow_recipe,
 )
 
+_WorkflowTarget = TypeVar("_WorkflowTarget", bound=types.FunctionType)
 
+
+@overload
+def workflow(func: _WorkflowTarget, /) -> _WorkflowTarget: ...
+@overload
 def workflow(
-    func: FunctionType | str | None = None,
+    func: str | None = None,
     /,
     *output_labels: str,
     version_scraping: versions.VersionScrapingMap | None = None,
     forbid_main: bool = False,
     forbid_locals: bool = False,
     require_version: bool = False,
-) -> FunctionType | Callable[[FunctionType], FunctionType]:
+) -> Callable[[_WorkflowTarget], _WorkflowTarget]: ...
+def workflow(func=None, /, *output_labels: str, **kwargs):
     """
     Decorator that attaches a :class:`~flowrep.models.nodes.workflow_recipe.WorkflowRecipe`
     to the ``flowrep_recipe`` attribute of a function, under constraints that the
@@ -70,22 +76,21 @@ def workflow(
         :class:`~flowrep.models.nodes.workflow_recipe.WorkflowRecipe`.
     """
 
-    def wrap(f: FunctionType, labels: tuple[str, ...]) -> FunctionType:
-        f.flowrep_recipe = parse_workflow(  # type: ignore[attr-defined]
-            f,
-            *labels,
-            version_scraping=version_scraping,
-            forbid_main=forbid_main,
-            forbid_locals=forbid_locals,
-            require_version=require_version,
-        )
+    def wrap(f, labels):
+        f.flowrep_recipe = parse_workflow(f, *labels, **kwargs)
         return f
 
-    return parser_helpers.apply_label_decorator(func, output_labels, wrap, "@workflow")
+    return parser_helpers.apply_label_decorator(
+        func,
+        output_labels,
+        wrap=wrap,
+        decorator_name="@workflow",
+        allowed_types=(types.FunctionType,),
+    )
 
 
 def parse_workflow(
-    func: FunctionType,
+    func: types.FunctionType,
     *output_labels: str,
     version_scraping: versions.VersionScrapingMap | None = None,
     forbid_main: bool = False,
@@ -435,7 +440,7 @@ class _WorkflowFunctionParser(WorkflowParser):
         info_factory: versions.VersionInfoFactory,
         *,
         source: base_models.PythonReference | None = None,
-        func: FunctionType,
+        func: types.FunctionType,
         output_labels: Collection[str],
     ):
         super().__init__(
@@ -463,7 +468,7 @@ class _WorkflowFunctionParser(WorkflowParser):
     def handle_return(
         self,
         body: ast.Return,
-        func: FunctionType,
+        func: types.FunctionType,
         output_labels: Collection[str],
     ) -> None:
         returned_symbols = parser_helpers.resolve_symbols_to_strings(body.value)

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -260,6 +260,7 @@ def _parse_function(
     function = retrieve.import_from_string(fully_qualified_name)
     try:
         if isinstance(function, type):
+            base_models.ensure_class_signature_from_init(function, fully_qualified_name)
             hints = get_type_hints(
                 getattr(function, "__init__"), include_extras=True  # noqa: B009
             )

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -259,7 +259,14 @@ def _parse_function(
 ]:
     function = retrieve.import_from_string(fully_qualified_name)
     try:
-        hints = get_type_hints(function, include_extras=True)
+        if isinstance(function, type):
+            hints = get_type_hints(
+                getattr(function, "__init__"), include_extras=True  # noqa: B009
+            )
+            subst = _typevar_map(function)
+            hints = {k: subst.get(v, v) for k, v in hints.items()}
+        else:
+            hints = get_type_hints(function, include_extras=True)
     except NameError as e:
         raise NameError(
             f"While parsing {fully_qualified_name!r} for recipe inputs {inputs} and "
@@ -289,7 +296,8 @@ def _parse_function(
     missing = set(inputs) - available
     if missing and not accept_extra_inputs:
         raise ValueError(
-            f"Requested inputs {missing} not found in signature of {fully_qualified_name!r}"
+            f"Requested inputs {missing} not found in signature of "
+            f"{fully_qualified_name!r}. Available: {available!r}."
         )
 
     input_ports: dict[str, InputDataPort] = {}
@@ -314,7 +322,26 @@ def _parse_function(
     elif unpack_mode == atomic_recipe.UnpackMode.DATACLASS:
         output_ports = _parse_return_dataclass(return_annotation, outputs)
 
+    if isinstance(function, type):
+        output_ports[next(iter(output_ports))].annotation = function
+
     return function, input_ports, output_ports
+
+
+def _typevar_map(cls: type) -> dict[TypeVar, object]:
+    """Map TypeVars to concrete args from a class's specialized bases.
+
+    Walks ``__orig_bases__`` (e.g. ``MyGeneric[int]``) and pairs each origin's
+    declared ``__parameters__`` with the supplied ``__args__``.
+    """
+    mapping: dict[TypeVar, object] = {}
+    for base in getattr(cls, "__orig_bases__", ()):
+        origin = get_origin(base)
+        params = getattr(origin, "__parameters__", ())
+        args = get_args(base)
+        if params and len(params) == len(args):
+            mapping.update(zip(params, args, strict=True))
+    return mapping
 
 
 def _parse_return_without_unpacking(

--- a/tests/integration/parsers/test_parsing_atomic_classes.py
+++ b/tests/integration/parsers/test_parsing_atomic_classes.py
@@ -1,0 +1,158 @@
+"""
+End-to-end coverage of the ways ``@atomic`` can decorate class-ish targets.
+
+Every target must be defined at module scope: :func:`flowrep.wfms.run_recipe`
+resolves references by fully-qualified name at run time, so ``<locals>`` targets
+cannot be executed.
+
+Note that ``@atomic`` on a ``classmethod`` is *rejected* (its ``cls`` is bound
+away at access time); that failure case lives in the unit tests, not here.
+"""
+
+import dataclasses
+import numbers
+import unittest
+from typing import Generic, TypeVar
+
+import flowrep as fr
+from flowrep import base_models
+from flowrep.retrospective.datastructures import NotData
+
+_KEYWORD_ONLY = base_models.RestrictedParamKind.KEYWORD_ONLY
+
+
+@fr.atomic
+class Widget:
+    def __init__(self, *, x: int = 100):
+        self.x = x
+
+    @fr.atomic
+    def add(self, y):
+        self.x += y
+        return self.x
+
+    @staticmethod
+    @fr.atomic
+    def triple(a: str):
+        return 3 * a
+
+
+@fr.atomic
+@dataclasses.dataclass
+class Point:
+    x: int = 42
+
+
+_TBoundInt = TypeVar("_TBoundInt", bound=int)
+
+
+class GenericHolder(Generic[_TBoundInt]):
+    def __init__(self, x: _TBoundInt):
+        self.x = x
+
+
+@fr.atomic
+class ConcreteHolder(GenericHolder[int]): ...
+
+
+_TReal = TypeVar("_TReal", bound=numbers.Real)
+_UReal = TypeVar("_UReal", bound=numbers.Real)
+
+
+class DeepBase(Generic[_TReal]):
+    def __init__(self, x: _TReal):
+        self.x = x
+
+
+class DeepMiddle(DeepBase[_UReal], Generic[_UReal]):
+    """Re-exports the type parameter under a new name."""
+
+
+@fr.atomic
+class DeepTwoLevel(DeepMiddle[int]):
+    """Binds ``_UReal -> int``; resolving ``_TReal`` needs two-level composition."""
+
+
+class TestAtomicMethod(unittest.TestCase):
+    def test_method_runs_and_mutates_self(self):
+        recipe = Widget.add.flowrep_recipe
+        widget = Widget(x=42)
+        out = fr.tools.run_recipe(recipe, self=widget, y=-2)
+        self.assertEqual(out.output_ports["output_0"].value, 40)
+        self.assertEqual(widget.x, 40, "The bound instance should be mutated in place")
+
+
+class TestAtomicStaticmethod(unittest.TestCase):
+    def test_staticmethod_preserved_and_runs(self):
+        self.assertIsInstance(Widget.__dict__["triple"], staticmethod)
+        recipe = Widget.triple.flowrep_recipe
+        out = fr.tools.run_recipe(recipe, a="foo")
+        self.assertEqual(out.output_ports["output_0"].value, "foofoofoo")
+
+
+class TestAtomicClass(unittest.TestCase):
+    def test_keyword_only_input_kind(self):
+        recipe = Widget.flowrep_recipe
+        self.assertEqual(recipe.reference.restricted_input_kinds, {"x": _KEYWORD_ONLY})
+
+    def test_input_port_and_instance_output(self):
+        out = fr.tools.run_recipe(Widget.flowrep_recipe, x=42)
+        port = out.input_ports["x"]
+        self.assertEqual(port.value, 42)
+        self.assertIs(port.annotation, int)
+        self.assertEqual(port.default, 100)
+
+        instance = out.output_ports["instance"]
+        self.assertIs(instance.annotation, Widget)
+        self.assertEqual(instance.value.x, 42)
+
+
+class TestAtomicDataclass(unittest.TestCase):
+    def test_dataclass_input_uses_default(self):
+        recipe = Point.flowrep_recipe
+        self.assertEqual(recipe.reference.restricted_input_kinds, {})
+        out = fr.tools.run_recipe(recipe)
+        port = out.input_ports["x"]
+        self.assertIsInstance(port.value, NotData)
+        self.assertIs(port.annotation, int)
+        self.assertEqual(port.default, 42)
+
+        instance = out.output_ports["instance"]
+        self.assertIs(instance.annotation, Point)
+        self.assertEqual(instance.value.x, 42)
+
+
+class TestAtomicConcreteGeneric(unittest.TestCase):
+    def test_typevar_resolves_to_concrete_arg(self):
+        out = fr.tools.run_recipe(ConcreteHolder.flowrep_recipe, x=100)
+        port = out.input_ports["x"]
+        self.assertEqual(port.value, 100)
+        self.assertIs(
+            port.annotation, int, "MyGeneric[int] should resolve _TBoundInt -> int"
+        )
+
+        instance = out.output_ports["instance"]
+        self.assertIs(instance.annotation, ConcreteHolder)
+        self.assertEqual(instance.value.x, 100)
+
+
+class TestAtomicDeepGenericLimitation(unittest.TestCase):
+    def test_two_level_typevar_stays_unresolved(self):
+        # Documents a known limitation: single-level ``__orig_bases__`` mapping
+        # cannot compose _TReal -> _UReal -> int, so the annotation stays a TypeVar.
+        out = fr.tools.run_recipe(DeepTwoLevel.flowrep_recipe, x=100)
+        port = out.input_ports["x"]
+        self.assertEqual(port.value, 100)
+        self.assertIsInstance(
+            port.annotation,
+            TypeVar,
+            msg="This doesn't document a desired behaviour -- it would be lovely if we "
+            "could resolve the int hint here -- this is just to document that "
+            "resolving generics to port annotations has limits in the current "
+            "implementation",
+        )
+        self.assertEqual(port.annotation.__name__, "_TReal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -243,6 +243,47 @@ class TestAtomicTypeValidation(unittest.TestCase):
 
         self.assertIn("__init__", str(ctx.exception))
 
+    def test_rejects_class_with_recipe_classvar(self):
+        with self.assertRaises(TypeError) as ctx:
+
+            @atomic_parser.atomic
+            class Collides:
+                flowrep_recipe = 5
+
+                def __init__(self, x: int = 1):
+                    self.x = x
+
+        self.assertIn("flowrep_recipe", str(ctx.exception))
+
+    def test_rejects_class_with_recipe_method(self):
+        with self.assertRaises(TypeError) as ctx:
+
+            @atomic_parser.atomic("instance")
+            class Collides:
+                def __init__(self, x: int = 1):
+                    self.x = x
+
+                def flowrep_recipe(self):
+                    pass
+
+        self.assertIn("flowrep_recipe", str(ctx.exception))
+
+    def test_subclass_of_decorated_class_allowed(self):
+        # The inherited recipe lives on the base's __dict__, not the subclass's,
+        # so decorating the subclass is fine and shadows it with its own recipe.
+        @atomic_parser.atomic
+        class Base:
+            def __init__(self, x: int = 1):
+                self.x = x
+
+        @atomic_parser.atomic
+        class Sub(Base):
+            def __init__(self, y: int = 2):
+                self.y = y
+
+        self.assertEqual(Base.flowrep_recipe.inputs, ["x"])
+        self.assertEqual(Sub.flowrep_recipe.inputs, ["y"])
+
 
 class TestAtomicWithOutputLabels(unittest.TestCase):
     def test_atomic_with_explicit_output_labels(self):

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -6,7 +6,7 @@ import inspect
 import textwrap
 import unittest
 from types import FunctionType
-from typing import Annotated
+from typing import Annotated, NamedTuple
 
 from flowrep import base_models
 from flowrep.parsers import atomic_parser, label_helpers, parser_helpers
@@ -171,6 +171,77 @@ class TestParseAtomic(unittest.TestCase):
 
         node = atomic_parser.parse_atomic(has_docstring)
         self.assertEqual(node.description, "Here's a docstring")
+
+
+class TestAtomicTypeValidation(unittest.TestCase):
+    def test_accepts_class(self):
+        @atomic_parser.atomic
+        class MyClass:
+            def __init__(self, x: int = 1):
+                self.x = x
+
+        self.assertTrue(hasattr(MyClass, "flowrep_recipe"))
+        self.assertEqual(MyClass.flowrep_recipe.inputs, ["x"])
+        self.assertEqual(MyClass.flowrep_recipe.outputs, ["instance"])
+
+    def test_rejects_callable_instance_bare(self):
+        class MyCallable:
+            def __call__(self):
+                pass
+
+        with self.assertRaises(TypeError) as ctx:
+            atomic_parser.atomic(MyCallable())
+        self.assertIn("can only decorate", str(ctx.exception))
+
+    def test_rejects_callable_instance_with_args(self):
+        class MyCallable:
+            def __call__(self):
+                pass
+
+        decorator = atomic_parser.atomic("output")
+        with self.assertRaises(TypeError) as ctx:
+            decorator(MyCallable())
+        self.assertIn("can only decorate", str(ctx.exception))
+
+    def test_rejects_classmethod_bare(self):
+        with self.assertRaises(TypeError) as ctx:
+
+            @atomic_parser.atomic
+            @classmethod
+            def method(cls):
+                pass
+
+        self.assertIn("cannot decorate a classmethod", str(ctx.exception))
+
+    def test_rejects_classmethod_with_args(self):
+        with self.assertRaises(TypeError) as ctx:
+
+            @atomic_parser.atomic("output")
+            @classmethod
+            def method(cls):
+                pass
+
+        self.assertIn("cannot decorate a classmethod", str(ctx.exception))
+
+    def test_rejects_new_based_class_bare(self):
+        with self.assertRaises(TypeError) as ctx:
+
+            @atomic_parser.atomic
+            class Point(NamedTuple):
+                x: int
+                y: int
+
+        self.assertIn("__init__", str(ctx.exception))
+
+    def test_rejects_new_based_class_with_args(self):
+        with self.assertRaises(TypeError) as ctx:
+
+            @atomic_parser.atomic("instance")
+            class MyNew:
+                def __new__(cls, a: int):
+                    return super().__new__(cls)
+
+        self.assertIn("__init__", str(ctx.exception))
 
 
 class TestAtomicWithOutputLabels(unittest.TestCase):

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -223,6 +223,22 @@ class TestAtomicTypeValidation(unittest.TestCase):
 
         self.assertIn("cannot decorate a classmethod", str(ctx.exception))
 
+    def test_rejects_staticmethod_bare(self):
+        with self.assertRaisesRegex(TypeError, "should be placed beneath"):
+
+            @atomic_parser.atomic
+            @staticmethod
+            def method(cls):
+                pass
+
+    def test_rejects_staticmethod_with_args(self):
+        with self.assertRaisesRegex(TypeError, "should be placed beneath"):
+
+            @atomic_parser.atomic("output")
+            @staticmethod
+            def method(cls):
+                pass
+
     def test_rejects_new_based_class_bare(self):
         with self.assertRaises(TypeError) as ctx:
 

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -173,45 +173,6 @@ class TestParseAtomic(unittest.TestCase):
         self.assertEqual(node.description, "Here's a docstring")
 
 
-class TestAtomicTypeValidation(unittest.TestCase):
-    def test_rejects_class_bare_decorator(self):
-        with self.assertRaises(TypeError) as ctx:
-
-            @atomic_parser.atomic
-            class MyClass:
-                pass
-
-        self.assertIn("@atomic can only decorate functions", str(ctx.exception))
-
-    def test_rejects_class_with_args(self):
-        with self.assertRaises(TypeError) as ctx:
-
-            @atomic_parser.atomic("output")
-            class MyClass:
-                pass
-
-        self.assertIn("@atomic can only decorate functions", str(ctx.exception))
-
-    def test_rejects_callable_instance_bare(self):
-        class MyCallable:
-            def __call__(self):
-                pass
-
-        with self.assertRaises(TypeError) as ctx:
-            atomic_parser.atomic(MyCallable())
-        self.assertIn("@atomic can only decorate functions", str(ctx.exception))
-
-    def test_rejects_callable_instance_with_args(self):
-        class Callable:
-            def __call__(self):
-                pass
-
-        decorator = atomic_parser.atomic("output")
-        with self.assertRaises(TypeError) as ctx:
-            decorator(Callable())
-        self.assertIn("@atomic can only decorate functions", str(ctx.exception))
-
-
 class TestAtomicWithOutputLabels(unittest.TestCase):
     def test_atomic_with_explicit_output_labels(self):
         @atomic_parser.atomic("a", "b")

--- a/tests/unit/parsers/test_parser_helpers.py
+++ b/tests/unit/parsers/test_parser_helpers.py
@@ -1,4 +1,5 @@
 import ast
+import types
 import unittest
 
 from flowrep import base_models, edge_models
@@ -8,15 +9,23 @@ from flowrep.prospective import atomic_recipe, helper_models
 from flowrep_static import makers
 
 
-class TestEnsureFunction(unittest.TestCase):
-    def test_rejects_class(self):
+class TestEnsureAllowed(unittest.TestCase):
+    def test_with_class(self):
         class MyClass:
             pass
 
-        with self.assertRaises(TypeError) as ctx:
-            parser_helpers.ensure_function(MyClass, "@atomic")
-        self.assertIn("@atomic can only decorate functions", str(ctx.exception))
-        self.assertIn("type", str(ctx.exception))
+        with self.subTest("Rejects when type not included"):
+            with self.assertRaises(TypeError) as ctx:
+                parser_helpers._ensure_allowed(
+                    MyClass, (types.FunctionType,), "@atomic"
+                )
+            self.assertIn("'@atomic' can only decorate 'function'", str(ctx.exception))
+            self.assertIn("type", str(ctx.exception))
+
+        with self.subTest("Accepts when type included"):
+            parser_helpers._ensure_allowed(
+                MyClass, (types.FunctionType, type), "@atomic"
+            )
 
     def test_rejects_callable_instance(self):
         class Callable:
@@ -24,20 +33,20 @@ class TestEnsureFunction(unittest.TestCase):
                 pass
 
         with self.assertRaises(TypeError) as ctx:
-            parser_helpers.ensure_function(Callable(), "@atomic")
-        self.assertIn("@atomic can only decorate functions", str(ctx.exception))
+            parser_helpers._ensure_allowed(Callable(), (types.FunctionType,), "@atomic")
+        self.assertIn("'@atomic' can only decorate 'function'", str(ctx.exception))
         self.assertIn("Callable", str(ctx.exception))
 
     def test_accepts_lambda(self):
         # Lambdas are FunctionType, so this should pass _ensure_function
         # (they fail later in parse_atomic due to source unavailability)
         f = lambda: None  # noqa: E731
-        parser_helpers.ensure_function(f, "@atomic")
+        parser_helpers._ensure_allowed(f, (types.FunctionType,), "@atomic")
 
     def test_rejects_builtin(self):
         with self.assertRaises(TypeError) as ctx:
-            parser_helpers.ensure_function(len, "@atomic")
-        self.assertIn("@atomic can only decorate functions", str(ctx.exception))
+            parser_helpers._ensure_allowed(len, (types.FunctionType,), "@atomic")
+        self.assertIn("'@atomic' can only decorate 'function'", str(ctx.exception))
         self.assertIn("builtin_function_or_method", str(ctx.exception))
 
     def test_custom_decorator_name(self):
@@ -45,8 +54,8 @@ class TestEnsureFunction(unittest.TestCase):
             pass
 
         with self.assertRaises(TypeError) as ctx:
-            parser_helpers.ensure_function(Foo(), "@custom")
-        self.assertIn("@custom can only decorate functions", str(ctx.exception))
+            parser_helpers._ensure_allowed(Foo(), (types.FunctionType,), "@custom")
+        self.assertIn("'@custom' can only decorate 'function'", str(ctx.exception))
 
 
 class TestGetFunctionDefinition(unittest.TestCase):

--- a/tests/unit/parsers/test_workflow_parser.py
+++ b/tests/unit/parsers/test_workflow_parser.py
@@ -170,22 +170,22 @@ class TestWorkflowDecorator(unittest.TestCase):
 
 class TestWorkflowDecoratorTypeValidation(unittest.TestCase):
     def test_rejects_class_bare_decorator(self):
-        with self.assertRaises(TypeError) as ctx:
+        with self.assertRaisesRegex(
+            TypeError, "'@workflow' can only decorate 'function'"
+        ):
 
             @workflow_parser.workflow
             class MyClass:
                 pass
 
-        self.assertIn("@workflow can only decorate functions", str(ctx.exception))
-
     def test_rejects_class_with_args(self):
-        with self.assertRaises(TypeError) as ctx:
+        with self.assertRaisesRegex(
+            TypeError, "'@workflow' can only decorate 'function'"
+        ):
 
             @workflow_parser.workflow("output")
             class MyClass:
                 pass
-
-        self.assertIn("@workflow can only decorate functions", str(ctx.exception))
 
 
 class TestParseWorkflowBasic(unittest.TestCase):

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import pickle
 import unittest
-from typing import TYPE_CHECKING, get_origin
+from typing import TYPE_CHECKING, NamedTuple, get_origin
 
 from pyiron_snippets import versions
 
@@ -47,6 +47,11 @@ class InaccessibleFieldAnnotation:
 
 def return_problematic_dataclass(x) -> InaccessibleFieldAnnotation:
     return InaccessibleFieldAnnotation(x)
+
+
+class _RetroPoint(NamedTuple):
+    x: int
+    y: int
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -651,6 +656,21 @@ class TestAtomicFromRecipe(unittest.TestCase):
         self.assertIn(
             "(n=3) do not match length of return annotation", str(ctx.exception)
         )
+
+    def test_new_based_class_raises(self):
+        # @atomic blocks this at decoration time, so build the recipe by hand to
+        # confirm the retrospective path also fails cleanly (e.g. a deserialized
+        # recipe) rather than silently dropping annotations.
+        recipe = atomic_recipe.AtomicRecipe(
+            inputs=["x", "y"],
+            outputs=["instance"],
+            reference=base_models.PythonReference(
+                info=versions.VersionInfo.of(_RetroPoint),
+            ),
+        )
+        with self.assertRaises(TypeError) as ctx:
+            datastructures.AtomicData.from_recipe(recipe)
+        self.assertIn("__init__", str(ctx.exception))
 
     def test_unavailable_annotation(self):
         with self.assertRaisesRegex(NameError, "name 'SeabornColors' is not defined"):


### PR DESCRIPTION
And while we're there, handle decorating methods too, including passing decorations for methods and static methods, and clean failures for class methods. I.e., this is all fine:

```python
import flowrep as fr

@fr.atomic
class MyClass:

    def __init__(self, *, x: int = 100):
        self.x = x

    @fr.atomic
    def some_method(self, y):
        self.x += y
        return self.x

    @staticmethod
    @fr.atomic
    def some_static(a: str):
        return 3 * a
```

I'm going to hold off on documentation at the moment, because if people want method decoration, they're likely to just try it and it will work. This also works with dataclasses,

```python
import dataclasses
import flowrep as fr

@fr.atomic
@dataclasses.dataclass
class MyDataclass:
    x: int = 42
```

So I will handle documentation of this general capability until after introducing a combined `@fr.dataclass`.

Limitations: doesn't work for with the `@staticmethod` and `@fr.atomic` are in the other order, but fails clean and suggests reversing order; doesn't work for `@classmethod`, but has an informative error message when `@fr.atomic` is on the outside (and thus we have full and easy control of the message raised); doesn't work when the class uses `__new__`, but fails cleanly and informatively.