### PR TITLE
Rename LabeledRecipe.node to .recipe

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -230,10 +230,10 @@ We can look at the template it will follow, e.g., by peeking at the part of the 
 used for the "while" condition:
 
 ```python
->>> recipe_json["nodes"]["double_until_0"]["nodes"]["while_0"]["case"]["condition"]["node"]["type"]
+>>> recipe_json["nodes"]["double_until_0"]["nodes"]["while_0"]["case"]["condition"]["recipe"]["type"]
 'atomic'
 
->>> recipe_json["nodes"]["double_until_0"]["nodes"]["while_0"]["case"]["condition"]["node"]["reference"]["info"]["qualname"]
+>>> recipe_json["nodes"]["double_until_0"]["nodes"]["while_0"]["case"]["condition"]["recipe"]["reference"]["info"]["qualname"]
 'is_less_than_target'
 
 ```

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -2031,7 +2031,7 @@
     "print(f\"Zipped ports:  {for_node.zipped_ports}\")\n",
     "print(f\"Input edges:   {for_node.input_edges}\")\n",
     "print(\n",
-    "    f\"Body node:     {for_node.body_node.label} -> {type(for_node.body_node.node).__name__}\"\n",
+    "    f\"Body node:     {for_node.body_node.label} -> {type(for_node.body_node.recipe).__name__}\"\n",
     ")"
    ],
    "id": "b3caee22e3c3befc",
@@ -2729,7 +2729,7 @@
    "cell_type": "code",
    "source": [
     "intermediate = count_up.flowrep_recipe.nodes[\"while_0\"].case.body\n",
-    "print(f\"The intermediate node {intermediate.label!r} is of type {str(intermediate.node.type)!r}\")"
+    "print(f\"The intermediate node {intermediate.label!r} is of type {str(intermediate.recipe.type)!r}\")"
    ],
    "id": "d9bf38390b916b62",
    "outputs": [
@@ -2758,7 +2758,7 @@
    },
    "cell_type": "code",
    "source": [
-    "child_label, child_recipe = next(iter(intermediate.node.nodes.items()))\n",
+    "child_label, child_recipe = next(iter(intermediate.recipe.nodes.items()))\n",
     "print(f\"This workflow has a single-node body: {child_label!r} of type {str(child_recipe.type)!r}\")"
    ],
    "id": "1b2d2b33f6e90e59",

