### PR TITLE
Shortcut dataclass decorator

### DIFF
--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -37,8 +37,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:06.940948Z",
-     "start_time": "2026-07-08T19:18:06.702976Z"
+     "end_time": "2026-07-11T03:59:26.763353Z",
+     "start_time": "2026-07-11T03:59:26.493392Z"
     }
    },
    "cell_type": "code",
@@ -53,10 +53,10 @@
     {
      "data": {
       "text/plain": [
-       "(<function flowrep.parsers.atomic_parser.atomic(func: function | str | None = None, /, *output_labels: str, unpack_mode: flowrep.prospective.atomic_recipe.UnpackMode = <UnpackMode.TUPLE: 'tuple'>, version_scraping: dict[str, collections.abc.Callable[[str], str | None]] | None = None, forbid_main: bool = False, forbid_locals: bool = False, require_version: bool = False) -> function | collections.abc.Callable[[function], function]>,\n",
-       " <function flowrep.parsers.workflow_parser.workflow(func: 'FunctionType | str | None' = None, /, *output_labels: 'str', version_scraping: 'versions.VersionScrapingMap | None' = None, forbid_main: 'bool' = False, forbid_locals: 'bool' = False, require_version: 'bool' = False) -> 'FunctionType | Callable[[FunctionType], FunctionType]'>,\n",
-       " <function flowrep.parsers.atomic_parser.parse_atomic(func: function, *output_labels: str, unpack_mode: flowrep.prospective.atomic_recipe.UnpackMode = <UnpackMode.TUPLE: 'tuple'>, version_scraping: dict[str, collections.abc.Callable[[str], str | None]] | None = None, forbid_main: bool = False, forbid_locals: bool = False, require_version: bool = False) -> flowrep.prospective.atomic_recipe.AtomicRecipe>,\n",
-       " <function flowrep.parsers.workflow_parser.parse_workflow(func: 'FunctionType', *output_labels: 'str', version_scraping: 'versions.VersionScrapingMap | None' = None, forbid_main: 'bool' = False, forbid_locals: 'bool' = False, require_version: 'bool' = False)>)"
+       "(<function flowrep.parsers.atomic_parser.atomic(func=None, /, *output_labels, **kwargs)>,\n",
+       " <function flowrep.parsers.workflow_parser.workflow(func=None, /, *output_labels: 'str', **kwargs)>,\n",
+       " <function flowrep.parsers.atomic_parser.parse_atomic(func: function | type, *output_labels: str, unpack_mode: flowrep.prospective.atomic_recipe.UnpackMode = <UnpackMode.TUPLE: 'tuple'>, version_scraping: dict[str, collections.abc.Callable[[str], str | None]] | None = None, forbid_main: bool = False, forbid_locals: bool = False, require_version: bool = False) -> flowrep.prospective.atomic_recipe.AtomicRecipe>,\n",
+       " <function flowrep.parsers.workflow_parser.parse_workflow(func: 'types.FunctionType', *output_labels: 'str', version_scraping: 'versions.VersionScrapingMap | None' = None, forbid_main: 'bool' = False, forbid_locals: 'bool' = False, require_version: 'bool' = False)>)"
       ]
      },
      "execution_count": 1,
@@ -103,8 +103,8 @@
    "id": "8590ac6e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:06.965078Z",
-     "start_time": "2026-07-08T19:18:06.954273Z"
+     "end_time": "2026-07-11T03:59:26.799300Z",
+     "start_time": "2026-07-11T03:59:26.767530Z"
     }
    },
    "source": [
@@ -163,8 +163,8 @@
    "id": "fbb2ac82",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.010508Z",
-     "start_time": "2026-07-08T19:18:06.976085Z"
+     "end_time": "2026-07-11T03:59:26.820218Z",
+     "start_time": "2026-07-11T03:59:26.810921Z"
     }
    },
    "source": [
@@ -204,8 +204,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.105791Z",
-     "start_time": "2026-07-08T19:18:07.025150Z"
+     "end_time": "2026-07-11T03:59:26.851682Z",
+     "start_time": "2026-07-11T03:59:26.835165Z"
     }
    },
    "cell_type": "code",
@@ -240,8 +240,8 @@
    "id": "4ce6917d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.139145Z",
-     "start_time": "2026-07-08T19:18:07.108196Z"
+     "end_time": "2026-07-11T03:59:26.882655Z",
+     "start_time": "2026-07-11T03:59:26.865800Z"
     }
    },
    "source": [
@@ -313,8 +313,8 @@
    "id": "cac0a1bd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.167112Z",
-     "start_time": "2026-07-08T19:18:07.141157Z"
+     "end_time": "2026-07-11T03:59:26.923576Z",
+     "start_time": "2026-07-11T03:59:26.894563Z"
     }
    },
    "source": [
@@ -354,8 +354,8 @@
    "id": "9f659bd7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.196374Z",
-     "start_time": "2026-07-08T19:18:07.169167Z"
+     "end_time": "2026-07-11T03:59:26.973444Z",
+     "start_time": "2026-07-11T03:59:26.925617Z"
     }
    },
    "source": [
@@ -394,8 +394,8 @@
    "id": "467bd6b8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.226225Z",
-     "start_time": "2026-07-08T19:18:07.198296Z"
+     "end_time": "2026-07-11T03:59:26.989432Z",
+     "start_time": "2026-07-11T03:59:26.975366Z"
     }
    },
    "source": [
@@ -448,8 +448,8 @@
    "id": "0d46e437",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.253676Z",
-     "start_time": "2026-07-08T19:18:07.228131Z"
+     "end_time": "2026-07-11T03:59:27.016177Z",
+     "start_time": "2026-07-11T03:59:26.999641Z"
     }
    },
    "source": [
@@ -490,8 +490,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.282755Z",
-     "start_time": "2026-07-08T19:18:07.255656Z"
+     "end_time": "2026-07-11T03:59:27.066635Z",
+     "start_time": "2026-07-11T03:59:27.027778Z"
     }
    },
    "cell_type": "code",
@@ -528,8 +528,8 @@
    "id": "77276c40",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.313205Z",
-     "start_time": "2026-07-08T19:18:07.285100Z"
+     "end_time": "2026-07-11T03:59:27.086897Z",
+     "start_time": "2026-07-11T03:59:27.077624Z"
     }
    },
    "source": [
@@ -579,8 +579,8 @@
    "id": "a4019caa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.335662Z",
-     "start_time": "2026-07-08T19:18:07.326044Z"
+     "end_time": "2026-07-11T03:59:27.148721Z",
+     "start_time": "2026-07-11T03:59:27.098162Z"
     }
    },
    "source": [
@@ -629,8 +629,8 @@
    "id": "b8f03ee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.375880Z",
-     "start_time": "2026-07-08T19:18:07.347813Z"
+     "end_time": "2026-07-11T03:59:27.220959Z",
+     "start_time": "2026-07-11T03:59:27.150738Z"
     }
    },
    "source": [
@@ -698,10 +698,13 @@
    "id": "bdb1f0becd5134e5"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.261236Z",
+     "start_time": "2026-07-11T03:59:27.241863Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "import flowrep as fr\n",
     "\n",
@@ -731,7 +734,19 @@
     "        decorated.flowrep_recipe.outputs\n",
     "    )"
    ],
