### PR TITLE
Typing extensions

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - python >=3.11, <3.15
 - pydantic =2.12.5
 - pyiron_snippets =1.4.0
+- typing-extensions =4.16.0
 - bagofholding =0.1.12
 - ipytree =0.2.2
 - python-workflow-definition =0.1.5

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,3 +7,4 @@ dependencies:
 - python >=3.11, <3.15
 - pydantic =2.12.5
 - pyiron_snippets =1.4.0
+- typing-extensions =4.16.0

--- a/.ci_support/lower-bounds.yml
+++ b/.ci_support/lower-bounds.yml
@@ -8,6 +8,7 @@ dependencies:
   - python =3.11
   - pydantic =2.12.0
   - pyiron_snippets =1.3.0
+  - typing-extensions =4.8.0
   - bagofholding =0.1.5
   - ipytree =0.2.1
   - python-workflow-definition =0.1.4

--- a/.ci_support/lower-bounds.yml
+++ b/.ci_support/lower-bounds.yml
@@ -8,7 +8,7 @@ dependencies:
   - python =3.11
   - pydantic =2.12.0
   - pyiron_snippets =1.3.0
-  - typing-extensions =4.8.0
+  - typing-extensions =4.14.1
   - bagofholding =0.1.5
   - ipytree =0.2.1
   - python-workflow-definition =0.1.4

--- a/.ci_support/upper-bounds.yml
+++ b/.ci_support/upper-bounds.yml
@@ -2,3 +2,4 @@ channels:
   - conda-forge
 dependencies:
   - pyiron_snippets =2.0.0
+  - typing_extensions =5.0.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - python >=3.11, <3.15
 - pydantic =2.12.5
 - pyiron_snippets =1.4.0
+- typing-extensions =4.16.0
 - bagofholding =0.1.12
 - ipytree =0.2.2
 - python-workflow-definition =0.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "packaging==26.2",
     "pydantic==2.12.5",
     "pyiron_snippets==1.4.0",
+    "typing-extensions==4.16.0",
 ]
 dynamic = [ "version",]
 authors = [


### PR DESCRIPTION
We added explicit dependence with the constants parsing, and have so far gotten away with implicit fulfillment because of the `pydantic` dependency. Here we make the explicit dependence explicit.