--- a/src/flowrep/compiler/flow_control.py
+++ b/src/flowrep/compiler/flow_control.py
@@ -106,7 +106,7 @@ def _emit_for_each(
     lines = [f"{out_syms[port]} = []" for port in node.outputs]
 
     body_label = node.body_node.label
-    body = node.body_node.node
+    body = node.body_node.recipe
 
     def collection_symbol(body_port: str) -> str:
         """Return the enclosing-scope symbol that feeds a body port."""
@@ -178,7 +178,7 @@ def _render_condition(
     alloc: function.NameAllocator,
 ) -> str:
     """Render a condition call as an inline expression (no assignment)."""
-    cond_node = case_condition.node
+    cond_node = case_condition.recipe
     cond_label = case_condition.label
     call_path = statements.node_call_path(cond_node, cond_label, emitter, alloc)
     if call_path is None:
@@ -244,7 +244,7 @@ def _emit_if(
         lines.append(f"{keyword} {cond_expr}:")
         body = _emit_branch(
             case.body.label,
-            case.body.node,
+            case.body.recipe,
             node,
             in_resolver,
             out_syms,
@@ -256,7 +256,7 @@ def _emit_if(
         lines.append("else:")
         body = _emit_branch(
             node.else_case.label,
-            node.else_case.node,
+            node.else_case.recipe,
             node,
             in_resolver,
             out_syms,
@@ -290,7 +290,7 @@ def _emit_try(
     # try body
     try_lines = _emit_branch(
         node.try_node.label,
-        node.try_node.node,
+        node.try_node.recipe,
         node,
         in_resolver,
         out_syms,
@@ -309,7 +309,7 @@ def _emit_try(
         lines.append(header)
         body = _emit_branch(
             case.body.label,
-            case.body.node,
+            case.body.recipe,
             node,
             in_resolver,
             out_syms,
@@ -332,7 +332,7 @@ def _emit_while(
     cond_expr = _render_condition(case.condition, node, in_resolver, emitter, alloc)
 
     body_label = case.body.label
-    body = case.body.node
+    body = case.body.recipe
 
     # Map body inputs to enclosing-scope symbols (unwired defaults are omitted).
     body_in_syms: dict[str, str] = {}

--- a/src/flowrep/compiler/function.py
+++ b/src/flowrep/compiler/function.py
@@ -137,18 +137,18 @@ def _collect_loop_variables(
 ) -> None:
     if isinstance(node, for_recipe.ForEachRecipe):
         names.update(node.iterated_ports)
-        _collect_loop_variables_from_body(node.body_node.node, names)
+        _collect_loop_variables_from_body(node.body_node.recipe, names)
     elif isinstance(node, if_recipe.IfRecipe):
         for body_case in node.cases:
-            _collect_loop_variables_from_body(body_case.body.node, names)
+            _collect_loop_variables_from_body(body_case.body.recipe, names)
         if node.else_case is not None:
-            _collect_loop_variables_from_body(node.else_case.node, names)
+            _collect_loop_variables_from_body(node.else_case.recipe, names)
     elif isinstance(node, try_recipe.TryRecipe):
-        _collect_loop_variables_from_body(node.try_node.node, names)
+        _collect_loop_variables_from_body(node.try_node.recipe, names)
         for exception_case in node.exception_cases:
-            _collect_loop_variables_from_body(exception_case.body.node, names)
+            _collect_loop_variables_from_body(exception_case.body.recipe, names)
     elif isinstance(node, while_recipe.WhileRecipe):
-        _collect_loop_variables_from_body(node.case.body.node, names)
+        _collect_loop_variables_from_body(node.case.body.recipe, names)
     # atomic / referenced / reference-free workflow peer node: not inlined here
 
 

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -344,7 +344,7 @@ def get_labeled_recipe(
                 require_version=info_factory.require_version,
             )
     label = label_helpers.unique_suffix(label_prefix, existing_names)
-    return helper_models.LabeledRecipe(label=label, node=child_recipe)
+    return helper_models.LabeledRecipe(label=label, recipe=child_recipe)
 
 
 def _infer_node_name(node: base_models.NodeRecipe, ast_call: ast.expr) -> str:

--- a/src/flowrep/parsers/case_helpers.py
+++ b/src/flowrep/parsers/case_helpers.py
@@ -41,10 +41,10 @@ def parse_case(
         )
 
     condition = atomic_parser.get_labeled_recipe(test, set(), scope, info_factory)
-    if len(condition.node.outputs) != 1:
+    if len(condition.recipe.outputs) != 1:
         raise ValueError(
             f"If/elif condition must return exactly one value (and it had better be "
-            f"truthy), but got {condition.node.outputs}"
+            f"truthy), but got {condition.recipe.outputs}"
         )
 
     scope_copy = symbol_map.fork()
@@ -69,7 +69,7 @@ def _relabel_node_data(
     new_label: str,
 ) -> tuple[helper_models.LabeledRecipe, edge_models.InputEdges]:
     relabeled_node = helper_models.LabeledRecipe(
-        label=new_label, node=labeled_node.node
+        label=new_label, recipe=labeled_node.recipe
     )
     relabeled_inputs: edge_models.InputEdges = {
         edge_models.TargetHandle(node=new_label, port=target.port): source
@@ -87,7 +87,7 @@ class WalkedBranch:
     def to_labeled_node(self) -> helper_models.LabeledRecipe:
         return helper_models.LabeledRecipe(
             label=self.label,
-            node=self.walker.build_model(),
+            recipe=self.walker.build_model(),
         )
 
 

--- a/src/flowrep/parsers/for_parser.py
+++ b/src/flowrep/parsers/for_parser.py
@@ -62,7 +62,7 @@ def parse_for_node(
     outputs, output_edges = _wire_outputs(body_walker, input_edges)
 
     body_node = helper_models.LabeledRecipe(
-        label=FOR_BODY_LABEL, node=body_walker.build_model()
+        label=FOR_BODY_LABEL, recipe=body_walker.build_model()
     )
 
     return for_recipe.ForEachRecipe(

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -194,7 +194,7 @@ def consume_call_arguments(
         constant_parser.inject_constant(nodes, scope, value, child.label, consumer_port)
 
     for i, arg in enumerate(ast_call.args):
-        _consume(arg, child.node.inputs[i])
+        _consume(arg, child.recipe.inputs[i])
     for kw in ast_call.keywords:
         if not isinstance(kw.arg, str):  # pragma: no cover
             raise TypeError(

--- a/src/flowrep/parsers/symbol_scope.py
+++ b/src/flowrep/parsers/symbol_scope.py
@@ -157,9 +157,9 @@ class SymbolScope(Mapping[str, edge_models.InputSource | edge_models.SourceHandl
             raise ValueError(
                 f"Symbol(s) {overshadowed} already registered as accumulators."
             )
-        if len(new_symbols) != len(child.node.outputs):
+        if len(new_symbols) != len(child.recipe.outputs):
             raise ValueError(
-                f"Cannot map {child.node.outputs} to symbols {new_symbols}"
+                f"Cannot map {child.recipe.outputs} to symbols {new_symbols}"
             )
         reassigned = [s for s in new_symbols if s in self._sources]
         for symbol in reassigned:
@@ -168,7 +168,7 @@ class SymbolScope(Mapping[str, edge_models.InputSource | edge_models.SourceHandl
         self._sources.update(
             {
                 sym: edge_models.SourceHandle(node=child.label, port=port)
-                for sym, port in zip(new_symbols, child.node.outputs, strict=True)
+                for sym, port in zip(new_symbols, child.recipe.outputs, strict=True)
             }
         )
 

--- a/src/flowrep/parsers/while_parser.py
+++ b/src/flowrep/parsers/while_parser.py
@@ -54,7 +54,7 @@ def parse_while_node(
     case = helper_models.ConditionalCase(
         condition=labeled_condition,
         body=helper_models.LabeledRecipe(
-            label=WHILE_BODY_LABEL, node=body_walker.build_model()
+            label=WHILE_BODY_LABEL, recipe=body_walker.build_model()
         ),
     )
 

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -277,7 +277,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
                 self.scope,
                 self.info_factory,
             )
-            self.nodes[child.label] = child.node
+            self.nodes[child.label] = child.recipe
             parser_helpers.consume_call_arguments(
                 self.symbol_map, rhs, child, self.nodes
             )
@@ -304,7 +304,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             )
             self.nodes[label] = node
             self.symbol_map.register(
-                new_symbols, helper_models.LabeledRecipe(label=label, node=node)
+                new_symbols, helper_models.LabeledRecipe(label=label, recipe=node)
             )
         elif isinstance(rhs, ast.Name):
             if len(new_symbols) != 1:
@@ -350,7 +350,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             else:
                 self.symbol_map.consume(port, label, port)
 
-        labeled_node = helper_models.LabeledRecipe(label=label, node=node)
+        labeled_node = helper_models.LabeledRecipe(label=label, recipe=node)
         self.symbol_map.register(new_symbols=node.outputs, child=labeled_node)
 
     def visit_For(self, tree: ast.For) -> None:

--- a/src/flowrep/prospective/for_recipe.py
+++ b/src/flowrep/prospective/for_recipe.py
@@ -84,7 +84,7 @@ class ForEachRecipe(base_models.NodeRecipe):
 
     @property
     def prospective_nodes(self) -> Recipes:
-        return {self.body_node.label: self.body_node.node}
+        return {self.body_node.label: self.body_node.recipe}
 
     @property
     def iterated_ports(self) -> base_models.Labels:
@@ -165,11 +165,11 @@ class ForEachRecipe(base_models.NodeRecipe):
         if invalid := {
             port
             for port in self.iterated_ports
-            if port not in self.body_node.node.inputs
+            if port not in self.body_node.recipe.inputs
         }:
             raise ValueError(
                 f"For node must iterate on body node ports "
-                f"({self.body_node.node.inputs}) but got: {invalid}"
+                f"({self.body_node.recipe.inputs}) but got: {invalid}"
             )
         return self
 

--- a/src/flowrep/prospective/helper_models.py
+++ b/src/flowrep/prospective/helper_models.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 class LabeledRecipe(pydantic.BaseModel):
     label: base_models.Label
-    node: "RecipeDiscrimination"  # noqa: F821, UP037
+    recipe: "RecipeDiscrimination"  # noqa: F821, UP037
 
 
 class ConditionalCase(pydantic.BaseModel):
@@ -30,15 +30,15 @@ class ConditionalCase(pydantic.BaseModel):
     @pydantic.model_validator(mode="after")
     def validate_condition_is_accessible(self):
         if self.condition_output is None:
-            if len(self.condition.node.outputs) != 1:
+            if len(self.condition.recipe.outputs) != 1:
                 raise ValueError(
                     f"condition must have exactly one output if condition_output is not "
-                    f"provided. Got condition outputs: {self.condition.node.outputs}"
+                    f"provided. Got condition outputs: {self.condition.recipe.outputs}"
                 )
-        elif self.condition_output not in self.condition.node.outputs:
+        elif self.condition_output not in self.condition.recipe.outputs:
             raise ValueError(
                 f"condition_output '{self.condition_output}' is not found among "
-                f"available outputs: {self.condition.node.outputs}"
+                f"available outputs: {self.condition.recipe.outputs}"
             )
         return self
 

--- a/src/flowrep/prospective/if_recipe.py
+++ b/src/flowrep/prospective/if_recipe.py
@@ -61,11 +61,11 @@ class IfRecipe(base_models.NodeRecipe):
     def prospective_nodes(self) -> Recipes:
         nodes = {}
         for case in self.cases:
-            nodes[case.condition.label] = case.condition.node
-            nodes[case.body.label] = case.body.node
+            nodes[case.condition.label] = case.condition.recipe
+            nodes[case.body.label] = case.body.recipe
 
         if self.else_case:
-            nodes[self.else_case.label] = self.else_case.node
+            nodes[self.else_case.label] = self.else_case.recipe
         return nodes
 
     @pydantic.model_validator(mode="after")

--- a/src/flowrep/prospective/std.py
+++ b/src/flowrep/prospective/std.py
@@ -14,7 +14,7 @@ from flowrep.prospective import atomic_recipe, helper_models
 
 abs = helper_models.LabeledRecipe(
     label="abs",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.abs),
             restricted_input_kinds={
@@ -29,7 +29,7 @@ abs = helper_models.LabeledRecipe(
 
 add = helper_models.LabeledRecipe(
     label="add",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.add),
             restricted_input_kinds={
@@ -45,7 +45,7 @@ add = helper_models.LabeledRecipe(
 
 index = helper_models.LabeledRecipe(
     label="index",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.index),
             restricted_input_kinds={
@@ -60,7 +60,7 @@ index = helper_models.LabeledRecipe(
 
 inv = helper_models.LabeledRecipe(
     label="inv",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.inv),
             restricted_input_kinds={
@@ -75,7 +75,7 @@ inv = helper_models.LabeledRecipe(
 
 invert = helper_models.LabeledRecipe(
     label="invert",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.invert),
             restricted_input_kinds={
@@ -90,7 +90,7 @@ invert = helper_models.LabeledRecipe(
 
 neg = helper_models.LabeledRecipe(
     label="neg",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.neg),
             restricted_input_kinds={
@@ -105,7 +105,7 @@ neg = helper_models.LabeledRecipe(
 
 pos = helper_models.LabeledRecipe(
     label="pos",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.pos),
             restricted_input_kinds={
@@ -120,7 +120,7 @@ pos = helper_models.LabeledRecipe(
 
 not_ = helper_models.LabeledRecipe(
     label="not_",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.not_),
             restricted_input_kinds={
@@ -135,7 +135,7 @@ not_ = helper_models.LabeledRecipe(
 
 truth = helper_models.LabeledRecipe(
     label="truth",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.truth),
             restricted_input_kinds={
@@ -150,7 +150,7 @@ truth = helper_models.LabeledRecipe(
 
 length_hint = helper_models.LabeledRecipe(
     label="length_hint",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.length_hint),
             restricted_input_kinds={
@@ -165,7 +165,7 @@ length_hint = helper_models.LabeledRecipe(
 
 sub = helper_models.LabeledRecipe(
     label="sub",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.sub),
             restricted_input_kinds={
@@ -181,7 +181,7 @@ sub = helper_models.LabeledRecipe(
 
 isub = helper_models.LabeledRecipe(
     label="isub",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.isub),
             restricted_input_kinds={
@@ -197,7 +197,7 @@ isub = helper_models.LabeledRecipe(
 
 iadd = helper_models.LabeledRecipe(
     label="iadd",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.iadd),
             restricted_input_kinds={
@@ -213,7 +213,7 @@ iadd = helper_models.LabeledRecipe(
 
 mul = helper_models.LabeledRecipe(
     label="mul",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.mul),
             restricted_input_kinds={
@@ -229,7 +229,7 @@ mul = helper_models.LabeledRecipe(
 
 imul = helper_models.LabeledRecipe(
     label="imul",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.imul),
             restricted_input_kinds={
@@ -245,7 +245,7 @@ imul = helper_models.LabeledRecipe(
 
 floordiv = helper_models.LabeledRecipe(
     label="floordiv",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.floordiv),
             restricted_input_kinds={
@@ -261,7 +261,7 @@ floordiv = helper_models.LabeledRecipe(
 
 ifloordiv = helper_models.LabeledRecipe(
     label="ifloordiv",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.ifloordiv),
             restricted_input_kinds={
@@ -277,7 +277,7 @@ ifloordiv = helper_models.LabeledRecipe(
 
 truediv = helper_models.LabeledRecipe(
     label="truediv",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.truediv),
             restricted_input_kinds={
@@ -293,7 +293,7 @@ truediv = helper_models.LabeledRecipe(
 
 itruediv = helper_models.LabeledRecipe(
     label="itruediv",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.itruediv),
             restricted_input_kinds={
@@ -309,7 +309,7 @@ itruediv = helper_models.LabeledRecipe(
 
 mod = helper_models.LabeledRecipe(
     label="mod",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.mod),
             restricted_input_kinds={
@@ -325,7 +325,7 @@ mod = helper_models.LabeledRecipe(
 
 imod = helper_models.LabeledRecipe(
     label="imod",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.imod),
             restricted_input_kinds={
@@ -341,7 +341,7 @@ imod = helper_models.LabeledRecipe(
 
 pow = helper_models.LabeledRecipe(
     label="pow",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.pow),
             restricted_input_kinds={
@@ -357,7 +357,7 @@ pow = helper_models.LabeledRecipe(
 
 ipow = helper_models.LabeledRecipe(
     label="ipow",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.ipow),
             restricted_input_kinds={
@@ -373,7 +373,7 @@ ipow = helper_models.LabeledRecipe(
 
 and_ = helper_models.LabeledRecipe(
     label="and_",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.and_),
             restricted_input_kinds={
@@ -389,7 +389,7 @@ and_ = helper_models.LabeledRecipe(
 
 iand = helper_models.LabeledRecipe(
     label="iand",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.iand),
             restricted_input_kinds={
@@ -405,7 +405,7 @@ iand = helper_models.LabeledRecipe(
 
 or_ = helper_models.LabeledRecipe(
     label="or_",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.or_),
             restricted_input_kinds={
@@ -421,7 +421,7 @@ or_ = helper_models.LabeledRecipe(
 
 ior = helper_models.LabeledRecipe(
     label="ior",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.ior),
             restricted_input_kinds={
@@ -437,7 +437,7 @@ ior = helper_models.LabeledRecipe(
 
 xor = helper_models.LabeledRecipe(
     label="xor",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.xor),
             restricted_input_kinds={
@@ -453,7 +453,7 @@ xor = helper_models.LabeledRecipe(
 
 ixor = helper_models.LabeledRecipe(
     label="ixor",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.ixor),
             restricted_input_kinds={
@@ -469,7 +469,7 @@ ixor = helper_models.LabeledRecipe(
 
 lshift = helper_models.LabeledRecipe(
     label="lshift",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.lshift),
             restricted_input_kinds={
@@ -485,7 +485,7 @@ lshift = helper_models.LabeledRecipe(
 
 ilshift = helper_models.LabeledRecipe(
     label="ilshift",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.ilshift),
             restricted_input_kinds={
@@ -501,7 +501,7 @@ ilshift = helper_models.LabeledRecipe(
 
 rshift = helper_models.LabeledRecipe(
     label="rshift",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.rshift),
             restricted_input_kinds={
@@ -517,7 +517,7 @@ rshift = helper_models.LabeledRecipe(
 
 irshift = helper_models.LabeledRecipe(
     label="irshift",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.irshift),
             restricted_input_kinds={
@@ -533,7 +533,7 @@ irshift = helper_models.LabeledRecipe(
 
 matmul = helper_models.LabeledRecipe(
     label="matmul",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.matmul),
             restricted_input_kinds={
@@ -549,7 +549,7 @@ matmul = helper_models.LabeledRecipe(
 
 imatmul = helper_models.LabeledRecipe(
     label="imatmul",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.imatmul),
             restricted_input_kinds={
@@ -565,7 +565,7 @@ imatmul = helper_models.LabeledRecipe(
 
 eq = helper_models.LabeledRecipe(
     label="eq",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.eq),
             restricted_input_kinds={
@@ -581,7 +581,7 @@ eq = helper_models.LabeledRecipe(
 
 ne = helper_models.LabeledRecipe(
     label="ne",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.ne),
             restricted_input_kinds={
@@ -597,7 +597,7 @@ ne = helper_models.LabeledRecipe(
 
 lt = helper_models.LabeledRecipe(
     label="lt",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.lt),
             restricted_input_kinds={
@@ -613,7 +613,7 @@ lt = helper_models.LabeledRecipe(
 
 le = helper_models.LabeledRecipe(
     label="le",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.le),
             restricted_input_kinds={
@@ -629,7 +629,7 @@ le = helper_models.LabeledRecipe(
 
 gt = helper_models.LabeledRecipe(
     label="gt",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.gt),
             restricted_input_kinds={
@@ -645,7 +645,7 @@ gt = helper_models.LabeledRecipe(
 
 ge = helper_models.LabeledRecipe(
     label="ge",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.ge),
             restricted_input_kinds={
@@ -661,7 +661,7 @@ ge = helper_models.LabeledRecipe(
 
 is_ = helper_models.LabeledRecipe(
     label="is_",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.is_),
             restricted_input_kinds={
@@ -677,7 +677,7 @@ is_ = helper_models.LabeledRecipe(
 
 is_not = helper_models.LabeledRecipe(
     label="is_not",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.is_not),
             restricted_input_kinds={
@@ -693,7 +693,7 @@ is_not = helper_models.LabeledRecipe(
 
 contains = helper_models.LabeledRecipe(
     label="contains",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.contains),
             restricted_input_kinds={
@@ -709,7 +709,7 @@ contains = helper_models.LabeledRecipe(
 
 countOf = helper_models.LabeledRecipe(
     label="countOf",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.countOf),
             restricted_input_kinds={
@@ -725,7 +725,7 @@ countOf = helper_models.LabeledRecipe(
 
 indexOf = helper_models.LabeledRecipe(
     label="indexOf",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.indexOf),
             restricted_input_kinds={
@@ -741,7 +741,7 @@ indexOf = helper_models.LabeledRecipe(
 
 concat = helper_models.LabeledRecipe(
     label="concat",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.concat),
             restricted_input_kinds={
@@ -757,7 +757,7 @@ concat = helper_models.LabeledRecipe(
 
 iconcat = helper_models.LabeledRecipe(
     label="iconcat",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.iconcat),
             restricted_input_kinds={
@@ -773,7 +773,7 @@ iconcat = helper_models.LabeledRecipe(
 
 getitem = helper_models.LabeledRecipe(
     label="getitem",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.getitem),
             restricted_input_kinds={
@@ -789,7 +789,7 @@ getitem = helper_models.LabeledRecipe(
 
 setitem = helper_models.LabeledRecipe(
     label="setitem",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.setitem),
             restricted_input_kinds={
@@ -806,7 +806,7 @@ setitem = helper_models.LabeledRecipe(
 
 delitem = helper_models.LabeledRecipe(
     label="delitem",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(operator.delitem),
             restricted_input_kinds={
@@ -833,7 +833,7 @@ def _call_wrapper(
 
 call = helper_models.LabeledRecipe(
     label="call",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(_call_wrapper),
             restricted_input_kinds={
@@ -862,7 +862,7 @@ def _getattr_wrapper(
 
 getattr_ = helper_models.LabeledRecipe(
     label="getattr_",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(_getattr_wrapper),
             restricted_input_kinds={
@@ -883,7 +883,7 @@ def _identity_function(x):
 
 identity = helper_models.LabeledRecipe(
     label="identity",
-    node=atomic_recipe.AtomicRecipe(
+    recipe=atomic_recipe.AtomicRecipe(
         reference=base_models.PythonReference(
             info=versions.VersionInfo.of(_identity_function),
         ),

--- a/src/flowrep/prospective/try_recipe.py
+++ b/src/flowrep/prospective/try_recipe.py
@@ -58,9 +58,9 @@ class TryRecipe(base_models.NodeRecipe):
 
     @property
     def prospective_nodes(self) -> Recipes:
-        nodes = {self.try_node.label: self.try_node.node}
+        nodes = {self.try_node.label: self.try_node.recipe}
         for case in self.exception_cases:
-            nodes[case.body.label] = case.body.node
+            nodes[case.body.label] = case.body.recipe
         return nodes
 
     @pydantic.model_validator(mode="after")

--- a/src/flowrep/prospective/while_recipe.py
+++ b/src/flowrep/prospective/while_recipe.py
@@ -73,8 +73,8 @@ class WhileRecipe(base_models.NodeRecipe):
     @property
     def prospective_nodes(self) -> Recipes:
         return {
-            self.case.condition.label: self.case.condition.node,
-            self.case.body.label: self.case.body.node,
+            self.case.condition.label: self.case.condition.recipe,
+            self.case.body.label: self.case.body.recipe,
         }
 
     @property

--- a/src/flowrep/wfms.py
+++ b/src/flowrep/wfms.py
@@ -231,7 +231,7 @@ def _run_for(
     _populate_input_ports(node, kwargs)
 
     body_label = recipe.body_node.label
-    body_recipe = recipe.body_node.node
+    body_recipe = recipe.body_node.recipe
     iterated_ports = recipe.iterated_ports
 
     # body iterated port -> for-node input name
@@ -321,8 +321,8 @@ def _run_while(
 
     cond_label = recipe.case.condition.label
     body_label = recipe.case.body.label
-    cond_recipe = recipe.case.condition.node
-    body_recipe = recipe.case.body.node
+    cond_recipe = recipe.case.condition.recipe
+    body_recipe = recipe.case.body.recipe
 
     # Working copy of current values — starts from inputs, body outputs update it
     current: dict[str, Any] = {
@@ -380,7 +380,7 @@ def _run_if(recipe: if_recipe.IfRecipe, **kwargs: Any) -> datastructures.IfData:
         cond_kwargs = _gather_dynamic_child_inputs(
             case.condition.label, recipe.input_edges, node
         )
-        cond_node = run_recipe(case.condition.node, **cond_kwargs)
+        cond_node = run_recipe(case.condition.recipe, **cond_kwargs)
         node.nodes[case.condition.label] = cond_node
 
         if _evaluate_condition(case, cond_node):
@@ -400,7 +400,7 @@ def _execute_if_branch(
     branch: helper_models.LabeledRecipe,
 ) -> None:
     branch_kwargs = _gather_dynamic_child_inputs(branch.label, recipe.input_edges, node)
-    branch_node = run_recipe(branch.node, **branch_kwargs)
+    branch_node = run_recipe(branch.recipe, **branch_kwargs)
     node.nodes[branch.label] = branch_node
 
     _populate_prospective_outputs(node, recipe.prospective_output_edges, branch.label)
@@ -424,7 +424,7 @@ def _run_try(recipe: try_recipe.TryRecipe, **kwargs: Any) -> datastructures.TryD
     )
 
     try:
-        try_node = run_recipe(recipe.try_node.node, **try_kwargs)
+        try_node = run_recipe(recipe.try_node.recipe, **try_kwargs)
         node.nodes[recipe.try_node.label] = try_node
         _populate_prospective_outputs(
             node, recipe.prospective_output_edges, recipe.try_node.label
@@ -440,7 +440,7 @@ def _run_try(recipe: try_recipe.TryRecipe, **kwargs: Any) -> datastructures.TryD
                 handler_kwargs = _gather_dynamic_child_inputs(
                     case.body.label, recipe.input_edges, node
                 )
-                handler_node = run_recipe(case.body.node, **handler_kwargs)
+                handler_node = run_recipe(case.body.recipe, **handler_kwargs)
                 node.nodes[case.body.label] = handler_node
                 _populate_prospective_outputs(
                     node, recipe.prospective_output_edges, case.body.label

--- a/tests/flowrep_static/makers.py
+++ b/tests/flowrep_static/makers.py
@@ -55,7 +55,7 @@ def make_labeled_atomic(
 ) -> helper_models.LabeledRecipe:
     return helper_models.LabeledRecipe(
         label=label,
-        node=make_atomic(
+        recipe=make_atomic(
             inputs=inputs or [],
             outputs=outputs or [],
             module=module,

--- a/tests/integration/parsers/test_parsing_composite_workflow.py
+++ b/tests/integration/parsers/test_parsing_composite_workflow.py
@@ -90,13 +90,13 @@ _if_node = {
         {
             "condition": {
                 "label": "condition_0",
-                "node": library.my_condition.flowrep_recipe,
+                "recipe": library.my_condition.flowrep_recipe,
             },
-            "body": {"label": "body_0", "node": _if_true_body},
+            "body": {"label": "body_0", "recipe": _if_true_body},
             "condition_output": None,
         },
     ],
-    "else_case": {"label": "else_body", "node": _if_else_body},
+    "else_case": {"label": "else_body", "recipe": _if_else_body},
     "input_edges": {
         "condition_0.m": "r",
         "condition_0.n": "y",
@@ -124,7 +124,7 @@ _for_node = {
     "type": "for_each",
     "inputs": ["y", "c", "rs"],
     "outputs": ["acc"],
-    "body_node": {"label": "body", "node": _for_body},
+    "body_node": {"label": "body", "recipe": _for_body},
     "input_edges": {"body.y": "y", "body.c": "c", "body.r": "rs"},
     "output_edges": {"acc": "body.v"},
     "nested_ports": ["r"],
@@ -164,9 +164,9 @@ _while_node = {
     "case": {
         "condition": {
             "label": "condition",
-            "node": library.my_condition.flowrep_recipe,
+            "recipe": library.my_condition.flowrep_recipe,
         },
-        "body": {"label": "body", "node": _while_body},
+        "body": {"label": "body", "recipe": _while_body},
         "condition_output": None,
     },
     "input_edges": {
@@ -219,11 +219,11 @@ _try_node = {
     "type": "try",
     "inputs": ["a", "y", "bound"],
     "outputs": ["b", "z"],
-    "try_node": {"label": "try_body", "node": _try_body},
+    "try_node": {"label": "try_body", "recipe": _try_body},
     "exception_cases": [
         {
             "exceptions": [versions.VersionInfo.of(ValueError)],
-            "body": {"label": "except_body_0", "node": _except_body},
+            "body": {"label": "except_body_0", "recipe": _except_body},
         },
     ],
     "input_edges": {

--- a/tests/integration/parsers/test_parsing_for_nodes.py
+++ b/tests/integration/parsers/test_parsing_for_nodes.py
@@ -47,7 +47,7 @@ for_node = for_recipe.ForEachRecipe.model_validate(
         "type": "for_each",
         "inputs": ["pass_through"],
         "outputs": ["vecs"],
-        "body_node": {"label": "body", "node": for_body},
+        "body_node": {"label": "body", "recipe": for_body},
         "input_edges": {"body.n": "pass_through"},
         "output_edges": {"vecs": "body.rs"},
         "nested_ports": ["n"],
@@ -137,7 +137,7 @@ zbat_for_node = for_recipe.ForEachRecipe.model_validate(
             "d_accumulator",
             "sums",
         ],
-        "body_node": {"label": "body", "node": zbat_for_body},
+        "body_node": {"label": "body", "recipe": zbat_for_body},
         "input_edges": {
             "body.a": "a",
             "body.b": "bs",
@@ -234,7 +234,7 @@ nested_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "outputs": ["sq_sums"],
                 "body_node": {
                     "label": "body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["n"],
                         "outputs": ["summed"],
@@ -246,7 +246,7 @@ nested_node = workflow_recipe.WorkflowRecipe.model_validate(
                                 "outputs": ["squares"],
                                 "body_node": {
                                     "label": "body",
-                                    "node": {
+                                    "recipe": {
                                         "type": "workflow",
                                         "inputs": ["r"],
                                         "outputs": ["sq"],
@@ -340,7 +340,7 @@ nested_with_passed_input_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "outputs": ["sq_sums"],
                 "body_node": {
                     "label": "body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["n", "range_offset", "square_offset"],
                         "outputs": ["summed"],
@@ -352,7 +352,7 @@ nested_with_passed_input_node = workflow_recipe.WorkflowRecipe.model_validate(
                                 "outputs": ["squares"],
                                 "body_node": {
                                     "label": "body",
-                                    "node": {
+                                    "recipe": {
                                         "type": "workflow",
                                         "inputs": ["r", "square_offset"],
                                         "outputs": ["sq"],

--- a/tests/integration/parsers/test_parsing_if_nodes.py
+++ b/tests/integration/parsers/test_parsing_if_nodes.py
@@ -29,11 +29,11 @@ simple_node = workflow_recipe.WorkflowRecipe.model_validate(
                     {
                         "condition": {
                             "label": "condition_0",
-                            "node": library.my_condition.flowrep_recipe,
+                            "recipe": library.my_condition.flowrep_recipe,
                         },
                         "body": {
                             "label": "body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["z"],
@@ -50,7 +50,7 @@ simple_node = workflow_recipe.WorkflowRecipe.model_validate(
                 ],
                 "else_case": {
                     "label": "else_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "y"],
                         "outputs": ["z"],
@@ -113,11 +113,11 @@ elif_node = workflow_recipe.WorkflowRecipe.model_validate(
                     {
                         "condition": {
                             "label": "condition_0",
-                            "node": library.my_condition.flowrep_recipe,
+                            "recipe": library.my_condition.flowrep_recipe,
                         },
                         "body": {
                             "label": "body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["z"],
@@ -134,11 +134,11 @@ elif_node = workflow_recipe.WorkflowRecipe.model_validate(
                     {
                         "condition": {
                             "label": "condition_1",
-                            "node": library.my_condition.flowrep_recipe,
+                            "recipe": library.my_condition.flowrep_recipe,
                         },
                         "body": {
                             "label": "body_1",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["z"],
@@ -155,7 +155,7 @@ elif_node = workflow_recipe.WorkflowRecipe.model_validate(
                 ],
                 "else_case": {
                     "label": "else_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["y", "flag"],
                         "outputs": ["z"],
@@ -225,11 +225,11 @@ context_node = workflow_recipe.WorkflowRecipe.model_validate(
                     {
                         "condition": {
                             "label": "condition_0",
-                            "node": library.my_condition.flowrep_recipe,
+                            "recipe": library.my_condition.flowrep_recipe,
                         },
                         "body": {
                             "label": "body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "b"],
                                 "outputs": ["y"],
@@ -246,7 +246,7 @@ context_node = workflow_recipe.WorkflowRecipe.model_validate(
                 ],
                 "else_case": {
                     "label": "else_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "b"],
                         "outputs": ["y"],
@@ -310,11 +310,11 @@ multi_output_node = workflow_recipe.WorkflowRecipe.model_validate(
                     {
                         "condition": {
                             "label": "condition_0",
-                            "node": library.my_condition.flowrep_recipe,
+                            "recipe": library.my_condition.flowrep_recipe,
                         },
                         "body": {
                             "label": "body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["a", "b"],
@@ -340,7 +340,7 @@ multi_output_node = workflow_recipe.WorkflowRecipe.model_validate(
                 ],
                 "else_case": {
                     "label": "else_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "y"],
                         "outputs": ["a", "b"],
@@ -414,11 +414,11 @@ no_else_node = workflow_recipe.WorkflowRecipe.model_validate(
                     {
                         "condition": {
                             "label": "condition_0",
-                            "node": library.my_condition.flowrep_recipe,
+                            "recipe": library.my_condition.flowrep_recipe,
                         },
                         "body": {
                             "label": "body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["z"],

--- a/tests/integration/parsers/test_parsing_try_nodes.py
+++ b/tests/integration/parsers/test_parsing_try_nodes.py
@@ -32,7 +32,7 @@ simple_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "outputs": ["z"],
                 "try_node": {
                     "label": "try_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "y"],
                         "outputs": ["z"],
@@ -49,7 +49,7 @@ simple_node = workflow_recipe.WorkflowRecipe.model_validate(
                         "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["z"],
@@ -115,7 +115,7 @@ multi_except_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "outputs": ["z"],
                 "try_node": {
                     "label": "try_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "y"],
                         "outputs": ["z"],
@@ -132,7 +132,7 @@ multi_except_node = workflow_recipe.WorkflowRecipe.model_validate(
                         "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["z"],
@@ -152,7 +152,7 @@ multi_except_node = workflow_recipe.WorkflowRecipe.model_validate(
                         "exceptions": [_TYPE_ERROR_INFO],
                         "body": {
                             "label": "except_body_1",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x"],
                                 "outputs": ["z"],
@@ -221,7 +221,7 @@ context_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "outputs": ["y"],
                 "try_node": {
                     "label": "try_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "b"],
                         "outputs": ["y"],
@@ -238,7 +238,7 @@ context_node = workflow_recipe.WorkflowRecipe.model_validate(
                         "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "b"],
                                 "outputs": ["y"],
@@ -308,7 +308,7 @@ multi_output_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "outputs": ["a", "b"],
                 "try_node": {
                     "label": "try_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "y"],
                         "outputs": ["a", "b"],
@@ -334,7 +334,7 @@ multi_output_node = workflow_recipe.WorkflowRecipe.model_validate(
                         "exceptions": [_VALUE_ERROR_INFO],
                         "body": {
                             "label": "except_body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["a", "b"],
@@ -405,7 +405,7 @@ tuple_exc_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "outputs": ["z"],
                 "try_node": {
                     "label": "try_body",
-                    "node": {
+                    "recipe": {
                         "type": "workflow",
                         "inputs": ["x", "y"],
                         "outputs": ["z"],
@@ -425,7 +425,7 @@ tuple_exc_node = workflow_recipe.WorkflowRecipe.model_validate(
                         ],
                         "body": {
                             "label": "except_body_0",
-                            "node": {
+                            "recipe": {
                                 "type": "workflow",
                                 "inputs": ["x", "y"],
                                 "outputs": ["z"],

--- a/tests/integration/parsers/test_parsing_while_nodes.py
+++ b/tests/integration/parsers/test_parsing_while_nodes.py
@@ -36,11 +36,11 @@ simple_while_while_node = while_recipe.WhileRecipe.model_validate(
         "case": {
             "condition": {
                 "label": "condition",
-                "node": library.my_condition.flowrep_recipe,
+                "recipe": library.my_condition.flowrep_recipe,
             },
             "body": {
                 "label": "body",
-                "node": simple_while_while_node_body,
+                "recipe": simple_while_while_node_body,
             },
         },
         "input_edges": {
@@ -109,11 +109,11 @@ nest_while_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "case": {
                     "condition": {
                         "label": "condition",
-                        "node": library.my_condition.flowrep_recipe,
+                        "recipe": library.my_condition.flowrep_recipe,
                     },
                     "body": {
                         "label": "body",
-                        "node": {
+                        "recipe": {
                             "type": "workflow",
                             "inputs": ["x", "a", "y", "n"],
                             "outputs": ["x", "y"],
@@ -126,11 +126,11 @@ nest_while_node = workflow_recipe.WorkflowRecipe.model_validate(
                                     "case": {
                                         "condition": {
                                             "label": "condition",
-                                            "node": library.my_condition.flowrep_recipe,
+                                            "recipe": library.my_condition.flowrep_recipe,
                                         },
                                         "body": {
                                             "label": "body",
-                                            "node": {
+                                            "recipe": {
                                                 "type": "workflow",
                                                 "inputs": ["y", "x"],
                                                 "outputs": ["y"],
@@ -247,11 +247,11 @@ multi_reassign_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "case": {
                     "condition": {
                         "label": "condition",
-                        "node": library.my_condition.flowrep_recipe,
+                        "recipe": library.my_condition.flowrep_recipe,
                     },
                     "body": {
                         "label": "body",
-                        "node": multi_reassign_body,
+                        "recipe": multi_reassign_body,
                     },
                 },
                 "input_edges": {
@@ -323,9 +323,9 @@ sequential_whiles_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "case": {
                     "condition": {
                         "label": "condition",
-                        "node": library.my_condition.flowrep_recipe,
+                        "recipe": library.my_condition.flowrep_recipe,
                     },
-                    "body": {"label": "body", "node": seq_while_body},
+                    "body": {"label": "body", "recipe": seq_while_body},
                 },
                 "input_edges": {
                     "condition.m": "x",
@@ -342,9 +342,9 @@ sequential_whiles_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "case": {
                     "condition": {
                         "label": "condition",
-                        "node": library.my_condition.flowrep_recipe,
+                        "recipe": library.my_condition.flowrep_recipe,
                     },
-                    "body": {"label": "body", "node": seq_while_body},
+                    "body": {"label": "body", "recipe": seq_while_body},
                 },
                 "input_edges": {
                     "condition.m": "x",
@@ -400,11 +400,11 @@ chained_body_node = workflow_recipe.WorkflowRecipe.model_validate(
                 "case": {
                     "condition": {
                         "label": "condition",
-                        "node": library.my_condition.flowrep_recipe,
+                        "recipe": library.my_condition.flowrep_recipe,
                     },
                     "body": {
                         "label": "body",
-                        "node": {
+                        "recipe": {
                             "type": "workflow",
                             "inputs": ["x", "a", "b"],
                             "outputs": ["x"],

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -52,7 +52,7 @@ workflow_condition_recipe = workflow_recipe.WorkflowRecipe(
                 helper_models.ConditionalCase(
                     condition=helper_models.LabeledRecipe(
                         label="condition",
-                        node=workflow_recipe.WorkflowRecipe(
+                        recipe=workflow_recipe.WorkflowRecipe(
                             inputs=["inp"],
                             outputs=["out"],
                             nodes={},
@@ -67,13 +67,13 @@ workflow_condition_recipe = workflow_recipe.WorkflowRecipe(
                     ),
                     body=helper_models.LabeledRecipe(
                         label="if_case",
-                        node=library.increment.flowrep_recipe,
+                        recipe=library.increment.flowrep_recipe,
                     ),
                 ),
             ],
             else_case=helper_models.LabeledRecipe(
                 label="else_case",
-                node=library.decrement.flowrep_recipe,
+                recipe=library.decrement.flowrep_recipe,
             ),
             input_edges={
                 edge_models.TargetHandle(
@@ -121,7 +121,7 @@ workflow_while_recipe = workflow_recipe.WorkflowRecipe(
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="condition",
-                    node=workflow_recipe.WorkflowRecipe(
+                    recipe=workflow_recipe.WorkflowRecipe(
                         inputs=["inp"],
                         outputs=["out"],
                         nodes={},
@@ -136,7 +136,7 @@ workflow_while_recipe = workflow_recipe.WorkflowRecipe(
                 ),
                 body=helper_models.LabeledRecipe(
                     label="while_body",
-                    node=library.decrement.flowrep_recipe,
+                    recipe=library.decrement.flowrep_recipe,
                 ),
             ),
             input_edges={
@@ -179,14 +179,14 @@ workflow_try_recipe = workflow_recipe.WorkflowRecipe(
             outputs=["z"],
             try_node=helper_models.LabeledRecipe(
                 label="try_body",
-                node=library.divide.flowrep_recipe,
+                recipe=library.divide.flowrep_recipe,
             ),
             exception_cases=[
                 helper_models.ExceptionCase(
                     exceptions=[versions.VersionInfo.of(ZeroDivisionError)],
                     body=helper_models.LabeledRecipe(
                         label="except_body",
-                        node=library.identity.flowrep_recipe,
+                        recipe=library.identity.flowrep_recipe,
                     ),
                 )
             ],
@@ -237,7 +237,7 @@ workflow_for_each_recipe = workflow_recipe.WorkflowRecipe(
             outputs=["ys"],
             body_node=helper_models.LabeledRecipe(
                 label="for_body",
-                node=library.increment.flowrep_recipe,
+                recipe=library.increment.flowrep_recipe,
             ),
             input_edges={
                 edge_models.TargetHandle(
@@ -275,7 +275,7 @@ def _for_each_increment(label_body: str):
         inputs=["xs"],
         outputs=["ys"],
         body_node=helper_models.LabeledRecipe(
-            label=label_body, node=library.increment.flowrep_recipe
+            label=label_body, recipe=library.increment.flowrep_recipe
         ),
         input_edges={
             edge_models.TargetHandle(
@@ -303,16 +303,16 @@ if_flow_control_condition_recipe = workflow_recipe.WorkflowRecipe(
             cases=[
                 helper_models.ConditionalCase(
                     condition=helper_models.LabeledRecipe(
-                        label="flowcond", node=_for_each_increment("c_body")
+                        label="flowcond", recipe=_for_each_increment("c_body")
                     ),
                     condition_output="ys",
                     body=helper_models.LabeledRecipe(
-                        label="cbranch", node=_for_each_increment("inc_body")
+                        label="cbranch", recipe=_for_each_increment("inc_body")
                     ),
                 )
             ],
             else_case=helper_models.LabeledRecipe(
-                label="cebranch", node=_for_each_increment("dec_body")
+                label="cebranch", recipe=_for_each_increment("dec_body")
             ),
             input_edges={
                 edge_models.TargetHandle(
@@ -357,11 +357,11 @@ while_flow_control_condition_recipe = workflow_recipe.WorkflowRecipe(
             outputs=["xs"],
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
-                    label="wcond", node=_for_each_increment("wc_body")
+                    label="wcond", recipe=_for_each_increment("wc_body")
                 ),
                 condition_output="ys",
                 body=helper_models.LabeledRecipe(
-                    label="wbody", node=_for_each_increment("wb_body")
+                    label="wbody", recipe=_for_each_increment("wb_body")
                 ),
             ),
             input_edges={
@@ -401,7 +401,7 @@ def _for_each(label_body: str, node):
     return for_recipe.ForEachRecipe(
         inputs=["xs"],
         outputs=["ys"],
-        body_node=helper_models.LabeledRecipe(label=label_body, node=node),
+        body_node=helper_models.LabeledRecipe(label=label_body, recipe=node),
         input_edges={
             edge_models.TargetHandle(
                 node=label_body, port="x"
@@ -426,17 +426,17 @@ if_branch_is_for_each_recipe = workflow_recipe.WorkflowRecipe(
             cases=[
                 helper_models.ConditionalCase(
                     condition=helper_models.LabeledRecipe(
-                        label="cond", node=library.is_positive.flowrep_recipe
+                        label="cond", recipe=library.is_positive.flowrep_recipe
                     ),
                     body=helper_models.LabeledRecipe(
                         label="if_branch",
-                        node=_for_each("inc_body", library.increment.flowrep_recipe),
+                        recipe=_for_each("inc_body", library.increment.flowrep_recipe),
                     ),
                 )
             ],
             else_case=helper_models.LabeledRecipe(
                 label="else_branch",
-                node=_for_each("dec_body", library.decrement.flowrep_recipe),
+                recipe=_for_each("dec_body", library.decrement.flowrep_recipe),
             ),
             input_edges={
                 edge_models.TargetHandle(
@@ -482,15 +482,15 @@ _inner_if_recipe = if_recipe.IfRecipe(
     cases=[
         helper_models.ConditionalCase(
             condition=helper_models.LabeledRecipe(
-                label="icond", node=library.is_positive.flowrep_recipe
+                label="icond", recipe=library.is_positive.flowrep_recipe
             ),
             body=helper_models.LabeledRecipe(
-                label="ibranch", node=library.increment.flowrep_recipe
+                label="ibranch", recipe=library.increment.flowrep_recipe
             ),
         )
     ],
     else_case=helper_models.LabeledRecipe(
-        label="ebranch", node=library.decrement.flowrep_recipe
+        label="ebranch", recipe=library.decrement.flowrep_recipe
     ),
     input_edges={
         edge_models.TargetHandle(node="icond", port="n"): edge_models.InputSource(
@@ -520,7 +520,7 @@ for_body_is_if_recipe = workflow_recipe.WorkflowRecipe(
             inputs=["xs"],
             outputs=["ys"],
             body_node=helper_models.LabeledRecipe(
-                label="inner_if", node=_inner_if_recipe
+                label="inner_if", recipe=_inner_if_recipe
             ),
             input_edges={
                 edge_models.TargetHandle(
@@ -2165,10 +2165,10 @@ class TestConstantMaterialize(unittest.TestCase):
             cases=[
                 helper_models.ConditionalCase(
                     condition=helper_models.LabeledRecipe(
-                        label="cond", node=library.is_positive.flowrep_recipe
+                        label="cond", recipe=library.is_positive.flowrep_recipe
                     ),
                     body=helper_models.LabeledRecipe(
-                        label="body", node=constant_recipe.ConstantRecipe(constant=42)
+                        label="body", recipe=constant_recipe.ConstantRecipe(constant=42)
                     ),
                 )
             ],
@@ -2180,7 +2180,7 @@ class TestConstantMaterialize(unittest.TestCase):
                 ]
             },
             else_case=helper_models.LabeledRecipe(
-                label="else_body", node=constant_recipe.ConstantRecipe(constant=-1)
+                label="else_body", recipe=constant_recipe.ConstantRecipe(constant=-1)
             ),
         )
         wf = workflow_recipe.WorkflowRecipe(

--- a/tests/unit/parsers/test_for_parser.py
+++ b/tests/unit/parsers/test_for_parser.py
@@ -558,7 +558,7 @@ class TestForParserStructure(unittest.TestCase):
             return results
 
         fn = self._parse(wf).nodes["for_each_0"]
-        self.assertIsInstance(fn.body_node.node, workflow_recipe.WorkflowRecipe)
+        self.assertIsInstance(fn.body_node.recipe, workflow_recipe.WorkflowRecipe)
 
     def test_multiple_accumulators(self):
         def wf(xs):
@@ -618,7 +618,7 @@ class TestForParserStructure(unittest.TestCase):
             return results
 
         fn = self._parse(wf).nodes["for_each_0"]
-        body = fn.body_node.node
+        body = fn.body_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         self.assertIn("for_each_0", body.nodes)
         self.assertIsInstance(body.nodes["for_each_0"], for_recipe.ForEachRecipe)
@@ -655,7 +655,7 @@ class TestForParserStructure(unittest.TestCase):
             return results
 
         fn = self._parse(wf).nodes["for_each_0"]
-        body = fn.body_node.node
+        body = fn.body_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         while_nodes = [
             n for n in body.nodes.values() if isinstance(n, while_recipe.WhileRecipe)
@@ -678,7 +678,7 @@ class TestForParserStructure(unittest.TestCase):
             return results
 
         fn = self._parse(wf).nodes["for_each_0"]
-        body = fn.body_node.node
+        body = fn.body_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         if_nodes = [n for n in body.nodes.values() if isinstance(n, if_recipe.IfRecipe)]
         self.assertEqual(len(if_nodes), 1)
@@ -697,7 +697,7 @@ class TestForParserStructure(unittest.TestCase):
             return results
 
         fn = self._parse(wf).nodes["for_each_0"]
-        body = fn.body_node.node
+        body = fn.body_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         try_nodes = [
             n for n in body.nodes.values() if isinstance(n, try_recipe.TryRecipe)
@@ -834,7 +834,7 @@ class TestForParserVersionPropagation(unittest.TestCase):
             wf, version_scraping={self._pkg(): lambda _: custom}
         )
         for_node = node.nodes["for_each_0"]
-        body = for_node.body_node.node
+        body = for_node.body_node.recipe
         child = body.nodes["undecorated_identity_0"]
         self.assertEqual(child.reference.info.version, custom)
 
@@ -857,9 +857,9 @@ class TestForParserVersionPropagation(unittest.TestCase):
             wf, version_scraping={self._pkg(): lambda _: custom}
         )
         for_node = node.nodes["for_each_0"]
-        outer_body = for_node.body_node.node
+        outer_body = for_node.body_node.recipe
         inner_for = outer_body.nodes["for_each_0"]
-        inner_body = inner_for.body_node.node
+        inner_body = inner_for.body_node.recipe
         child = inner_body.nodes["undecorated_identity_0"]
         self.assertEqual(child.reference.info.version, custom)
 

--- a/tests/unit/parsers/test_if_parser.py
+++ b/tests/unit/parsers/test_if_parser.py
@@ -563,8 +563,8 @@ class TestIfParserStructure(unittest.TestCase):
             return z
 
         ifn = self._parse(wf).nodes["if_0"]
-        self.assertIsInstance(ifn.cases[0].body.node, workflow_recipe.WorkflowRecipe)
-        self.assertIsInstance(ifn.else_case.node, workflow_recipe.WorkflowRecipe)
+        self.assertIsInstance(ifn.cases[0].body.recipe, workflow_recipe.WorkflowRecipe)
+        self.assertIsInstance(ifn.else_case.recipe, workflow_recipe.WorkflowRecipe)
 
     def test_multiple_outputs(self):
         def wf(x, y):
@@ -666,7 +666,7 @@ class TestIfParserStructure(unittest.TestCase):
             return z
 
         ifn = self._parse(wf).nodes["if_0"]
-        body = ifn.cases[0].body.node
+        body = ifn.cases[0].body.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         for_nodes = [
             n for n in body.nodes.values() if isinstance(n, for_recipe.ForEachRecipe)
@@ -686,7 +686,7 @@ class TestIfParserStructure(unittest.TestCase):
             return z
 
         ifn = self._parse(wf).nodes["if_0"]
-        body = ifn.cases[0].body.node
+        body = ifn.cases[0].body.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         while_nodes = [
             n for n in body.nodes.values() if isinstance(n, while_recipe.WhileRecipe)
@@ -707,7 +707,7 @@ class TestIfParserStructure(unittest.TestCase):
             return z
 
         ifn = self._parse(wf).nodes["if_0"]
-        body = ifn.cases[0].body.node
+        body = ifn.cases[0].body.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         inner_if_nodes = [
             n for n in body.nodes.values() if isinstance(n, if_recipe.IfRecipe)
@@ -729,7 +729,7 @@ class TestIfParserStructure(unittest.TestCase):
             return z
 
         ifn = self._parse(wf).nodes["if_0"]
-        else_body = ifn.else_case.node
+        else_body = ifn.else_case.recipe
         self.assertIsInstance(else_body, workflow_recipe.WorkflowRecipe)
         for_nodes = [
             n
@@ -752,7 +752,7 @@ class TestIfParserStructure(unittest.TestCase):
             return z
 
         ifn = self._parse(wf).nodes["if_0"]
-        body = ifn.cases[0].body.node
+        body = ifn.cases[0].body.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         try_nodes = [
             n for n in body.nodes.values() if isinstance(n, try_recipe.TryRecipe)
@@ -773,7 +773,7 @@ class TestIfParserStructure(unittest.TestCase):
             return z
 
         ifn = self._parse(wf).nodes["if_0"]
-        else_body = ifn.else_case.node
+        else_body = ifn.else_case.recipe
         self.assertIsInstance(else_body, workflow_recipe.WorkflowRecipe)
         try_nodes = [
             n for n in else_body.nodes.values() if isinstance(n, try_recipe.TryRecipe)
@@ -895,7 +895,7 @@ class TestIfParserVersionPropagation(unittest.TestCase):
             wf, version_scraping={self._pkg(): lambda _: custom}
         )
         if_node = node.nodes["if_0"]
-        body = if_node.cases[0].body.node
+        body = if_node.cases[0].body.recipe
         child = body.nodes["undecorated_identity_0"]
         self.assertEqual(child.reference.info.version, custom)
 
@@ -914,7 +914,7 @@ class TestIfParserVersionPropagation(unittest.TestCase):
             wf, version_scraping={self._pkg(): lambda _: custom}
         )
         if_node = node.nodes["if_0"]
-        else_body = if_node.else_case.node
+        else_body = if_node.else_case.recipe
         child = else_body.nodes["undecorated_identity_0"]
         self.assertEqual(child.reference.info.version, custom)
 
@@ -938,10 +938,10 @@ class TestIfParserVersionPropagation(unittest.TestCase):
         )
         if_node = node.nodes["if_0"]
         # condition is pre-decorated, and so keeps its own version
-        condition_node = if_node.cases[0].condition.node
+        condition_node = if_node.cases[0].condition.recipe
         self.assertNotEqual(condition_node.reference.info.version, custom)
         # body child is undecorated, and so picks up custom version
-        body_child = if_node.cases[0].body.node.nodes["undecorated_identity_0"]
+        body_child = if_node.cases[0].body.recipe.nodes["undecorated_identity_0"]
         self.assertEqual(body_child.reference.info.version, custom)
 
     def test_version_constraints_propagate_to_condition(self):

--- a/tests/unit/parsers/test_parser_helpers.py
+++ b/tests/unit/parsers/test_parser_helpers.py
@@ -320,7 +320,7 @@ class TestConsumeCallArguments(unittest.TestCase):
         outputs = outputs or ["output_0"]
         return helper_models.LabeledRecipe(
             label=label,
-            node=atomic_recipe.AtomicRecipe(
+            recipe=atomic_recipe.AtomicRecipe(
                 reference=makers.make_reference(module="test.module", qualname="func"),
                 inputs=inputs,
                 outputs=outputs,

--- a/tests/unit/parsers/test_symbol_scope.py
+++ b/tests/unit/parsers/test_symbol_scope.py
@@ -18,7 +18,7 @@ def _make_source(node: str, port: str) -> edge_models.SourceHandle:
 def _make_labeled_node(label: str, outputs: list[str]) -> helper_models.LabeledRecipe:
     return helper_models.LabeledRecipe(
         label=label,
-        node=atomic_recipe.AtomicRecipe(
+        recipe=atomic_recipe.AtomicRecipe(
             reference=base_models.PythonReference(
                 info=versions.VersionInfo(
                     module="test.module", qualname="func", version=None

--- a/tests/unit/parsers/test_try_parser.py
+++ b/tests/unit/parsers/test_try_parser.py
@@ -369,9 +369,9 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        self.assertIsInstance(tn.try_node.node, workflow_recipe.WorkflowRecipe)
+        self.assertIsInstance(tn.try_node.recipe, workflow_recipe.WorkflowRecipe)
         self.assertIsInstance(
-            tn.exception_cases[0].body.node, workflow_recipe.WorkflowRecipe
+            tn.exception_cases[0].body.recipe, workflow_recipe.WorkflowRecipe
         )
 
     def test_exception_types_resolved(self):
@@ -508,7 +508,7 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        body = tn.try_node.node
+        body = tn.try_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         for_nodes = [
             n for n in body.nodes.values() if isinstance(n, for_recipe.ForEachRecipe)
@@ -528,7 +528,7 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        body = tn.try_node.node
+        body = tn.try_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         while_nodes = [
             n for n in body.nodes.values() if isinstance(n, while_recipe.WhileRecipe)
@@ -549,7 +549,7 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        body = tn.try_node.node
+        body = tn.try_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         if_nodes = [n for n in body.nodes.values() if isinstance(n, if_recipe.IfRecipe)]
         self.assertEqual(len(if_nodes), 1)
@@ -568,7 +568,7 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        body = tn.try_node.node
+        body = tn.try_node.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         inner_try_nodes = [
             n for n in body.nodes.values() if isinstance(n, try_recipe.TryRecipe)
@@ -591,7 +591,7 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        except_body = tn.exception_cases[0].body.node
+        except_body = tn.exception_cases[0].body.recipe
         self.assertIsInstance(except_body, workflow_recipe.WorkflowRecipe)
         for_nodes = [
             n
@@ -614,7 +614,7 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        except_body = tn.exception_cases[0].body.node
+        except_body = tn.exception_cases[0].body.recipe
         self.assertIsInstance(except_body, workflow_recipe.WorkflowRecipe)
         while_nodes = [
             n
@@ -638,7 +638,7 @@ class TestTryParserStructure(unittest.TestCase):
             return z
 
         tn = self._parse(wf).nodes["try_0"]
-        except_body = tn.exception_cases[0].body.node
+        except_body = tn.exception_cases[0].body.recipe
         self.assertIsInstance(except_body, workflow_recipe.WorkflowRecipe)
         if_nodes = [
             n for n in except_body.nodes.values() if isinstance(n, if_recipe.IfRecipe)
@@ -761,7 +761,7 @@ class TestTryParserVersionPropagation(unittest.TestCase):
             wf, version_scraping={self._pkg(): lambda _: custom}
         )
         try_node = node.nodes["try_0"]
-        body = try_node.try_node.node
+        body = try_node.try_node.recipe
         child = body.nodes["undecorated_identity_0"]
         self.assertEqual(child.reference.info.version, custom)
 
@@ -780,7 +780,7 @@ class TestTryParserVersionPropagation(unittest.TestCase):
             wf, version_scraping={self._pkg(): lambda _: custom}
         )
         try_node = node.nodes["try_0"]
-        except_body = try_node.exception_cases[0].body.node
+        except_body = try_node.exception_cases[0].body.recipe
         child = except_body.nodes["undecorated_identity_0"]
         self.assertEqual(child.reference.info.version, custom)
 
@@ -800,10 +800,10 @@ class TestTryParserVersionPropagation(unittest.TestCase):
         )
         try_node = node.nodes["try_0"]
         # Pre-decorated child in try body keeps its own version
-        try_child = try_node.try_node.node.nodes["identity_0"]
+        try_child = try_node.try_node.recipe.nodes["identity_0"]
         self.assertNotEqual(try_child.reference.info.version, custom)
         # Undecorated child in except body picks up custom version
-        except_child = try_node.exception_cases[0].body.node.nodes[
+        except_child = try_node.exception_cases[0].body.recipe.nodes[
             "undecorated_identity_0"
         ]
         self.assertEqual(except_child.reference.info.version, custom)

--- a/tests/unit/parsers/test_while_parser.py
+++ b/tests/unit/parsers/test_while_parser.py
@@ -304,7 +304,7 @@ class TestWhileParserStructure(unittest.TestCase):
             return x
 
         wn = self._parse(wf).nodes["while_0"]
-        self.assertIsInstance(wn.case.body.node, workflow_recipe.WorkflowRecipe)
+        self.assertIsInstance(wn.case.body.recipe, workflow_recipe.WorkflowRecipe)
 
     def test_outputs_subset_of_inputs(self):
         def wf(x, step, bound):
@@ -384,7 +384,7 @@ class TestWhileParserStructure(unittest.TestCase):
             return x
 
         wn = self._parse(wf).nodes["while_0"]
-        body = wn.case.body.node
+        body = wn.case.body.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         for_nodes = [
             n for n in body.nodes.values() if isinstance(n, for_recipe.ForEachRecipe)
@@ -405,7 +405,7 @@ class TestWhileParserStructure(unittest.TestCase):
             return x
 
         wn = self._parse(wf).nodes["while_0"]
-        body = wn.case.body.node
+        body = wn.case.body.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         if_nodes = [n for n in body.nodes.values() if isinstance(n, if_recipe.IfRecipe)]
         self.assertEqual(len(if_nodes), 1)
@@ -424,7 +424,7 @@ class TestWhileParserStructure(unittest.TestCase):
             return x
 
         wn = self._parse(wf).nodes["while_0"]
-        body = wn.case.body.node
+        body = wn.case.body.recipe
         self.assertIsInstance(body, workflow_recipe.WorkflowRecipe)
         try_nodes = [
             n for n in body.nodes.values() if isinstance(n, try_recipe.TryRecipe)
@@ -483,7 +483,7 @@ class TestWhileParserVersionPropagation(unittest.TestCase):
             wf, version_scraping={self._pkg(): lambda _: custom}
         )
         while_node = node.nodes["while_0"]
-        body = while_node.case.body.node
+        body = while_node.case.body.recipe
         child = body.nodes["undecorated_identity_0"]
         self.assertEqual(child.reference.info.version, custom)
 
@@ -503,10 +503,10 @@ class TestWhileParserVersionPropagation(unittest.TestCase):
         )
         while_node = node.nodes["while_0"]
         # condition is pre-decorated → keeps its own version
-        condition_node = while_node.case.condition.node
+        condition_node = while_node.case.condition.recipe
         self.assertNotEqual(condition_node.reference.info.version, custom)
         # body child is undecorated → picks up custom version
-        body_child = while_node.case.body.node.nodes["undecorated_identity_0"]
+        body_child = while_node.case.body.recipe.nodes["undecorated_identity_0"]
         self.assertEqual(body_child.reference.info.version, custom)
 
     def test_version_constraints_propagate_to_condition(self):

--- a/tests/unit/prospective/test_for_recipe.py
+++ b/tests/unit/prospective/test_for_recipe.py
@@ -387,7 +387,7 @@ class TestForEachRecipeFullySourcing(unittest.TestCase):
             },
             nested_ports=["x"],
         )
-        self.assertIn("extra", node.body_node.node.inputs)
+        self.assertIn("extra", node.body_node.recipe.inputs)
 
     def test_body_mixed_sourcing_one_unsourced_raises(self):
         """Multiple body inputs: edged, defaulted, and unsourced → fails."""
@@ -656,7 +656,7 @@ class TestForEachRecipeComposition(unittest.TestCase):
             outputs=["results"],
             body_node=helper_models.LabeledRecipe(
                 label="body",
-                node=inner_workflow,
+                recipe=inner_workflow,
             ),
             input_edges={
                 edge_models.TargetHandle(
@@ -670,7 +670,7 @@ class TestForEachRecipeComposition(unittest.TestCase):
             },
             nested_ports=["x"],
         )
-        self.assertIsInstance(for_node.body_node.node, workflow_recipe.WorkflowRecipe)
+        self.assertIsInstance(for_node.body_node.recipe, workflow_recipe.WorkflowRecipe)
 
     def test_for_node_as_workflow_child(self):
         for_node = for_recipe.ForEachRecipe(

--- a/tests/unit/prospective/test_helper_models.py
+++ b/tests/unit/prospective/test_helper_models.py
@@ -18,7 +18,7 @@ class TestConditionalCaseValidation(unittest.TestCase):
     def _make_condition(outputs=None):
         return helper_models.LabeledRecipe(
             label="condition",
-            node=makers.make_atomic(
+            recipe=makers.make_atomic(
                 inputs=["x"], outputs=outputs or ["result"], qualname="check"
             ),
         )
@@ -27,7 +27,7 @@ class TestConditionalCaseValidation(unittest.TestCase):
     def _make_body():
         return helper_models.LabeledRecipe(
             label="body",
-            node=makers.make_atomic(inputs=["x"], outputs=["y"], qualname="handle"),
+            recipe=makers.make_atomic(inputs=["x"], outputs=["y"], qualname="handle"),
         )
 
     def test_single_output_condition_no_explicit_output(self):
@@ -82,7 +82,7 @@ class TestExceptionCaseValidation(unittest.TestCase):
         case = helper_models.ExceptionCase(
             exceptions=[value_info],
             body=helper_models.LabeledRecipe(
-                label="handler", node=self._make_except_body()
+                label="handler", recipe=self._make_except_body()
             ),
         )
         self.assertEqual(case.exceptions, [value_info])
@@ -96,7 +96,7 @@ class TestExceptionCaseValidation(unittest.TestCase):
                 versions.VersionInfo.of(KeyError),
             ],
             body=helper_models.LabeledRecipe(
-                label="handler", node=self._make_except_body()
+                label="handler", recipe=self._make_except_body()
             ),
         )
         self.assertEqual(len(case.exceptions), 3)
@@ -107,7 +107,7 @@ class TestExceptionCaseValidation(unittest.TestCase):
             helper_models.ExceptionCase(
                 exceptions=[],
                 body=helper_models.LabeledRecipe(
-                    label="handler", node=self._make_except_body()
+                    label="handler", recipe=self._make_except_body()
                 ),
             )
         self.assertIn("at least one", str(ctx.exception))
@@ -123,7 +123,7 @@ class TestExceptionCaseSerialization(unittest.TestCase):
             ],
             body=helper_models.LabeledRecipe(
                 label="handler",
-                node=atomic_recipe.AtomicRecipe(
+                recipe=atomic_recipe.AtomicRecipe(
                     reference=makers.make_reference("mod", "handle_error"),
                     inputs=["x"],
                     outputs=["y"],
@@ -147,10 +147,10 @@ class TestLabeledNode(unittest.TestCase):
         """LabeledNode with valid label and node."""
         ln = helper_models.LabeledRecipe(
             label="my_node",
-            node=makers.make_atomic(inputs=["x"], outputs=["y"]),
+            recipe=makers.make_atomic(inputs=["x"], outputs=["y"]),
         )
         self.assertEqual(ln.label, "my_node")
-        self.assertIsInstance(ln.node, atomic_recipe.AtomicRecipe)
+        self.assertIsInstance(ln.recipe, atomic_recipe.AtomicRecipe)
 
     def test_labeled_node_with_workflow(self):
         """LabeledNode can contain a WorkflowRecipe."""
@@ -162,13 +162,13 @@ class TestLabeledNode(unittest.TestCase):
             edges={},
             output_edges={"b": "leaf.y"},
         )
-        ln = helper_models.LabeledRecipe(label="nested", node=inner)
-        self.assertIsInstance(ln.node, workflow_recipe.WorkflowRecipe)
+        ln = helper_models.LabeledRecipe(label="nested", recipe=inner)
+        self.assertIsInstance(ln.recipe, workflow_recipe.WorkflowRecipe)
 
     def test_invalid_label_keyword(self):
         """LabeledNode rejects Python keywords as labels."""
         with self.assertRaises(pydantic.ValidationError) as ctx:
-            helper_models.LabeledRecipe(label="for", node=makers.make_atomic())
+            helper_models.LabeledRecipe(label="for", recipe=makers.make_atomic())
         self.assertIn("valid Python identifier", str(ctx.exception))
 
     def test_invalid_label_reserved(self):
@@ -178,7 +178,7 @@ class TestLabeledNode(unittest.TestCase):
                 self.subTest(label=reserved),
                 self.assertRaises(pydantic.ValidationError),
             ):
-                helper_models.LabeledRecipe(label=reserved, node=makers.make_atomic())
+                helper_models.LabeledRecipe(label=reserved, recipe=makers.make_atomic())
 
     def test_invalid_label_not_identifier(self):
         """LabeledNode rejects non-identifiers as labels."""
@@ -187,7 +187,7 @@ class TestLabeledNode(unittest.TestCase):
                 self.subTest(label=invalid),
                 self.assertRaises(pydantic.ValidationError),
             ):
-                helper_models.LabeledRecipe(label=invalid, node=makers.make_atomic())
+                helper_models.LabeledRecipe(label=invalid, recipe=makers.make_atomic())
 
 
 class TestConditionalCase(unittest.TestCase):
@@ -198,11 +198,11 @@ class TestConditionalCase(unittest.TestCase):
         cc = helper_models.ConditionalCase(
             condition=helper_models.LabeledRecipe(
                 label="cond",
-                node=makers.make_atomic(inputs=["x"], outputs=["result"]),
+                recipe=makers.make_atomic(inputs=["x"], outputs=["result"]),
             ),
             body=helper_models.LabeledRecipe(
                 label="body",
-                node=makers.make_atomic(inputs=["y"], outputs=["out"]),
+                recipe=makers.make_atomic(inputs=["y"], outputs=["out"]),
             ),
         )
         self.assertIsNone(cc.condition_output)
@@ -212,11 +212,11 @@ class TestConditionalCase(unittest.TestCase):
         cc = helper_models.ConditionalCase(
             condition=helper_models.LabeledRecipe(
                 label="cond",
-                node=makers.make_atomic(inputs=["x"], outputs=["a", "b", "flag"]),
+                recipe=makers.make_atomic(inputs=["x"], outputs=["a", "b", "flag"]),
             ),
             body=helper_models.LabeledRecipe(
                 label="body",
-                node=makers.make_atomic(inputs=["y"], outputs=["out"]),
+                recipe=makers.make_atomic(inputs=["y"], outputs=["out"]),
             ),
             condition_output="flag",
         )
@@ -228,11 +228,11 @@ class TestConditionalCase(unittest.TestCase):
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="cond",
-                    node=makers.make_atomic(inputs=["x"], outputs=["a", "b"]),
+                    recipe=makers.make_atomic(inputs=["x"], outputs=["a", "b"]),
                 ),
                 body=helper_models.LabeledRecipe(
                     label="body",
-                    node=makers.make_atomic(inputs=["y"], outputs=["out"]),
+                    recipe=makers.make_atomic(inputs=["y"], outputs=["out"]),
                 ),
             )
         self.assertIn("exactly one output", str(ctx.exception))
@@ -243,11 +243,11 @@ class TestConditionalCase(unittest.TestCase):
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="cond",
-                    node=makers.make_atomic(inputs=["x"], outputs=["a", "b"]),
+                    recipe=makers.make_atomic(inputs=["x"], outputs=["a", "b"]),
                 ),
                 body=helper_models.LabeledRecipe(
                     label="body",
-                    node=makers.make_atomic(inputs=["y"], outputs=["out"]),
+                    recipe=makers.make_atomic(inputs=["y"], outputs=["out"]),
                 ),
                 condition_output="nonexistent",
             )
@@ -258,9 +258,9 @@ class TestConditionalCase(unittest.TestCase):
         """Condition and body can have different labels."""
         cc = helper_models.ConditionalCase(
             condition=helper_models.LabeledRecipe(
-                label="check", node=makers.make_atomic(outputs=["ok"])
+                label="check", recipe=makers.make_atomic(outputs=["ok"])
             ),
-            body=helper_models.LabeledRecipe(label="run", node=makers.make_atomic()),
+            body=helper_models.LabeledRecipe(label="run", recipe=makers.make_atomic()),
         )
         self.assertEqual(cc.condition.label, "check")
         self.assertEqual(cc.body.label, "run")
@@ -270,10 +270,10 @@ class TestConditionalCase(unittest.TestCase):
         with self.assertRaises(pydantic.ValidationError) as ctx:
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
-                    label="same", node=makers.make_atomic(outputs=["ok"])
+                    label="same", recipe=makers.make_atomic(outputs=["ok"])
                 ),
                 body=helper_models.LabeledRecipe(
-                    label="same", node=makers.make_atomic()
+                    label="same", recipe=makers.make_atomic()
                 ),
             )
         self.assertIn("distinct labels", str(ctx.exception))

--- a/tests/unit/prospective/test_if_recipe.py
+++ b/tests/unit/prospective/test_if_recipe.py
@@ -46,7 +46,7 @@ def _make_output_edges(cases, else_case=None):
     if else_case is not None:
         sources.append(
             edge_models.SourceHandle(
-                node=else_case.label, port=else_case.node.outputs[0]
+                node=else_case.label, port=else_case.recipe.outputs[0]
             )
         )
     return {edge_models.OutputTarget(port="out"): sources}
@@ -170,7 +170,7 @@ class TestIfRecipeCasesValidation(unittest.TestCase):
         cases = [
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
-                    label="workflow_condition", node=workflow_condition
+                    label="workflow_condition", recipe=workflow_condition
                 ),
                 body=makers.make_labeled_with_defaults("body"),
             )
@@ -184,7 +184,7 @@ class TestIfRecipeCasesValidation(unittest.TestCase):
             prospective_output_edges=_make_output_edges(cases),
         )
         self.assertIsInstance(
-            node.cases[0].condition.node, workflow_recipe.WorkflowRecipe
+            node.cases[0].condition.recipe, workflow_recipe.WorkflowRecipe
         )
 
 
@@ -390,14 +390,14 @@ class TestIfRecipeFullySourcing(unittest.TestCase):
                 ]
             },
         )
-        self.assertIn("extra", node.cases[0].body.node.inputs)
+        self.assertIn("extra", node.cases[0].body.recipe.inputs)
 
     def test_mixed_across_cases_unsourced_else_raises(self):
         """Condition edged, body defaulted, else unsourced → fails on else."""
         cases = _make_conditional_cases(1)
         else_case = helper_models.LabeledRecipe(
             label="else_body",
-            node=atomic_recipe.AtomicRecipe(
+            recipe=atomic_recipe.AtomicRecipe(
                 reference=makers.make_reference(qualname="handle"),  # no defaults
                 inputs=["x", "z"],
                 outputs=["y"],
@@ -693,9 +693,9 @@ class TestIfRecipeSerialization(unittest.TestCase):
         cases = [
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
-                    label="condition", node=condition
+                    label="condition", recipe=condition
                 ),
-                body=helper_models.LabeledRecipe(label="body", node=body),
+                body=helper_models.LabeledRecipe(label="body", recipe=body),
                 condition_output="a",
             )
         ]

--- a/tests/unit/prospective/test_std.py
+++ b/tests/unit/prospective/test_std.py
@@ -41,228 +41,228 @@ class _HasAttrs:
 class TestStdExecution(unittest.TestCase):
 
     def test_abs(self):
-        out = wfms.run_recipe(std.abs.node, a=-3)
+        out = wfms.run_recipe(std.abs.recipe, a=-3)
         self.assertEqual(3, out.output_ports["absolute"].value)
 
     def test_add(self):
-        out = wfms.run_recipe(std.add.node, a=1, b=2)
+        out = wfms.run_recipe(std.add.recipe, a=1, b=2)
         self.assertEqual(3, out.output_ports["added"].value)
 
     def test_index(self):
-        out = wfms.run_recipe(std.index.node, a=5)
+        out = wfms.run_recipe(std.index.recipe, a=5)
         self.assertEqual(5, out.output_ports["index"].value)
 
     def test_inv(self):
-        out = wfms.run_recipe(std.inv.node, a=0)
+        out = wfms.run_recipe(std.inv.recipe, a=0)
         self.assertEqual(-1, out.output_ports["inverted"].value)
 
     def test_invert(self):
-        out = wfms.run_recipe(std.invert.node, a=0)
+        out = wfms.run_recipe(std.invert.recipe, a=0)
         self.assertEqual(-1, out.output_ports["inverted"].value)
 
     def test_neg(self):
-        out = wfms.run_recipe(std.neg.node, a=2)
+        out = wfms.run_recipe(std.neg.recipe, a=2)
         self.assertEqual(-2, out.output_ports["negative"].value)
 
     def test_pos(self):
-        out = wfms.run_recipe(std.pos.node, a=-2)
+        out = wfms.run_recipe(std.pos.recipe, a=-2)
         self.assertEqual(-2, out.output_ports["positive"].value)
 
     def test_not_(self):
-        out = wfms.run_recipe(std.not_.node, a=False)
+        out = wfms.run_recipe(std.not_.recipe, a=False)
         self.assertEqual(True, out.output_ports["negated"].value)
 
     def test_truth(self):
-        out = wfms.run_recipe(std.truth.node, a=[])
+        out = wfms.run_recipe(std.truth.recipe, a=[])
         self.assertEqual(False, out.output_ports["truth"].value)
 
     def test_length_hint(self):
-        out = wfms.run_recipe(std.length_hint.node, obj=[1, 2, 3])
+        out = wfms.run_recipe(std.length_hint.recipe, obj=[1, 2, 3])
         self.assertEqual(3, out.output_ports["length"].value)
 
     def test_sub(self):
-        out = wfms.run_recipe(std.sub.node, a=5, b=2)
+        out = wfms.run_recipe(std.sub.recipe, a=5, b=2)
         self.assertEqual(3, out.output_ports["difference"].value)
 
     def test_isub(self):
-        out = wfms.run_recipe(std.isub.node, a=5, b=2)
+        out = wfms.run_recipe(std.isub.recipe, a=5, b=2)
         self.assertEqual(3, out.output_ports["difference"].value)
 
     def test_iadd(self):
-        out = wfms.run_recipe(std.iadd.node, a=1, b=2)
+        out = wfms.run_recipe(std.iadd.recipe, a=1, b=2)
         self.assertEqual(3, out.output_ports["added"].value)
 
     def test_mul(self):
-        out = wfms.run_recipe(std.mul.node, a=2, b=3)
+        out = wfms.run_recipe(std.mul.recipe, a=2, b=3)
         self.assertEqual(6, out.output_ports["product"].value)
 
     def test_imul(self):
-        out = wfms.run_recipe(std.imul.node, a=2, b=3)
+        out = wfms.run_recipe(std.imul.recipe, a=2, b=3)
         self.assertEqual(6, out.output_ports["product"].value)
 
     def test_floordiv(self):
-        out = wfms.run_recipe(std.floordiv.node, a=7, b=2)
+        out = wfms.run_recipe(std.floordiv.recipe, a=7, b=2)
         self.assertEqual(3, out.output_ports["quotient"].value)
 
     def test_ifloordiv(self):
-        out = wfms.run_recipe(std.ifloordiv.node, a=7, b=2)
+        out = wfms.run_recipe(std.ifloordiv.recipe, a=7, b=2)
         self.assertEqual(3, out.output_ports["quotient"].value)
 
     def test_truediv(self):
-        out = wfms.run_recipe(std.truediv.node, a=6, b=2)
+        out = wfms.run_recipe(std.truediv.recipe, a=6, b=2)
         self.assertEqual(3.0, out.output_ports["quotient"].value)
 
     def test_itruediv(self):
-        out = wfms.run_recipe(std.itruediv.node, a=6, b=2)
+        out = wfms.run_recipe(std.itruediv.recipe, a=6, b=2)
         self.assertEqual(3.0, out.output_ports["quotient"].value)
 
     def test_mod(self):
-        out = wfms.run_recipe(std.mod.node, a=7, b=3)
+        out = wfms.run_recipe(std.mod.recipe, a=7, b=3)
         self.assertEqual(1, out.output_ports["remainder"].value)
 
     def test_imod(self):
-        out = wfms.run_recipe(std.imod.node, a=7, b=3)
+        out = wfms.run_recipe(std.imod.recipe, a=7, b=3)
         self.assertEqual(1, out.output_ports["remainder"].value)
 
     def test_pow(self):
-        out = wfms.run_recipe(std.pow.node, a=2, b=3)
+        out = wfms.run_recipe(std.pow.recipe, a=2, b=3)
         self.assertEqual(8, out.output_ports["power"].value)
 
     def test_ipow(self):
-        out = wfms.run_recipe(std.ipow.node, a=2, b=3)
+        out = wfms.run_recipe(std.ipow.recipe, a=2, b=3)
         self.assertEqual(8, out.output_ports["power"].value)
 
     def test_and_(self):
-        out = wfms.run_recipe(std.and_.node, a=6, b=3)
+        out = wfms.run_recipe(std.and_.recipe, a=6, b=3)
         self.assertEqual(2, out.output_ports["conjunction"].value)
 
     def test_iand(self):
-        out = wfms.run_recipe(std.iand.node, a=6, b=3)
+        out = wfms.run_recipe(std.iand.recipe, a=6, b=3)
         self.assertEqual(2, out.output_ports["conjunction"].value)
 
     def test_or_(self):
-        out = wfms.run_recipe(std.or_.node, a=6, b=1)
+        out = wfms.run_recipe(std.or_.recipe, a=6, b=1)
         self.assertEqual(7, out.output_ports["disjunction"].value)
 
     def test_ior(self):
-        out = wfms.run_recipe(std.ior.node, a=6, b=1)
+        out = wfms.run_recipe(std.ior.recipe, a=6, b=1)
         self.assertEqual(7, out.output_ports["disjunction"].value)
 
     def test_xor(self):
-        out = wfms.run_recipe(std.xor.node, a=6, b=3)
+        out = wfms.run_recipe(std.xor.recipe, a=6, b=3)
         self.assertEqual(5, out.output_ports["exclusive_or"].value)
 
     def test_ixor(self):
-        out = wfms.run_recipe(std.ixor.node, a=6, b=3)
+        out = wfms.run_recipe(std.ixor.recipe, a=6, b=3)
         self.assertEqual(5, out.output_ports["exclusive_or"].value)
 
     def test_lshift(self):
-        out = wfms.run_recipe(std.lshift.node, a=1, b=3)
+        out = wfms.run_recipe(std.lshift.recipe, a=1, b=3)
         self.assertEqual(8, out.output_ports["left_shifted"].value)
 
     def test_ilshift(self):
-        out = wfms.run_recipe(std.ilshift.node, a=1, b=3)
+        out = wfms.run_recipe(std.ilshift.recipe, a=1, b=3)
         self.assertEqual(8, out.output_ports["left_shifted"].value)
 
     def test_rshift(self):
-        out = wfms.run_recipe(std.rshift.node, a=8, b=2)
+        out = wfms.run_recipe(std.rshift.recipe, a=8, b=2)
         self.assertEqual(2, out.output_ports["right_shifted"].value)
 
     def test_irshift(self):
-        out = wfms.run_recipe(std.irshift.node, a=8, b=2)
+        out = wfms.run_recipe(std.irshift.recipe, a=8, b=2)
         self.assertEqual(2, out.output_ports["right_shifted"].value)
 
     def test_matmul(self):
-        out = wfms.run_recipe(std.matmul.node, a=_Mat(1), b=_Mat(2))
+        out = wfms.run_recipe(std.matmul.recipe, a=_Mat(1), b=_Mat(2))
         result = out.output_ports["matrix_product"].value
         self.assertEqual(("mm", 1, 2), result)
 
     def test_imatmul(self):
-        out = wfms.run_recipe(std.imatmul.node, a=_Mat(1), b=_Mat(2))
+        out = wfms.run_recipe(std.imatmul.recipe, a=_Mat(1), b=_Mat(2))
         result = out.output_ports["matrix_product"].value
         self.assertEqual(("imm", 1, 2), result)
 
     def test_eq(self):
-        out = wfms.run_recipe(std.eq.node, a=1, b=1)
+        out = wfms.run_recipe(std.eq.recipe, a=1, b=1)
         self.assertEqual(True, out.output_ports["equal"].value)
 
     def test_ne(self):
-        out = wfms.run_recipe(std.ne.node, a=1, b=2)
+        out = wfms.run_recipe(std.ne.recipe, a=1, b=2)
         self.assertEqual(True, out.output_ports["not_equal"].value)
 
     def test_lt(self):
-        out = wfms.run_recipe(std.lt.node, a=1, b=2)
+        out = wfms.run_recipe(std.lt.recipe, a=1, b=2)
         self.assertEqual(True, out.output_ports["less"].value)
 
     def test_le(self):
-        out = wfms.run_recipe(std.le.node, a=2, b=2)
+        out = wfms.run_recipe(std.le.recipe, a=2, b=2)
         self.assertEqual(True, out.output_ports["less_equal"].value)
 
     def test_gt(self):
-        out = wfms.run_recipe(std.gt.node, a=2, b=1)
+        out = wfms.run_recipe(std.gt.recipe, a=2, b=1)
         self.assertEqual(True, out.output_ports["greater"].value)
 
     def test_ge(self):
-        out = wfms.run_recipe(std.ge.node, a=2, b=2)
+        out = wfms.run_recipe(std.ge.recipe, a=2, b=2)
         self.assertEqual(True, out.output_ports["greater_equal"].value)
 
     def test_is_(self):
-        out = wfms.run_recipe(std.is_.node, a=None, b=None)
+        out = wfms.run_recipe(std.is_.recipe, a=None, b=None)
         self.assertEqual(True, out.output_ports["identical"].value)
 
     def test_is_not(self):
-        out = wfms.run_recipe(std.is_not.node, a=1, b=2)
+        out = wfms.run_recipe(std.is_not.recipe, a=1, b=2)
         self.assertEqual(True, out.output_ports["not_identical"].value)
 
     def test_contains(self):
-        out = wfms.run_recipe(std.contains.node, a=[1, 2, 3], b=2)
+        out = wfms.run_recipe(std.contains.recipe, a=[1, 2, 3], b=2)
         self.assertEqual(True, out.output_ports["contains"].value)
 
     def test_countOf(self):
-        out = wfms.run_recipe(std.countOf.node, a=[1, 2, 2, 3], b=2)
+        out = wfms.run_recipe(std.countOf.recipe, a=[1, 2, 2, 3], b=2)
         self.assertEqual(2, out.output_ports["count"].value)
 
     def test_indexOf(self):
-        out = wfms.run_recipe(std.indexOf.node, a=[1, 2, 3], b=3)
+        out = wfms.run_recipe(std.indexOf.recipe, a=[1, 2, 3], b=3)
         self.assertEqual(2, out.output_ports["index"].value)
 
     def test_concat(self):
-        out = wfms.run_recipe(std.concat.node, a=[1], b=[2])
+        out = wfms.run_recipe(std.concat.recipe, a=[1], b=[2])
         self.assertEqual([1, 2], out.output_ports["concatenated"].value)
 
     def test_iconcat(self):
-        out = wfms.run_recipe(std.iconcat.node, a=[1], b=[2])
+        out = wfms.run_recipe(std.iconcat.recipe, a=[1], b=[2])
         self.assertEqual([1, 2], out.output_ports["concatenated"].value)
 
     def test_getitem(self):
-        out = wfms.run_recipe(std.getitem.node, a=[10, 20], b=1)
+        out = wfms.run_recipe(std.getitem.recipe, a=[10, 20], b=1)
         self.assertEqual(20, out.output_ports["item"].value)
 
     def test_setitem(self):
         d = {}
-        wfms.run_recipe(std.setitem.node, a=d, b="k", c=1)
+        wfms.run_recipe(std.setitem.recipe, a=d, b="k", c=1)
         self.assertEqual(1, d["k"])
 
     def test_delitem(self):
         d = {"k": 1}
-        wfms.run_recipe(std.delitem.node, a=d, b="k")
+        wfms.run_recipe(std.delitem.recipe, a=d, b="k")
         self.assertNotIn("k", d)
 
     def test_call(self):
         with self.subTest("no variadics"):
-            out = wfms.run_recipe(std.call.node, obj=_return_42)
+            out = wfms.run_recipe(std.call.recipe, obj=_return_42)
             self.assertEqual(42, out.output_ports["result"].value)
         with self.subTest("args"):
-            out = wfms.run_recipe(std.call.node, obj=_return_42, args_=(1, 2))
+            out = wfms.run_recipe(std.call.recipe, obj=_return_42, args_=(1, 2))
             self.assertEqual((42, (1, 2)), out.output_ports["result"].value)
         with self.subTest("kwargs"):
             out = wfms.run_recipe(
-                std.call.node, obj=_return_42, kwargs_={"a": 3, "b": 4}
+                std.call.recipe, obj=_return_42, kwargs_={"a": 3, "b": 4}
             )
             self.assertEqual((42, {"a": 3, "b": 4}), out.output_ports["result"].value)
         with self.subTest("both"):
             out = wfms.run_recipe(
-                std.call.node, obj=_return_42, args_=(1, 2), kwargs_={"a": 3, "b": 4}
+                std.call.recipe, obj=_return_42, args_=(1, 2), kwargs_={"a": 3, "b": 4}
             )
             self.assertEqual(
                 (42, (1, 2), {"a": 3, "b": 4}), out.output_ports["result"].value
@@ -271,20 +271,24 @@ class TestStdExecution(unittest.TestCase):
     def test_getattr_(self):
         with self.subTest("instance attribute"):
             out = wfms.run_recipe(
-                std.getattr_.node, obj=_HasAttrs(), name="instance_attr"
+                std.getattr_.recipe, obj=_HasAttrs(), name="instance_attr"
             )
             self.assertEqual(42, out.output_ports["attr"].value)
 
         with self.subTest("class attribute"):
-            out = wfms.run_recipe(std.getattr_.node, obj=_HasAttrs(), name="class_attr")
+            out = wfms.run_recipe(
+                std.getattr_.recipe, obj=_HasAttrs(), name="class_attr"
+            )
             self.assertEqual("shared", out.output_ports["attr"].value)
 
         with self.subTest("bound method"):
-            out = wfms.run_recipe(std.getattr_.node, obj=_HasAttrs(), name="method")
+            out = wfms.run_recipe(std.getattr_.recipe, obj=_HasAttrs(), name="method")
             self.assertEqual("called", out.output_ports["attr"].value())
 
         with self.subTest("tuple attributes are delivered whole"):
-            out = wfms.run_recipe(std.getattr_.node, obj=_HasAttrs(), name="tuple_attr")
+            out = wfms.run_recipe(
+                std.getattr_.recipe, obj=_HasAttrs(), name="tuple_attr"
+            )
             self.assertEqual(
                 (1, 2),
                 out.output_ports["attr"].value,
@@ -298,19 +302,19 @@ class TestStdExecution(unittest.TestCase):
                 AttributeError, msg="Failed lookups should surface to the caller"
             ),
         ):
-            wfms.run_recipe(std.getattr_.node, obj=_HasAttrs(), name="not_here")
+            wfms.run_recipe(std.getattr_.recipe, obj=_HasAttrs(), name="not_here")
 
     def test_identity(self):
         with self.subTest("value"):
-            out = wfms.run_recipe(std.identity.node, x=42)
+            out = wfms.run_recipe(std.identity.recipe, x=42)
             self.assertEqual(42, out.output_ports["x"].value)
 
         with self.subTest("none"):
-            out = wfms.run_recipe(std.identity.node, x=None)
+            out = wfms.run_recipe(std.identity.recipe, x=None)
             self.assertIsNone(out.output_ports["x"].value)
 
         with self.subTest("tuples are delivered whole"):
-            out = wfms.run_recipe(std.identity.node, x=(1, 2))
+            out = wfms.run_recipe(std.identity.recipe, x=(1, 2))
             self.assertEqual(
                 (1, 2),
                 out.output_ports["x"].value,
@@ -320,7 +324,7 @@ class TestStdExecution(unittest.TestCase):
 
         with self.subTest("passthrough is not a copy"):
             obj = _HasAttrs()
-            out = wfms.run_recipe(std.identity.node, x=obj)
+            out = wfms.run_recipe(std.identity.recipe, x=obj)
             self.assertIs(
                 obj,
                 out.output_ports["x"].value,

--- a/tests/unit/prospective/test_try_recipe.py
+++ b/tests/unit/prospective/test_try_recipe.py
@@ -186,7 +186,7 @@ class TestTryRecipeExceptionCasesValidation(unittest.TestCase):
         exception_case = helper_models.ExceptionCase(
             exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledRecipe(
-                label="workflow_handler", node=workflow_body
+                label="workflow_handler", recipe=workflow_body
             ),
         )
 
@@ -201,7 +201,7 @@ class TestTryRecipeExceptionCasesValidation(unittest.TestCase):
             ),
         )
         self.assertIsInstance(
-            node.exception_cases[0].body.node, workflow_recipe.WorkflowRecipe
+            node.exception_cases[0].body.recipe, workflow_recipe.WorkflowRecipe
         )
 
 
@@ -325,7 +325,7 @@ class TestTryRecipeFullySourcing(unittest.TestCase):
         """Try body input without edge or default → rejected."""
         try_node = helper_models.LabeledRecipe(
             label="try_body",
-            node=atomic_recipe.AtomicRecipe(
+            recipe=atomic_recipe.AtomicRecipe(
                 reference=makers.make_reference(qualname="try_func"),  # no defaults
                 inputs=["x", "extra"],
                 outputs=["y"],
@@ -361,7 +361,7 @@ class TestTryRecipeFullySourcing(unittest.TestCase):
                 exceptions=[_VALUE_ERROR_INFO],
                 body=helper_models.LabeledRecipe(
                     label="except_0",
-                    node=atomic_recipe.AtomicRecipe(
+                    recipe=atomic_recipe.AtomicRecipe(
                         reference=makers.make_reference(
                             qualname="handle_error"
                         ),  # no defaults
@@ -397,7 +397,7 @@ class TestTryRecipeFullySourcing(unittest.TestCase):
         """Try body input without edge but with default → accepted."""
         try_node = helper_models.LabeledRecipe(
             label="try_body",
-            node=atomic_recipe.AtomicRecipe(
+            recipe=atomic_recipe.AtomicRecipe(
                 reference=makers.make_reference(
                     qualname="try_func", inputs_with_defaults=["extra"]
                 ),
@@ -425,7 +425,7 @@ class TestTryRecipeFullySourcing(unittest.TestCase):
                 ]
             },
         )
-        self.assertIn("extra", node.try_node.node.inputs)
+        self.assertIn("extra", node.try_node.recipe.inputs)
 
     def test_mixed_try_edged_except_unsourced_raises(self):
         """Try body fully edged, except_1 missing edge and default → fails."""
@@ -656,10 +656,10 @@ class TestTryRecipeProspectiveOutputEdgesValidation(unittest.TestCase):
             inputs=["x"],
             outputs=["out1", "out2"],
         )
-        try_node = helper_models.LabeledRecipe(label="try_body", node=body_node)
+        try_node = helper_models.LabeledRecipe(label="try_body", recipe=body_node)
         exception_case = helper_models.ExceptionCase(
             exceptions=[_VALUE_ERROR_INFO],
-            body=helper_models.LabeledRecipe(label="except_body", node=body_node),
+            body=helper_models.LabeledRecipe(label="except_body", recipe=body_node),
         )
         node = try_recipe.TryRecipe(
             inputs=["inp"],
@@ -691,7 +691,7 @@ class TestTryRecipeProspectiveOutputEdgesValidation(unittest.TestCase):
         """TryRecipe with no outputs requires empty prospective_output_edges."""
         try_node = helper_models.LabeledRecipe(
             label="try_body",
-            node=atomic_recipe.AtomicRecipe(
+            recipe=atomic_recipe.AtomicRecipe(
                 reference=base_models.PythonReference(
                     info=versions.VersionInfo(
                         module="mod", qualname="func", version=None
@@ -705,7 +705,7 @@ class TestTryRecipeProspectiveOutputEdgesValidation(unittest.TestCase):
             exceptions=[_VALUE_ERROR_INFO],
             body=helper_models.LabeledRecipe(
                 label="handler",
-                node=atomic_recipe.AtomicRecipe(
+                recipe=atomic_recipe.AtomicRecipe(
                     reference=makers.make_reference(qualname="handler"),
                     inputs=["x"],
                     outputs=[],

--- a/tests/unit/prospective/test_union_types.py
+++ b/tests/unit/prospective/test_union_types.py
@@ -72,7 +72,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                     "outputs": ["results"],
                     "body_node": {
                         "label": "body",
-                        "node": {
+                        "recipe": {
                             "type": "atomic",
                             "reference": reference_dict(),
                             "inputs": ["item"],
@@ -96,7 +96,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                     "case": {
                         "condition": {
                             "label": "c",
-                            "node": {
+                            "recipe": {
                                 "type": "atomic",
                                 "reference": reference_dict("m", "f"),
                                 "inputs": [],
@@ -105,7 +105,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                         },
                         "body": {
                             "label": "b",
-                            "node": {
+                            "recipe": {
                                 "type": "atomic",
                                 "reference": reference_dict("m", "g"),
                                 "inputs": [],
@@ -130,7 +130,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                         {
                             "condition": {
                                 "label": "condition_0",
-                                "node": {
+                                "recipe": {
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["result"],
@@ -143,7 +143,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             },
                             "body": {
                                 "label": "body_0",
-                                "node": {
+                                "recipe": {
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["y"],
@@ -170,7 +170,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                         {
                             "condition": {
                                 "label": "condition_0",
-                                "node": {
+                                "recipe": {
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["result"],
@@ -183,7 +183,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             },
                             "body": {
                                 "label": "body_0",
-                                "node": {
+                                "recipe": {
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["y"],
@@ -198,7 +198,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                     "prospective_output_edges": {"out": ["body_0.y", "else_body.y"]},
                     "else_case": {
                         "label": "else_body",
-                        "node": {
+                        "recipe": {
                             "type": "atomic",
                             "inputs": ["x"],
                             "outputs": ["y"],
@@ -217,7 +217,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                     "outputs": ["out"],
                     "try_node": {
                         "label": "try_body",
-                        "node": {
+                        "recipe": {
                             "type": "atomic",
                             "inputs": ["x"],
                             "outputs": ["y"],
@@ -230,7 +230,7 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             "exceptions": [versions.VersionInfo.of(ValueError)],
                             "body": {
                                 "label": "except_0",
-                                "node": {
+                                "recipe": {
                                     "type": "atomic",
                                     "inputs": ["x"],
                                     "outputs": ["y"],
@@ -473,7 +473,7 @@ class TestNestedUnionResolution(unittest.TestCase):
                     "outputs": ["out"],
                     "body_node": {
                         "label": "body",
-                        "node": {
+                        "recipe": {
                             "type": "atomic",
                             "reference": reference_dict(qualname="transform"),
                             "inputs": ["item"],
@@ -496,7 +496,7 @@ class TestNestedUnionResolution(unittest.TestCase):
         self.assertIsInstance(wf, workflow_recipe.WorkflowRecipe)
         self.assertIsInstance(wf.nodes["for_node"], for_recipe.ForEachRecipe)
         self.assertIsInstance(
-            wf.nodes["for_node"].body_node.node, atomic_recipe.AtomicRecipe
+            wf.nodes["for_node"].body_node.recipe, atomic_recipe.AtomicRecipe
         )
 
     def test_deeply_nested_workflows(self):

--- a/tests/unit/prospective/test_while_recipe.py
+++ b/tests/unit/prospective/test_while_recipe.py
@@ -301,7 +301,7 @@ class TestWhileRecipeFullySourcing(unittest.TestCase):
             },
             output_edges={},
         )
-        self.assertIn("extra", wn.case.condition.node.inputs)
+        self.assertIn("extra", wn.case.condition.recipe.inputs)
 
     def test_body_unsourced_no_default_raises(self):
         """Body input without edge or default → rejected."""
@@ -354,7 +354,7 @@ class TestWhileRecipeFullySourcing(unittest.TestCase):
             },
             output_edges={},
         )
-        self.assertIn("extra", wn.case.body.node.inputs)
+        self.assertIn("extra", wn.case.body.recipe.inputs)
 
 
 class TestWhileRecipeOutputEdges(unittest.TestCase):
@@ -567,11 +567,11 @@ class TestWhileRecipeSerialization(unittest.TestCase):
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="check",
-                    node=makers.make_atomic(inputs=["val"], outputs=["flag"]),
+                    recipe=makers.make_atomic(inputs=["val"], outputs=["flag"]),
                 ),
                 body=helper_models.LabeledRecipe(
                     label="step",
-                    node=makers.make_atomic(inputs=["x", "y"], outputs=["a", "b"]),
+                    recipe=makers.make_atomic(inputs=["x", "y"], outputs=["a", "b"]),
                 ),
             ),
             input_edges={"check.val": "n", "step.x": "n", "step.y": "acc"},
@@ -600,11 +600,11 @@ class TestWhileRecipeSerialization(unittest.TestCase):
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="cond",
-                    node=makers.make_atomic(inputs=["v"], outputs=["ok"]),
+                    recipe=makers.make_atomic(inputs=["v"], outputs=["ok"]),
                 ),
                 body=helper_models.LabeledRecipe(
                     label="body",
-                    node=makers.make_atomic(inputs=["p"], outputs=["q"]),
+                    recipe=makers.make_atomic(inputs=["p"], outputs=["q"]),
                 ),
             ),
             input_edges={"cond.v": "a", "body.p": "a"},
@@ -622,11 +622,11 @@ class TestWhileRecipeSerialization(unittest.TestCase):
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="cond",
-                    node=makers.make_atomic(inputs=["inp"], outputs=["out"]),
+                    recipe=makers.make_atomic(inputs=["inp"], outputs=["out"]),
                 ),
                 body=helper_models.LabeledRecipe(
                     label="body",
-                    node=makers.make_atomic(inputs=["a"], outputs=["b"]),
+                    recipe=makers.make_atomic(inputs=["a"], outputs=["b"]),
                 ),
             ),
             input_edges={"cond.inp": "x", "body.a": "x"},
@@ -662,18 +662,18 @@ class TestWhileRecipeSerialization(unittest.TestCase):
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="check",
-                    node=makers.make_atomic(
+                    recipe=makers.make_atomic(
                         inputs=["v"], outputs=["done"], inputs_with_defaults=["v"]
                     ),
                 ),
-                body=helper_models.LabeledRecipe(label="process", node=inner),
+                body=helper_models.LabeledRecipe(label="process", recipe=inner),
             ),
             input_edges={"process.a": "start"},
             output_edges={"start": "process.b"},
         )
         data = wn.model_dump(mode="json")
         restored = while_recipe.WhileRecipe.model_validate(data)
-        self.assertIsInstance(restored.case.body.node, workflow_recipe.WorkflowRecipe)
+        self.assertIsInstance(restored.case.body.recipe, workflow_recipe.WorkflowRecipe)
 
 
 class TestWhileRecipeEdgeCases(unittest.TestCase):
@@ -685,11 +685,11 @@ class TestWhileRecipeEdgeCases(unittest.TestCase):
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="c",
-                    node=makers.make_atomic(inputs=[], outputs=["done"]),
+                    recipe=makers.make_atomic(inputs=[], outputs=["done"]),
                 ),
                 body=helper_models.LabeledRecipe(
                     label="b",
-                    node=makers.make_atomic(inputs=[], outputs=[]),
+                    recipe=makers.make_atomic(inputs=[], outputs=[]),
                 ),
             ),
             input_edges={},
@@ -704,11 +704,11 @@ class TestWhileRecipeEdgeCases(unittest.TestCase):
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="c",
-                    node=makers.make_atomic(inputs=[], outputs=[]),  # No outputs!
+                    recipe=makers.make_atomic(inputs=[], outputs=[]),  # No outputs!
                 ),
                 body=helper_models.LabeledRecipe(
                     label="b",
-                    node=makers.make_atomic(inputs=[], outputs=[]),
+                    recipe=makers.make_atomic(inputs=[], outputs=[]),
                 ),
             )
         self.assertIn("exactly one output", str(ctx.exception))
@@ -725,11 +725,11 @@ class TestWhileRecipeEdgeCases(unittest.TestCase):
             case=helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="cond",
-                    node=makers.make_atomic(inputs=["val"], outputs=["ok"]),
+                    recipe=makers.make_atomic(inputs=["val"], outputs=["ok"]),
                 ),
                 body=helper_models.LabeledRecipe(
                     label="body",
-                    node=makers.make_atomic(inputs=["inp"], outputs=["out"]),
+                    recipe=makers.make_atomic(inputs=["inp"], outputs=["out"]),
                 ),
             ),
             input_edges={"body.inp": "x", "cond.val": "x"},

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -145,7 +145,7 @@ def _for_negate() -> for_recipe.ForEachRecipe:
         inputs=["xs"],
         outputs=["ys"],
         body_node=helper_models.LabeledRecipe(
-            label="body", node=library.negate.flowrep_recipe
+            label="body", recipe=library.negate.flowrep_recipe
         ),
         input_edges={
             edge_models.TargetHandle(node="body", port="x"): edge_models.InputSource(
@@ -170,7 +170,7 @@ def _for_add_broadcast() -> for_recipe.ForEachRecipe:
         inputs=["xs", "offset"],
         outputs=["ys", "inputs_used"],
         body_node=helper_models.LabeledRecipe(
-            label="body", node=library.my_add.flowrep_recipe
+            label="body", recipe=library.my_add.flowrep_recipe
         ),
         input_edges={
             edge_models.TargetHandle(node="body", port="a"): edge_models.InputSource(
@@ -198,7 +198,7 @@ def _for_add_zipped() -> for_recipe.ForEachRecipe:
         inputs=["xs", "ys"],
         outputs=["sums"],
         body_node=helper_models.LabeledRecipe(
-            label="body", node=library.my_add.flowrep_recipe
+            label="body", recipe=library.my_add.flowrep_recipe
         ),
         input_edges={
             edge_models.TargetHandle(node="body", port="a"): edge_models.InputSource(
@@ -236,10 +236,10 @@ def _while_countdown() -> while_recipe.WhileRecipe:
         outputs=["n"],
         case=helper_models.ConditionalCase(
             condition=helper_models.LabeledRecipe(
-                label="condition", node=library.is_positive.flowrep_recipe
+                label="condition", recipe=library.is_positive.flowrep_recipe
             ),
             body=helper_models.LabeledRecipe(
-                label="body", node=_decrement_body_workflow()
+                label="body", recipe=_decrement_body_workflow()
             ),
         ),
         input_edges={
@@ -289,17 +289,17 @@ def _if_abs() -> if_recipe.IfRecipe:
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="condition_0",
-                    node=library.is_positive.flowrep_recipe,
+                    recipe=library.is_positive.flowrep_recipe,
                 ),
                 body=helper_models.LabeledRecipe(
                     label="body_0",
-                    node=_identity_body_workflow(),
+                    recipe=_identity_body_workflow(),
                 ),
             )
         ],
         else_case=helper_models.LabeledRecipe(
             label="else_body",
-            node=_negate_body_workflow(),
+            recipe=_negate_body_workflow(),
         ),
         input_edges={
             edge_models.TargetHandle(
@@ -339,18 +339,18 @@ def _if_abs_multi_output_condition() -> if_recipe.IfRecipe:
             helper_models.ConditionalCase(
                 condition=helper_models.LabeledRecipe(
                     label="condition_0",
-                    node=_value_and_flag.flowrep_recipe,
+                    recipe=_value_and_flag.flowrep_recipe,
                 ),
                 body=helper_models.LabeledRecipe(
                     label="body_0",
-                    node=_identity_body_workflow(),
+                    recipe=_identity_body_workflow(),
                 ),
                 condition_output="flag",
             )
         ],
         else_case=helper_models.LabeledRecipe(
             label="else_body",
-            node=_negate_body_workflow(),
+            recipe=_negate_body_workflow(),
         ),
         input_edges={
             edge_models.TargetHandle(
@@ -401,7 +401,7 @@ def _try_safe_divide() -> try_recipe.TryRecipe:
         inputs=["a", "b"],
         outputs=["result"],
         try_node=helper_models.LabeledRecipe(
-            label="try_body", node=_divide_body_workflow()
+            label="try_body", recipe=_divide_body_workflow()
         ),
         exception_cases=[
             helper_models.ExceptionCase(
@@ -409,7 +409,7 @@ def _try_safe_divide() -> try_recipe.TryRecipe:
                     versions.VersionInfo.of(ZeroDivisionError),
                 ],
                 body=helper_models.LabeledRecipe(
-                    label="except_body_0", node=_fallback_body_workflow()
+                    label="except_body_0", recipe=_fallback_body_workflow()
                 ),
             )
         ],


### PR DESCRIPTION
Because `LabeledRecipe` having a `label` and `node` is just ridiculous. It should clearly have a `label` and a `recipe`. Past-Liam didn't know what he was about.

This is a compatibility-breaking change, since serialized recipes still have `"node":` in this spot. We're v0, so I'm not going to worry about this.

It becomes important to fix only if we introduce a stdlib, because then people will be invoking things like `fr.std.add.recipe` and that's desirable vs `fr.std.add.node`, since it is ultimately returning a recipe object.