-   "id": "915053248a94e896"
+   "id": "915053248a94e896",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "__main__.MyClass ['x'] ['instance']\n",
+      "__main__.MyClass.some_method ['self', 'y'] ['output_0']\n",
+      "__main__.MyClass.some_static ['a'] ['triple', 'single']\n"
+     ]
+    }
+   ],
+   "execution_count": 14
   },
   {
    "metadata": {},
@@ -740,10 +755,13 @@
    "id": "acb61dfa571f0a0"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.277253Z",
+     "start_time": "2026-07-11T03:59:27.262256Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "import dataclasses\n",
     "\n",
@@ -756,7 +774,28 @@
     "print(\"Recipe?\", type(MyDataclass.flowrep_recipe))\n",
     "MyDataclass.flowrep_recipe.inputs, MyDataclass.flowrep_recipe.outputs"
    ],
-   "id": "e10b7383753d5d86"
+   "id": "e10b7383753d5d86",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataclass? True\n",
+      "Recipe? <class 'flowrep.prospective.atomic_recipe.AtomicRecipe'>\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(['a', 'x'], ['instance'])"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 15
   },
   {
    "metadata": {},
@@ -782,10 +821,13 @@
    "id": "cd048745aefa7acc"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.297043Z",
+     "start_time": "2026-07-11T03:59:27.283303Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "import numpy as np\n",
     "from pyiron_snippets import versions\n",
@@ -802,7 +844,18 @@
     "print(f\"Inputs:  {linspace_node.inputs}\")\n",
     "print(f\"Outputs: {linspace_node.outputs}\")"
    ],
-   "id": "8b5f8794c3dcd24d"
+   "id": "8b5f8794c3dcd24d",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inputs:  ['start', 'stop', 'num']\n",
+      "Outputs: ['samples']\n"
+     ]
+    }
+   ],
+   "execution_count": 16
   },
   {
    "cell_type": "markdown",
@@ -821,8 +874,8 @@
    "id": "1037ac27",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.437181Z",
-     "start_time": "2026-07-08T19:18:07.410908Z"
+     "end_time": "2026-07-11T03:59:27.313779Z",
+     "start_time": "2026-07-11T03:59:27.297985Z"
     }
    },
    "source": [
@@ -851,7 +904,7 @@
      ]
     }
    ],
-   "execution_count": 15
+   "execution_count": 17
   },
   {
    "cell_type": "markdown",
@@ -879,8 +932,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.491519Z",
-     "start_time": "2026-07-08T19:18:07.439249Z"
+     "end_time": "2026-07-11T03:59:27.331908Z",
+     "start_time": "2026-07-11T03:59:27.317556Z"
     }
    },
    "cell_type": "code",
@@ -893,12 +946,12 @@
        "array([1])"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 16
+   "execution_count": 18
   },
   {
    "metadata": {},
@@ -909,8 +962,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.525444Z",
-     "start_time": "2026-07-08T19:18:07.492679Z"
+     "end_time": "2026-07-11T03:59:27.346151Z",
+     "start_time": "2026-07-11T03:59:27.332863Z"
     }
    },
    "cell_type": "code",
@@ -923,12 +976,12 @@
        "(Point(x=1, y=2), (1, 2))"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 17
+   "execution_count": 19
   },
   {
    "metadata": {},
@@ -943,8 +996,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.617696Z",
-     "start_time": "2026-07-08T19:18:07.539352Z"
+     "end_time": "2026-07-11T03:59:27.360882Z",
+     "start_time": "2026-07-11T03:59:27.347172Z"
     }
    },
    "cell_type": "code",
@@ -977,13 +1030,13 @@
      ]
     }
    ],
-   "execution_count": 18
+   "execution_count": 20
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.652983Z",
-     "start_time": "2026-07-08T19:18:07.620246Z"
+     "end_time": "2026-07-11T03:59:27.375564Z",
+     "start_time": "2026-07-11T03:59:27.362210Z"
     }
    },
    "cell_type": "code",
@@ -996,12 +1049,12 @@
        "{'this': 1, 'that': 2, 'the_other': 3}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 19
+   "execution_count": 21
   },
   {
    "metadata": {},
@@ -1012,8 +1065,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.681796Z",
-     "start_time": "2026-07-08T19:18:07.663308Z"
+     "end_time": "2026-07-11T03:59:27.391960Z",
+     "start_time": "2026-07-11T03:59:27.377483Z"
     }
    },
    "cell_type": "code",
@@ -1050,13 +1103,13 @@
      ]
     }
    ],
-   "execution_count": 20
+   "execution_count": 22
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.709264Z",
-     "start_time": "2026-07-08T19:18:07.684206Z"
+     "end_time": "2026-07-11T03:59:27.405635Z",
+     "start_time": "2026-07-11T03:59:27.393499Z"
     }
    },
    "cell_type": "code",
@@ -1069,12 +1122,12 @@
        "6"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 21
+   "execution_count": 23
   },
   {
    "metadata": {},
@@ -1111,8 +1164,8 @@
    "id": "d39608c2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.749940Z",
-     "start_time": "2026-07-08T19:18:07.711386Z"
+     "end_time": "2026-07-11T03:59:27.428582Z",
+     "start_time": "2026-07-11T03:59:27.407171Z"
     }
    },
    "source": [
@@ -1156,12 +1209,12 @@
        "WorkflowRecipe(type=<RecipeElementType.WORKFLOW: 'workflow'>, inputs=['x', 'slope', 'intercept'], outputs=['result'], description='y = slope * x + intercept', nodes={'multiply_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>), 'add_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>)}, input_edges={TargetHandle(node='multiply_0', port='x'): InputSource(node=None, port='x'), TargetHandle(node='multiply_0', port='y'): InputSource(node=None, port='slope'), TargetHandle(node='add_0', port='b'): InputSource(node=None, port='intercept')}, edges={TargetHandle(node='add_0', port='a'): SourceHandle(node='multiply_0', port='product')}, output_edges={OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result')}, reference=PythonReference(info=VersionInfo(module='__main__', qualname='linear', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 22
+   "execution_count": 24
   },
   {
    "cell_type": "markdown",
@@ -1191,8 +1244,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.786325Z",
-     "start_time": "2026-07-08T19:18:07.752388Z"
+     "end_time": "2026-07-11T03:59:27.443414Z",
+     "start_time": "2026-07-11T03:59:27.429902Z"
     }
    },
    "cell_type": "code",
@@ -1205,12 +1258,12 @@
        "7"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 23
