### PR TITLE
Degenerate output

### DIFF
--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -541,11 +541,6 @@ class _WorkflowFunctionParser(WorkflowParser):
                 )
 
         returned_symbols = parser_helpers.resolve_symbols_to_strings(body.value)
-        base_models.validate_unique(
-            returned_symbols,
-            message=f"Workflow python definitions must have unique returns, but "
-            f"got duplicates in: {returned_symbols}",
-        )
 
         annotated_returns = label_helpers.get_annotated_output_labels(func)
         scraped_labels = label_helpers.merge_labels(
@@ -562,6 +557,14 @@ class _WorkflowFunctionParser(WorkflowParser):
             )
 
         final_ports = list(output_labels) if output_labels else scraped_labels
+
+        base_models.validate_unique(
+            final_ports,
+            message=f"Workflow python definitions must have unique outputs, but "
+            f"got duplicates in: {final_ports}. Was the same symbol returned multiple "
+            f"times? If so, try providing unique output labels or -- probably better "
+            f"-- don't return duplicate symbols.",
+        )
 
         for symbol, port in zip(returned_symbols, final_ports, strict=True):
             if symbol not in self.symbol_map:

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -824,38 +824,6 @@ class TestOutputsEdgeCases(unittest.TestCase):
             makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
         )
 
-    def test_duplicate_source_port_raises(self):
-        # Hand-build a recipe where two outputs share one source handle.
-        free = makers.reference_free(self._single_two_named_outputs_source())
-        # Force two output ports onto the same source handle.
-
-        single_src = next(iter(free.output_edges.values()))
-        bad = free.model_copy(
-            update={
-                "outputs": ["p", "q"],
-                "output_edges": {
-                    edge_models.OutputTarget(port="p"): single_src,
-                    edge_models.OutputTarget(port="q"): single_src,
-                },
-            }
-        )
-        # p and q both come from the same handle; no required-name conflict at the
-        # top level (we use annotations there), but the source code parser guards
-        # against duplicate output symbols
-        rendered = source._workflow2python(bad)
-        with self.assertRaisesRegex(
-            ValueError,
-            "Workflow python definitions must have unique returns",
-        ):
-            rendered.build()
-
-    def _single_two_named_outputs_source(self):
-        def one(a, b):
-            s = library.my_add(a, b)
-            return s
-
-        return one
-
 
 class TestNestedWorkflowNode(unittest.TestCase):
     def test_reference_free_subworkflow_node(self):

--- a/tests/unit/parsers/test_workflow_parser.py
+++ b/tests/unit/parsers/test_workflow_parser.py
@@ -1235,6 +1235,96 @@ class TestLiteralAssignment(unittest.TestCase):
         self.assertIn("exactly one symbol", str(ctx.exception))
 
 
+class TestParseWorkflowOutputUniqueness(unittest.TestCase):
+    def test_output_uniqueness(self):
+        def wf(x):
+            y = library.identity(x)
+            return y, y
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn(
+            "got duplicates in: ['y', 'y']",
+            str(ctx.exception),
+            msg="It's critical that each output _port_ be uniquely identifiable",
+        )
+
+        output_labels = ["o1", "o2"]
+        node = workflow_parser.parse_workflow(wf, *output_labels)
+        self.assertEqual(
+            node.outputs,
+            output_labels,
+            msg="Returning the same thing twice is permissible, as long as an explicit "
+            "output label is available",
+        )
+        self.assertEqual(
+            node.output_edges[edge_models.OutputTarget(port="o1")],
+            node.output_edges[edge_models.OutputTarget(port="o2")],
+            msg="The identical output should source from the same place.",
+        )
+
+
+class TestParseWorkflowReassignment(unittest.TestCase):
+    def test_reassignment_uses_most_recent(self):
+        def wf(a, b):
+            y = library.identity(a)
+            y = library.identity(b)
+            return y
+
+        node = workflow_parser.parse_workflow(wf)
+        self.assertEqual(
+            node.output_edges[edge_models.OutputTarget(port="y")],
+            edge_models.SourceHandle(node="identity_1", port="x"),
+            msg="Output should source from the most recent declaration",
+        )
+
+
+class TestParseWorkflowAliasing(unittest.TestCase):
+    def test_aliasing_uses_most_recent(self):
+        with self.subTest("Assignment most recent"):
+
+            def wf(a, b):
+                y = library.identity(a)
+                z = y
+                z = library.identity(b)
+                return z
+
+            node = workflow_parser.parse_workflow(wf)
+            self.assertEqual(
+                node.output_edges[edge_models.OutputTarget(port="z")],
+                edge_models.SourceHandle(node="identity_1", port="x"),
+                msg="Output should source from the most recent declaration",
+            )
+
+        with self.subTest("Aliasing most recent"):
+
+            def wf(a, b):
+                y = library.identity(a)
+                z = library.identity(b)
+                z = y
+                return z
+
+            node = workflow_parser.parse_workflow(wf)
+            self.assertEqual(
+                node.output_edges[edge_models.OutputTarget(port="z")],
+                edge_models.SourceHandle(node="identity_0", port="x"),
+                msg="Output should source from the most recent declaration",
+            )
+
+    def test_alias_as_duplicate(self):
+        def wf(a):
+            y = library.identity(a)
+            z = y
+            return y, z
+
+        node = workflow_parser.parse_workflow(wf)
+        self.assertEqual(["y", "z"], node.outputs)
+        self.assertEqual(
+            node.output_edges[edge_models.OutputTarget(port="y")],
+            node.output_edges[edge_models.OutputTarget(port="z")],
+        )
+
+
 class TestAttributeAccess(unittest.TestCase):
     def test_single_access(self):
         def wf(x0: int, comp: library.ComplexData):


### PR DESCRIPTION
Being able to reassign symbols to new values opened up a bug:

```python
import flowrep as fr

def f(x):
    return x


@fr.workflow
def wf(a):
    y = f(a)
    z = y
    return y, z

print(
    fr.tools.flowrep2python(
        wf.flowrep_recipe.model_copy(
            update={"reference": None}
        )
    ).source
)
```

This parses fine, because the symbol check sees `y` and `z` as different. But the compiler is smart enough to identify that these are the same and produces:

```python
from __future__ import annotations

import __main__
import flowrep
import typing

@flowrep.workflow("y", "z")
def compiled_from_workflow_recipe(a):
    f = __main__.f(x=a)
    return f, f
```

If we try to parse _that_, the parser complains that `f` and `f` are the same. 

The thing is, we don't really care if the same symbol gets returned twice. What matters is that the parsed workflow be able to secure unique identifiers for each _output port_. Which is absolutely the case here because of the way the compiler uses output labels based on the symbols.

So here we just shift the uniqueness check from the returned symbols over to the output labels used, and add some tests for this and stuff around it that I ran into while debugging this.