+   "execution_count": 25
   },
   {
    "cell_type": "markdown",
@@ -1248,8 +1301,8 @@
    "id": "55716aa9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.812555Z",
-     "start_time": "2026-07-08T19:18:07.788375Z"
+     "end_time": "2026-07-11T03:59:27.458290Z",
+     "start_time": "2026-07-11T03:59:27.444627Z"
     }
    },
    "source": [
@@ -1287,7 +1340,7 @@
      ]
     }
    ],
-   "execution_count": 24
+   "execution_count": 26
   },
   {
    "cell_type": "markdown",
@@ -1321,8 +1374,8 @@
    "id": "cd45cbb2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.840312Z",
-     "start_time": "2026-07-08T19:18:07.814638Z"
+     "end_time": "2026-07-11T03:59:27.474424Z",
+     "start_time": "2026-07-11T03:59:27.460856Z"
     }
    },
    "source": [
@@ -1348,7 +1401,7 @@
      ]
     }
    ],
-   "execution_count": 25
+   "execution_count": 27
   },
   {
    "cell_type": "markdown",
@@ -1376,8 +1429,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.854769Z",
-     "start_time": "2026-07-08T19:18:07.843738Z"
+     "end_time": "2026-07-11T03:59:27.481126Z",
+     "start_time": "2026-07-11T03:59:27.475464Z"
     }
    },
    "cell_type": "code",
@@ -1396,7 +1449,7 @@
    ],
    "id": "de18e624974cf3e2",
    "outputs": [],
-   "execution_count": 26
+   "execution_count": 28
   },
   {
    "metadata": {},
@@ -1410,8 +1463,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.890815Z",
-     "start_time": "2026-07-08T19:18:07.866052Z"
+     "end_time": "2026-07-11T03:59:27.494793Z",
+     "start_time": "2026-07-11T03:59:27.481683Z"
     }
    },
    "cell_type": "code",
@@ -1430,7 +1483,7 @@
      ]
     }
    ],
-   "execution_count": 27
+   "execution_count": 29
   },
   {
    "metadata": {},
@@ -1451,8 +1504,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.922858Z",
-     "start_time": "2026-07-08T19:18:07.894413Z"
+     "end_time": "2026-07-11T03:59:27.513972Z",
+     "start_time": "2026-07-11T03:59:27.496180Z"
     }
    },
    "cell_type": "code",
@@ -1465,12 +1518,12 @@
        "{'this': 'this default', 'that': 'that default', 'the_other': array([0, 2])}"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 28
+   "execution_count": 30
   },
   {
    "cell_type": "markdown",
@@ -1526,8 +1579,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.946727Z",
-     "start_time": "2026-07-08T19:18:07.924997Z"
+     "end_time": "2026-07-11T03:59:27.527620Z",
+     "start_time": "2026-07-11T03:59:27.515088Z"
     }
    },
    "cell_type": "code",
@@ -1540,12 +1593,12 @@
        "(None, None)"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 29
+   "execution_count": 31
   },
   {
    "cell_type": "markdown",
@@ -1560,8 +1613,8 @@
    "id": "06c2b2eb",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.974037Z",
-     "start_time": "2026-07-08T19:18:07.948875Z"
+     "end_time": "2026-07-11T03:59:27.541321Z",
+     "start_time": "2026-07-11T03:59:27.528514Z"
     }
    },
    "source": [
@@ -1597,7 +1650,7 @@
      ]
     }
    ],
-   "execution_count": 30
+   "execution_count": 32
   },
   {
    "cell_type": "markdown",
@@ -1616,8 +1669,8 @@
    "id": "6d7a6e2a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.008550Z",
-     "start_time": "2026-07-08T19:18:07.977759Z"
+     "end_time": "2026-07-11T03:59:27.563399Z",
+     "start_time": "2026-07-11T03:59:27.543583Z"
     }
    },
    "source": [
@@ -1709,7 +1762,7 @@
      ]
     }
    ],
-   "execution_count": 31
+   "execution_count": 33
   },
   {
    "cell_type": "markdown",
@@ -1726,8 +1779,8 @@
    "id": "53e8f09d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.039342Z",
-     "start_time": "2026-07-08T19:18:08.011058Z"
+     "end_time": "2026-07-11T03:59:27.579609Z",
+     "start_time": "2026-07-11T03:59:27.564310Z"
     }
    },
    "source": [
@@ -1746,7 +1799,7 @@
      ]
     }
    ],
-   "execution_count": 32
+   "execution_count": 34
   },
   {
    "cell_type": "markdown",
@@ -1779,8 +1832,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.060200Z",
-     "start_time": "2026-07-08T19:18:08.041728Z"
+     "end_time": "2026-07-11T03:59:27.595280Z",
+     "start_time": "2026-07-11T03:59:27.580498Z"
     }
    },
    "cell_type": "code",
@@ -1831,7 +1884,7 @@
      ]
     }
    ],
-   "execution_count": 33
+   "execution_count": 35
   },
   {
    "cell_type": "markdown",
@@ -1946,8 +1999,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.154739Z",
-     "start_time": "2026-07-08T19:18:08.108368Z"
+     "end_time": "2026-07-11T03:59:27.612857Z",
+     "start_time": "2026-07-11T03:59:27.596524Z"
     }
    },
    "cell_type": "code",
@@ -1999,7 +2052,7 @@
      ]
     }
    ],
-   "execution_count": 34
+   "execution_count": 36
   },
   {
    "cell_type": "markdown",
@@ -2030,8 +2083,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.185661Z",
-     "start_time": "2026-07-08T19:18:08.157120Z"
+     "end_time": "2026-07-11T03:59:27.682206Z",
+     "start_time": "2026-07-11T03:59:27.615166Z"
     }
    },
    "cell_type": "code",
@@ -2072,7 +2125,7 @@
      ]
     }
    ],
-   "execution_count": 35
+   "execution_count": 37
   },
   {
    "cell_type": "markdown",
@@ -2099,8 +2152,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.213361Z",
-     "start_time": "2026-07-08T19:18:08.187848Z"
+     "end_time": "2026-07-11T03:59:27.704571Z",
+     "start_time": "2026-07-11T03:59:27.688279Z"
     }
    },
    "cell_type": "code",
@@ -2129,7 +2182,7 @@
      ]
     }
    ],
-   "execution_count": 36
+   "execution_count": 38
   },
   {
    "metadata": {},
@@ -2145,8 +2198,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.254347Z",
-     "start_time": "2026-07-08T19:18:08.223930Z"
+     "end_time": "2026-07-11T03:59:27.718556Z",
+     "start_time": "2026-07-11T03:59:27.705531Z"
     }
    },
    "cell_type": "code",
@@ -2180,7 +2233,7 @@
      ]
     }
    ],
-   "execution_count": 37
+   "execution_count": 39
   },
   {
    "cell_type": "markdown",
@@ -2236,8 +2289,8 @@
    "id": "0a285891",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.282551Z",
-     "start_time": "2026-07-08T19:18:08.256506Z"
+     "end_time": "2026-07-11T03:59:27.733103Z",
+     "start_time": "2026-07-11T03:59:27.719591Z"
     }
    },
    "source": [
@@ -2281,7 +2334,7 @@
      ]
     }
    ],
-   "execution_count": 38
+   "execution_count": 40
   },
   {
    "cell_type": "markdown",
@@ -2332,8 +2385,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.311135Z",
-     "start_time": "2026-07-08T19:18:08.284995Z"
+     "end_time": "2026-07-11T03:59:27.757249Z",
+     "start_time": "2026-07-11T03:59:27.739975Z"
     }
    },
    "cell_type": "code",
@@ -2372,16 +2425,16 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_92383/3477409776.py\", line 16, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_59191/3477409776.py\", line 16, in <module>\n",
       "    conditional_availability(-1)\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_92383/3477409776.py\", line 9, in conditional_availability\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_59191/3477409776.py\", line 9, in conditional_availability\n",
       "    downstream = identity(result)\n",
       "                          ^^^^^^\n",
       "UnboundLocalError: cannot access local variable 'result' where it is not associated with a value\n"
      ]
     }
    ],
-   "execution_count": 39
+   "execution_count": 41
   },
   {
    "cell_type": "markdown",
@@ -2414,8 +2467,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.327185Z",
-     "start_time": "2026-07-08T19:18:08.313278Z"
+     "end_time": "2026-07-11T03:59:27.763575Z",
+     "start_time": "2026-07-11T03:59:27.758276Z"
     }
    },
    "source": [
@@ -2431,7 +2484,7 @@
     "    return result"
    ],
    "outputs": [],
-   "execution_count": 40
+   "execution_count": 42
   },
   {
    "cell_type": "markdown",
@@ -2461,8 +2514,8 @@
    "id": "52ab25e4",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.362190Z",
-     "start_time": "2026-07-08T19:18:08.339328Z"
+     "end_time": "2026-07-11T03:59:27.777055Z",
+     "start_time": "2026-07-11T03:59:27.764090Z"
     }
    },
    "source": [
@@ -2499,15 +2552,15 @@
      ]
     }
    ],
-   "execution_count": 41
+   "execution_count": 43
   },
   {
    "cell_type": "code",
    "id": "79c1d339",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.389181Z",
-     "start_time": "2026-07-08T19:18:08.364295Z"
+     "end_time": "2026-07-11T03:59:27.791355Z",
+     "start_time": "2026-07-11T03:59:27.777702Z"
     }
    },
    "source": [
@@ -2532,7 +2585,7 @@
      ]
     }
    ],
-   "execution_count": 42
+   "execution_count": 44
   },
   {
    "cell_type": "markdown",
@@ -2580,8 +2633,8 @@
    "id": "d76836d6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.416380Z",
-     "start_time": "2026-07-08T19:18:08.391480Z"
+     "end_time": "2026-07-11T03:59:27.808443Z",
+     "start_time": "2026-07-11T03:59:27.793731Z"
     }
    },
    "source": [
@@ -2636,7 +2689,7 @@
      ]
     }
    ],
-   "execution_count": 43
+   "execution_count": 45
   },
   {
    "cell_type": "markdown",
@@ -2669,8 +2722,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.442259Z",
-     "start_time": "2026-07-08T19:18:08.418776Z"
+     "end_time": "2026-07-11T03:59:27.823205Z",
+     "start_time": "2026-07-11T03:59:27.810632Z"
     }
    },
    "cell_type": "code",
@@ -2688,7 +2741,7 @@
      ]
     }
    ],
-   "execution_count": 44
+   "execution_count": 46
   },
   {
    "metadata": {},
@@ -2699,8 +2752,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.470068Z",
-     "start_time": "2026-07-08T19:18:08.444457Z"
+     "end_time": "2026-07-11T03:59:27.836844Z",
+     "start_time": "2026-07-11T03:59:27.824048Z"
     }
    },
    "cell_type": "code",
@@ -2718,7 +2771,7 @@
      ]
     }
    ],
-   "execution_count": 45
+   "execution_count": 47
   },
   {
    "cell_type": "markdown",
@@ -2748,8 +2801,8 @@
    "id": "3efa3180",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.497189Z",
-     "start_time": "2026-07-08T19:18:08.472269Z"
+     "end_time": "2026-07-11T03:59:27.852851Z",
+     "start_time": "2026-07-11T03:59:27.838047Z"
     }
    },
    "source": [
@@ -2770,13 +2823,16 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_92383/3041652459.py\", line 4, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_59191/3041652459.py\", line 4, in <module>\n",
       "    @fr.atomic(forbid_main=True)\n",
       "     ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/parser_helpers.py\", line 44, in decorator\n",
-      "    f.flowrep_recipe = parser(f, *parsed_labels, **parser_kwargs)  # type: ignore[attr-defined]\n",
-      "                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 110, in parse_atomic\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/parser_helpers.py\", line 45, in deferred\n",
+      "    return wrap(f, labels)\n",
+      "           ^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 76, in wrap\n",
+      "    f.flowrep_recipe = parse_atomic(f, *labels, **kwargs)\n",
+      "                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 152, in parse_atomic\n",
       "    function_info = versions.VersionInfo.of(\n",
       "                    ^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 125, in of\n",
@@ -2787,7 +2843,7 @@
      ]
     }
    ],
-   "execution_count": 46
+   "execution_count": 48
   },
   {
    "cell_type": "markdown",
@@ -2822,8 +2878,8 @@
    "id": "82468383",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.526175Z",
-     "start_time": "2026-07-08T19:18:08.499553Z"
+     "end_time": "2026-07-11T03:59:27.866707Z",
+     "start_time": "2026-07-11T03:59:27.853871Z"
     }
    },
    "source": [
@@ -2843,7 +2899,7 @@
      ]
     }
    ],
-   "execution_count": 47
+   "execution_count": 49
   },
   {
    "metadata": {},
@@ -2861,8 +2917,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.569735Z",
-     "start_time": "2026-07-08T19:18:08.537192Z"
+     "end_time": "2026-07-11T03:59:27.881332Z",
+     "start_time": "2026-07-11T03:59:27.867580Z"
     }
    },
    "cell_type": "code",
@@ -2887,7 +2943,7 @@
      ]
     }
    ],
-   "execution_count": 48
+   "execution_count": 50
   },
   {
    "metadata": {},
@@ -2902,8 +2958,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.620312Z",
-     "start_time": "2026-07-08T19:18:08.570694Z"
+     "end_time": "2026-07-11T03:59:27.886572Z",
+     "start_time": "2026-07-11T03:59:27.882757Z"
     }
    },
    "cell_type": "code",
@@ -2913,7 +2969,7 @@
    ],
    "id": "664078176aceb6e0",
    "outputs": [],
-   "execution_count": 49
+   "execution_count": 51
   },
   {
    "metadata": {},
@@ -2924,8 +2980,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.672899Z",
-     "start_time": "2026-07-08T19:18:08.646534Z"
+     "end_time": "2026-07-11T03:59:27.899934Z",
+     "start_time": "2026-07-11T03:59:27.887114Z"
     }
    },
    "cell_type": "code",
@@ -2951,7 +3007,7 @@
      ]
     }
    ],
-   "execution_count": 50
+   "execution_count": 52
   },
   {
    "metadata": {},
@@ -2962,8 +3018,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.703691Z",
-     "start_time": "2026-07-08T19:18:08.675081Z"
+     "end_time": "2026-07-11T03:59:27.914939Z",
+     "start_time": "2026-07-11T03:59:27.900898Z"
     }
    },
    "cell_type": "code",
@@ -2979,12 +3035,12 @@
        "3"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 51
+   "execution_count": 53
   },
   {
    "metadata": {},
@@ -2999,8 +3055,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.731114Z",
-     "start_time": "2026-07-08T19:18:08.705876Z"
+     "end_time": "2026-07-11T03:59:27.936649Z",
+     "start_time": "2026-07-11T03:59:27.922782Z"
     }
    },
    "cell_type": "code",
@@ -3040,7 +3096,7 @@
      ]
     }
    ],
-   "execution_count": 52
+   "execution_count": 54
   },
   {
    "metadata": {},
@@ -3055,8 +3111,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.759647Z",
-     "start_time": "2026-07-08T19:18:08.733623Z"
+     "end_time": "2026-07-11T03:59:27.953687Z",
+     "start_time": "2026-07-11T03:59:27.937643Z"
     }
    },
    "cell_type": "code",
@@ -3105,7 +3161,7 @@
      ]
     }
    ],
-   "execution_count": 53
+   "execution_count": 55
   },
   {
    "metadata": {},
@@ -3120,8 +3176,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.793444Z",
-     "start_time": "2026-07-08T19:18:08.769827Z"
+     "end_time": "2026-07-11T03:59:27.967749Z",
+     "start_time": "2026-07-11T03:59:27.954651Z"
     }
    },
    "cell_type": "code",
@@ -3136,12 +3192,12 @@
        " '_default_y': 4}"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 54
+   "execution_count": 56
   },
   {
    "metadata": {},
@@ -3152,8 +3208,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.818820Z",
-     "start_time": "2026-07-08T19:18:08.795508Z"
+     "end_time": "2026-07-11T03:59:27.982017Z",
+     "start_time": "2026-07-11T03:59:27.968628Z"
     }
    },
    "cell_type": "code",
@@ -3169,12 +3225,12 @@
        "3"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 55
+   "execution_count": 57
   },
   {
    "metadata": {},
@@ -3214,8 +3270,8 @@
    "id": "cabe9313",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.849049Z",
-     "start_time": "2026-07-08T19:18:08.820823Z"
+     "end_time": "2026-07-11T03:59:27.996803Z",
+     "start_time": "2026-07-11T03:59:27.983158Z"
     }
    },
    "source": [
@@ -3257,7 +3313,7 @@
      ]
     }
    ],
-   "execution_count": 56
+   "execution_count": 58
   },
   {
    "cell_type": "markdown",
@@ -3268,8 +3324,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.876142Z",
-     "start_time": "2026-07-08T19:18:08.851524Z"
+     "end_time": "2026-07-11T03:59:28.011631Z",
+     "start_time": "2026-07-11T03:59:27.997786Z"
     }
    },
    "cell_type": "code",
@@ -3303,7 +3359,7 @@
      ]
     }
    ],
-   "execution_count": 57
+   "execution_count": 59
   },
   {
    "cell_type": "markdown",
@@ -3347,8 +3403,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.903633Z",
-     "start_time": "2026-07-08T19:18:08.878269Z"
+     "end_time": "2026-07-11T03:59:28.018411Z",
+     "start_time": "2026-07-11T03:59:28.013354Z"
     }
    },
    "cell_type": "code",
@@ -3381,26 +3437,26 @@
    ],
    "id": "7ca53a662f660901",
    "outputs": [],
-   "execution_count": 58
+   "execution_count": 60
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.928421Z",
-     "start_time": "2026-07-08T19:18:08.913668Z"
+     "end_time": "2026-07-11T03:59:28.021921Z",
+     "start_time": "2026-07-11T03:59:28.018859Z"
     }
    },
    "cell_type": "code",
    "source": "node_data = fr.tools.recipe2data(scaled_range.flowrep_recipe)",
    "id": "f044f5954e57507c",
    "outputs": [],
-   "execution_count": 59
+   "execution_count": 61
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.954693Z",
-     "start_time": "2026-07-08T19:18:08.930062Z"
+     "end_time": "2026-07-11T03:59:28.034478Z",
+     "start_time": "2026-07-11T03:59:28.022277Z"
     }
    },
    "cell_type": "code",
@@ -3413,12 +3469,12 @@
        "flowrep.prospective.workflow_recipe.WorkflowRecipe"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 60
+   "execution_count": 62
   },
   {
    "metadata": {},
@@ -3434,8 +3490,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:08.982109Z",
-     "start_time": "2026-07-08T19:18:08.956836Z"
+     "end_time": "2026-07-11T03:59:28.053203Z",
+     "start_time": "2026-07-11T03:59:28.035405Z"
     }
    },
    "cell_type": "code",
@@ -3462,7 +3518,7 @@
      ]
     }
    ],
-   "execution_count": 61
+   "execution_count": 63
   },
   {
    "metadata": {},
@@ -3482,8 +3538,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.007894Z",
-     "start_time": "2026-07-08T19:18:08.984483Z"
+     "end_time": "2026-07-11T03:59:28.066698Z",
+     "start_time": "2026-07-11T03:59:28.054289Z"
     }
    },
    "cell_type": "code",
@@ -3496,12 +3552,12 @@
        "NOT_DATA"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 62
+   "execution_count": 64
   },
   {
    "metadata": {},
@@ -3512,8 +3568,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.035506Z",
-     "start_time": "2026-07-08T19:18:09.011016Z"
+     "end_time": "2026-07-11T03:59:28.083961Z",
+     "start_time": "2026-07-11T03:59:28.070939Z"
     }
    },
    "cell_type": "code",
@@ -3526,12 +3582,12 @@
        "1.0"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 63
+   "execution_count": 65
   },
   {
    "metadata": {},
@@ -3542,8 +3598,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.063681Z",
-     "start_time": "2026-07-08T19:18:09.037690Z"
+     "end_time": "2026-07-11T03:59:28.098845Z",
+     "start_time": "2026-07-11T03:59:28.084866Z"
     }
    },
    "cell_type": "code",
@@ -3561,12 +3617,12 @@
        "(float, list[float])"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 64
+   "execution_count": 66
   },
   {
    "metadata": {},
@@ -3577,8 +3633,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.129593Z",
-     "start_time": "2026-07-08T19:18:09.067368Z"
+     "end_time": "2026-07-11T03:59:28.113139Z",
+     "start_time": "2026-07-11T03:59:28.099705Z"
     }
    },
    "cell_type": "code",
@@ -3599,12 +3655,12 @@
        "(NOT_DATA, NOT_DATA, int, NOT_DATA, list[int])"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 65
+   "execution_count": 67
   },
   {
    "metadata": {},
@@ -3620,8 +3676,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.188804Z",
-     "start_time": "2026-07-08T19:18:09.131690Z"
+     "end_time": "2026-07-11T03:59:28.197700Z",
+     "start_time": "2026-07-11T03:59:28.116392Z"
     }
    },
    "cell_type": "code",
@@ -3640,13 +3696,13 @@
      ]
     }
    ],
-   "execution_count": 66
+   "execution_count": 68
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.215578Z",
-     "start_time": "2026-07-08T19:18:09.191182Z"
+     "end_time": "2026-07-11T03:59:28.219938Z",
+     "start_time": "2026-07-11T03:59:28.198309Z"
     }
    },
    "cell_type": "code",
@@ -3664,13 +3720,13 @@
      ]
     }
    ],
-   "execution_count": 67
+   "execution_count": 69
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.243104Z",
-     "start_time": "2026-07-08T19:18:09.218133Z"
+     "end_time": "2026-07-11T03:59:28.234494Z",
+     "start_time": "2026-07-11T03:59:28.220696Z"
     }
    },
    "cell_type": "code",
@@ -3688,7 +3744,7 @@
      ]
     }
    ],
-   "execution_count": 68
+   "execution_count": 70
   },
   {
    "metadata": {},
@@ -3708,8 +3764,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.279014Z",
-     "start_time": "2026-07-08T19:18:09.254695Z"
+     "end_time": "2026-07-11T03:59:28.248350Z",
+     "start_time": "2026-07-11T03:59:28.235562Z"
     }
    },
    "cell_type": "code",
@@ -3732,12 +3788,12 @@
        "(<RecipeElementType.FOR_EACH: 'for_each'>, {}, {}, {}, {})"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 69
+   "execution_count": 71
   },
   {
    "metadata": {},
@@ -3754,8 +3810,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.303156Z",
-     "start_time": "2026-07-08T19:18:09.281255Z"
+     "end_time": "2026-07-11T03:59:28.256186Z",
+     "start_time": "2026-07-11T03:59:28.249195Z"
     }
    },
    "cell_type": "code",
@@ -3773,7 +3829,7 @@
    ],
    "id": "ca0292eb59cf963a",
    "outputs": [],
-   "execution_count": 70
+   "execution_count": 72
   },
   {
    "metadata": {},
@@ -3784,8 +3840,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.325746Z",
-     "start_time": "2026-07-08T19:18:09.317583Z"
+     "end_time": "2026-07-11T03:59:28.270600Z",
+     "start_time": "2026-07-11T03:59:28.256991Z"
     }
    },
    "cell_type": "code",
@@ -3805,7 +3861,7 @@
      ]
     }
    ],
-   "execution_count": 71
+   "execution_count": 73
   },
   {
    "metadata": {},
@@ -3816,8 +3872,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.360299Z",
-     "start_time": "2026-07-08T19:18:09.336093Z"
+     "end_time": "2026-07-11T03:59:28.285169Z",
+     "start_time": "2026-07-11T03:59:28.271440Z"
     }
    },
    "cell_type": "code",
@@ -3836,12 +3892,12 @@
        "pyiron_snippets.colors.SeabornColors"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 72
+   "execution_count": 74
   },
   {
    "metadata": {},
@@ -3860,15 +3916,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.376084Z",
-     "start_time": "2026-07-08T19:18:09.362358Z"
+     "end_time": "2026-07-11T03:59:28.290343Z",
+     "start_time": "2026-07-11T03:59:28.286066Z"
     }
    },
    "cell_type": "code",
    "source": "ran_node = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=3)",
    "id": "54c1c113638190b8",
    "outputs": [],
-   "execution_count": 73
+   "execution_count": 75
   },
   {
    "metadata": {},
@@ -3882,8 +3938,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.407676Z",
-     "start_time": "2026-07-08T19:18:09.387947Z"
+     "end_time": "2026-07-11T03:59:28.305512Z",
+     "start_time": "2026-07-11T03:59:28.291868Z"
     }
    },
    "cell_type": "code",
@@ -3896,12 +3952,12 @@
        "[0.0, 1.0, 2.0]"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 74
+   "execution_count": 76
   },
   {
    "metadata": {},
@@ -3912,8 +3968,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.437317Z",
-     "start_time": "2026-07-08T19:18:09.410949Z"
+     "end_time": "2026-07-11T03:59:28.318869Z",
+     "start_time": "2026-07-11T03:59:28.306752Z"
     }
    },
    "cell_type": "code",
@@ -3939,7 +3995,7 @@
      ]
     }
    ],
-   "execution_count": 75
+   "execution_count": 77
   },
   {
    "metadata": {},
@@ -3957,8 +4013,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.468815Z",
-     "start_time": "2026-07-08T19:18:09.439496Z"
+     "end_time": "2026-07-11T03:59:28.334711Z",
+     "start_time": "2026-07-11T03:59:28.319711Z"
     }
    },
    "cell_type": "code",
@@ -4000,12 +4056,12 @@
        "{'scaled': OutputDataPort(value=[0.0, 1.0, 2.0, 3.0, 4.0], annotation=list[float])}"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 76
+   "execution_count": 78
   },
   {
    "metadata": {},
@@ -4016,8 +4072,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.845802Z",
-     "start_time": "2026-07-08T19:18:09.471023Z"
+     "end_time": "2026-07-11T03:59:28.698253Z",
+     "start_time": "2026-07-11T03:59:28.335655Z"
     }
    },
    "cell_type": "code",
@@ -4028,7 +4084,7 @@
    ],
    "id": "c4fe9644c6e43a16",
    "outputs": [],
-   "execution_count": 77
+   "execution_count": 79
   },
   {
    "metadata": {},
@@ -4046,8 +4102,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:09.886298Z",
-     "start_time": "2026-07-08T19:18:09.849512Z"
+     "end_time": "2026-07-11T03:59:28.726974Z",
+     "start_time": "2026-07-11T03:59:28.703632Z"
     }
    },
    "cell_type": "code",
@@ -4116,12 +4172,12 @@
        " 'rescale_all_0.for_each_0.body_4.rescale_0.outputs.result']"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 78
+   "execution_count": 80
   },
   {
    "metadata": {},
@@ -4132,8 +4188,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:10.250531Z",
-     "start_time": "2026-07-08T19:18:09.888429Z"
+     "end_time": "2026-07-11T03:59:29.067527Z",
+     "start_time": "2026-07-11T03:59:28.727957Z"
     }
    },
    "cell_type": "code",
@@ -4149,12 +4205,12 @@
        "(True, dict_keys(['for_each_0']))"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 79
+   "execution_count": 81
   },
   {
    "metadata": {},
@@ -4165,8 +4221,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:10.289820Z",
-     "start_time": "2026-07-08T19:18:10.255221Z"
+     "end_time": "2026-07-11T03:59:29.095206Z",
+     "start_time": "2026-07-11T03:59:29.075064Z"
     }
    },
    "cell_type": "code",
@@ -4182,12 +4238,12 @@
        "(True, 1)"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 80
+   "execution_count": 82
   },
   {
    "metadata": {},
@@ -4201,8 +4257,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:10.317527Z",
-     "start_time": "2026-07-08T19:18:10.292603Z"
+     "end_time": "2026-07-11T03:59:29.119470Z",
+     "start_time": "2026-07-11T03:59:29.096217Z"
     }
    },
    "cell_type": "code",
@@ -4222,7 +4278,7 @@
      ]
     }
    ],
-   "execution_count": 81
+   "execution_count": 83
   },
   {
    "metadata": {},
@@ -4233,8 +4289,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:10.373247Z",
-     "start_time": "2026-07-08T19:18:10.329201Z"
+     "end_time": "2026-07-11T03:59:29.204858Z",
+     "start_time": "2026-07-11T03:59:29.122996Z"
     }
    },
    "cell_type": "code",
@@ -4252,15 +4308,15 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "598c220874fb4603801b86957bb81977"
+       "model_id": "2a6153ff8d92439682550b236f758e0a"
       }
      },
-     "execution_count": 82,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 82
+   "execution_count": 84
   },
   {
    "metadata": {},
@@ -4307,15 +4363,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:10.393416Z",
-     "start_time": "2026-07-08T19:18:10.378336Z"
+     "end_time": "2026-07-11T03:59:29.226332Z",
+     "start_time": "2026-07-11T03:59:29.215800Z"
     }
    },
    "cell_type": "code",
    "source": "",
    "id": "f9bf1a0cd6d6913c",
    "outputs": [],
-   "execution_count": 82
+   "execution_count": 84
   }
  ],
  "metadata": {

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -686,11 +686,89 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d1b92a83",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
-    "### 1.6 Power-user: controlling inputs for tricky functions\n",
+    "### 1.6 Class atomic recipes\n",
+    "\n",
+    "Most of the time an atomic recipe will center around a function, but you can also parse and decorate classes into recipes. The resulting recipe takes the creation arguments as input, and returns a single `\"instance\"` output port for an instance of that class.\n",
+    "\n",
+    "Similarly, methods and static methods inside classes are just functions we can decorate and assign recipes. Note that when you make a recipe out of a regular method, it really does expect an instance of the class as the first input:"
+   ],
+   "id": "bdb1f0becd5134e5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import flowrep as fr\n",
+    "\n",
+    "@fr.atomic\n",
+    "class MyClass:\n",
+    "    def __init__(self, *, x: int = 100):\n",
+    "        self.x = x\n",
+    "\n",
+    "    @fr.atomic\n",
+    "    def some_method(self, y):\n",
+    "        self.x += y\n",
+    "        return self.x\n",
+    "\n",
+    "    @staticmethod\n",
+    "    @fr.atomic(\"triple\", \"single\")\n",
+    "    def some_static(a: str):\n",
+    "        return 3 * a, a\n",
+    "\n",
+    "for decorated in (\n",
+    "    MyClass,\n",
+    "    MyClass.some_method,\n",
+    "    MyClass.some_static,\n",
+    "):\n",
+    "    print(\n",
+    "        decorated.flowrep_recipe.reference.info.fully_qualified_name,\n",
+    "        decorated.flowrep_recipe.inputs,\n",
+    "        decorated.flowrep_recipe.outputs\n",
+    "    )"
+   ],
+   "id": "915053248a94e896"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "This also works trivially for dataclasses --  you can stack the decorators together, or use the `flowrep.dataclass` decorator to do both at once for you. Just like the decorated objects, these stay as usual dataclasses but get their `.flowrep_recipe` attached:",
+   "id": "acb61dfa571f0a0"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import dataclasses\n",
+    "\n",
+    "@fr.dataclass\n",
+    "class MyDataclass:\n",
+    "    a: str\n",
+    "    x: int = 1\n",
+    "\n",
+    "print(\"Dataclass?\", dataclasses.is_dataclass(MyDataclass))\n",
+    "print(\"Recipe?\", type(MyDataclass.flowrep_recipe))\n",
+    "MyDataclass.flowrep_recipe.inputs, MyDataclass.flowrep_recipe.outputs"
+   ],
+   "id": "e10b7383753d5d86"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "**Limitations**: `@staticmethod` only works when the decorators are applied in the right order; `@classmethod` doesn't work at all; classes defining a custom `__new__` will fail to parse cleanly; classes defining a class-level `flowrep_recipe` field (classvar or method) will fail cleanly.",
+   "id": "ec98d006c8259b8e"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### 1.7 Power-user: controlling inputs for tricky functions\n",
     "\n",
     "Not every function has a signature that maps cleanly to a workflow node. Two\n",
     "common cases:\n",
@@ -700,17 +778,14 @@
     "For a workflow node, we need outputs to be predictable. We can manually construct\n",
     "a recipe that exposes only a safe subset of inputs, relying on Python defaults\n",
     "for the rest:"
-   ]
+   ],
+   "id": "cd048745aefa7acc"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "id": "9ac92af2",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-08T19:18:07.408408Z",
-     "start_time": "2026-07-08T19:18:07.377892Z"
-    }
-   },
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "import numpy as np\n",
     "from pyiron_snippets import versions\n",
@@ -727,17 +802,7 @@
     "print(f\"Inputs:  {linspace_node.inputs}\")\n",
     "print(f\"Outputs: {linspace_node.outputs}\")"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inputs:  ['start', 'stop', 'num']\n",
-      "Outputs: ['samples']\n"
-     ]
-    }
-   ],
-   "execution_count": 14
+   "id": "8b5f8794c3dcd24d"
   },
   {
    "cell_type": "markdown",

--- a/src/flowrep/__init__.py
+++ b/src/flowrep/__init__.py
@@ -7,6 +7,7 @@ attribute onto a function at definition time, and parsers (`parse_atomic`,
 import importlib.metadata
 
 from flowrep.api import atomic as atomic
+from flowrep.api import dataclass as dataclass
 from flowrep.api import parse_atomic as parse_atomic
 from flowrep.api import parse_workflow as parse_workflow
 from flowrep.api import schemas as schemas

--- a/src/flowrep/api/__init__.py
+++ b/src/flowrep/api/__init__.py
@@ -10,6 +10,7 @@ primarily benefit downstream developers (e.g. WfMS creators).
 from flowrep.api import schemas as schemas
 from flowrep.api import tools as tools
 from flowrep.api.tools import atomic as atomic
+from flowrep.api.tools import dataclass as dataclass
 from flowrep.api.tools import parse_atomic as parse_atomic
 from flowrep.api.tools import parse_workflow as parse_workflow
 from flowrep.api.tools import workflow as workflow

--- a/src/flowrep/api/tools.py
+++ b/src/flowrep/api/tools.py
@@ -10,6 +10,7 @@ from flowrep.converters.python_workflow_definition import flowrep2pwd as flowrep
 from flowrep.converters.python_workflow_definition import pwd2flowrep as pwd2flowrep
 from flowrep.parsers.atomic_parser import atomic as atomic
 from flowrep.parsers.atomic_parser import parse_atomic as parse_atomic
+from flowrep.parsers.dataclass_parser import dataclass as dataclass
 from flowrep.parsers.workflow_parser import parse_workflow as parse_workflow
 from flowrep.parsers.workflow_parser import workflow as workflow
 from flowrep.retrospective.datastructures import recipe2data as recipe2data

--- a/src/flowrep/parsers/dataclass_parser.py
+++ b/src/flowrep/parsers/dataclass_parser.py
@@ -1,0 +1,42 @@
+import dataclasses
+import inspect
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
+
+from flowrep.parsers import atomic_parser
+
+_Cls = TypeVar("_Cls", bound=type)
+
+_DATACLASS_KWARGS = frozenset(
+    name
+    for name, param in inspect.signature(dataclasses.dataclass).parameters.items()
+    if param.kind is inspect.Parameter.KEYWORD_ONLY
+)
+
+
+@overload
+def dataclass(cls: _Cls, /) -> _Cls: ...
+@overload
+def dataclass(
+    label: str | None = None,
+    /,
+    *output_labels: str,
+    **kwargs: Any,
+) -> Callable[[_Cls], _Cls]: ...
+def dataclass(cls=None, /, *output_labels, **kwargs):
+    """Stack ``@dataclasses.dataclass`` then ``@atomic`` on a class.
+
+    Keyword args are routed by name: those matching ``dataclasses.dataclass``
+    go to it, the rest go to ``@atomic``. Usable bare or with arguments.
+    """
+    dataclass_kwargs = {k: v for k, v in kwargs.items() if k in _DATACLASS_KWARGS}
+    atomic_kwargs = {k: v for k, v in kwargs.items() if k not in _DATACLASS_KWARGS}
+
+    bare = isinstance(cls, type)
+    labels = output_labels if bare or cls is None else (cls, *output_labels)
+
+    def wrap(c):
+        c = dataclasses.dataclass(**dataclass_kwargs)(c)
+        return atomic_parser.atomic(*labels, **atomic_kwargs)(c)
+
+    return wrap(cls) if bare else wrap

--- a/tests/unit/parsers/test_dataclass_parser.py
+++ b/tests/unit/parsers/test_dataclass_parser.py
@@ -1,0 +1,114 @@
+import dataclasses
+import inspect
+import unittest
+
+from flowrep.parsers import atomic_parser, dataclass_parser
+from flowrep.prospective import atomic_recipe
+
+
+class TestDataclassDecorator(unittest.TestCase):
+    def test_bare_stacks_dataclass_and_atomic(self):
+        @dataclass_parser.dataclass
+        class Point:
+            x: int = 1
+            y: str = "a"
+
+        self.assertTrue(
+            dataclasses.is_dataclass(Point), "Should apply @dataclasses.dataclass"
+        )
+        self.assertIsInstance(Point.flowrep_recipe, atomic_recipe.AtomicRecipe)
+        self.assertEqual(Point.flowrep_recipe.inputs, ["x", "y"])
+        self.assertEqual(Point.flowrep_recipe.outputs, ["instance"])
+
+    def test_empty_parens(self):
+        @dataclass_parser.dataclass()
+        class Point:
+            x: int = 1
+
+        self.assertTrue(dataclasses.is_dataclass(Point))
+        self.assertEqual(Point.flowrep_recipe.outputs, ["instance"])
+
+    def test_captures_field_defaults(self):
+        @dataclass_parser.dataclass
+        class Point:
+            x: int = 42
+            y: int = 7
+
+        self.assertEqual(
+            Point.flowrep_recipe.reference.inputs_with_defaults, ["x", "y"]
+        )
+        self.assertEqual(Point(), Point(x=42, y=7))
+
+
+class TestDataclassOutputLabels(unittest.TestCase):
+    def test_explicit_output_label(self):
+        @dataclass_parser.dataclass("thing")
+        class Point:
+            x: int = 1
+
+        self.assertEqual(Point.flowrep_recipe.outputs, ["thing"])
+
+    def test_too_many_output_labels_raises(self):
+        with self.assertRaises(ValueError):
+
+            @dataclass_parser.dataclass("a", "b")
+            class Point:
+                x: int = 1
+
+
+class TestDataclassKwargRouting(unittest.TestCase):
+    def test_dataclass_kwarg_routed(self):
+        @dataclass_parser.dataclass(frozen=True)
+        class Point:
+            x: int = 1
+
+        self.assertTrue(Point.__dataclass_params__.frozen)
+        self.assertTrue(hasattr(Point, "flowrep_recipe"))
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            Point(x=1).x = 2
+
+    def test_atomic_kwarg_routed(self):
+        # forbid_locals belongs to @atomic; a class defined in this method has
+        # "<locals>" in its qualname, so routing it through should raise.
+        with self.assertRaisesRegex(ValueError, "<locals>"):
+
+            @dataclass_parser.dataclass(forbid_locals=True)
+            class Point:
+                x: int = 1
+
+    def test_both_kwargs_routed_together(self):
+        @dataclass_parser.dataclass(frozen=True, forbid_main=False)
+        class Point:
+            x: int = 1
+
+        self.assertTrue(Point.__dataclass_params__.frozen)
+        self.assertEqual(Point.flowrep_recipe.inputs, ["x"])
+
+
+class TestDataclassGuardsInherited(unittest.TestCase):
+    def test_recipe_attribute_collision_still_guarded(self):
+        # The collision guard lives in @atomic and should apply transitively.
+        with self.assertRaisesRegex(TypeError, "flowrep_recipe"):
+
+            @dataclass_parser.dataclass
+            class Point:
+                flowrep_recipe: int = 1
+
+
+class TestNamespaceOverlap(unittest.TestCase):
+    def test_dataclass_and_atomic_namespace_overlap(self):
+        atomic_kwargs = frozenset(
+            name
+            for name, param in inspect.signature(
+                atomic_parser.parse_atomic
+            ).parameters.items()
+            if param.kind is inspect.Parameter.KEYWORD_ONLY
+        )
+        self.assertFalse(
+            set(dataclass_parser._DATACLASS_KWARGS).intersection(atomic_kwargs),
+            msg="Ensure that dataclass and atomic kwargs don't overlap.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
To do `@flowrep.atomic` and `@dataclasses.dataclass` at the same time, nothing more. I.e.

```python
import dataclasses

import flowrep as fr

@fr.dataclass("my_dataclass_instance", frozen=True)
class MyDataclass:
    a: str
    x: int = 1

print("Dataclass?", dataclasses.is_dataclass(MyDataclass))
fr.tools.run_recipe(
    MyDataclass.flowrep_recipe, a="one", x=2
).output_ports["my_dataclass_instance"]
```

```
Dataclass? True
OutputDataPort(value=MyDataclass(a='one', x=2), annotation=<class '__main__.MyDataclass'>)
```

Closes #271 