### PR TITLE
Stdlib refactor

### DIFF
--- a/src/flowrep/__init__.py
+++ b/src/flowrep/__init__.py
@@ -11,6 +11,7 @@ from flowrep.api import dataclass as dataclass
 from flowrep.api import parse_atomic as parse_atomic
 from flowrep.api import parse_workflow as parse_workflow
 from flowrep.api import schemas as schemas
+from flowrep.api import std as std
 from flowrep.api import tools as tools
 from flowrep.api import workflow as workflow
 

--- a/src/flowrep/compiler/sugar.py
+++ b/src/flowrep/compiler/sugar.py
@@ -13,7 +13,7 @@ from flowrep.prospective import (
 )
 
 # `LabeledRecipe.recipe` is a discriminated union; the cast narrows it for mypy.
-_GETATTR = cast(atomic_recipe.AtomicRecipe, std.getattr_.recipe)
+_GETATTR = cast(atomic_recipe.AtomicRecipe, std.get_attr.flowrep_recipe)  # type: ignore[attr-defined]
 _GETATTR_FQN = _GETATTR.reference.info.fully_qualified_name
 
 # Port names are derived from the recipe, never spelled out: editing `std.getattr_`

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -5,6 +5,7 @@ import types
 from collections.abc import Callable, Iterable
 from typing import (
     Annotated,
+    Any,
     TypeVar,
     cast,
     get_args,
@@ -20,7 +21,7 @@ from flowrep.parsers import label_helpers, object_scope, parser_helpers
 from flowrep.parsers.label_helpers import default_output_label
 from flowrep.prospective import atomic_recipe, helper_models
 
-_AtomicTarget = TypeVar("_AtomicTarget", bound=types.FunctionType | type)
+_AtomicTarget = TypeVar("_AtomicTarget", bound=Callable[..., Any])
 
 
 @overload

--- a/src/flowrep/parsers/attribute_parser.py
+++ b/src/flowrep/parsers/attribute_parser.py
@@ -52,13 +52,7 @@ from collections.abc import Iterable
 
 from flowrep import edge_models
 from flowrep.parsers import constant_parser, label_helpers, symbol_scope
-from flowrep.prospective import std, union_types
-
-# Port names are derived from the recipe, never spelled out: editing `std.getattr_`
-# must not require editing strings anywhere else in the source.
-_GETATTR = std.getattr_.recipe
-_OBJ_PORT, _NAME_PORT = _GETATTR.inputs
-(_ATTR_PORT,) = _GETATTR.outputs
+from flowrep.prospective import union_types
 
 
 def chain_root(node: ast.expr) -> ast.Name | None:
@@ -96,6 +90,14 @@ def inject_attribute_chain(
     *node* must be a data attribute chain (see :func:`is_data_attribute`); callers
     are expected to gate on that before calling.
     """
+    # Port names are derived from the recipe, never spelled out: editing `std.getattr_`
+    # must not require editing strings anywhere else in the source.
+    from flowrep.prospective import std
+
+    _GETATTR = std.get_attr.flowrep_recipe  # type: ignore[attr-defined]
+    _OBJ_PORT, _NAME_PORT = _GETATTR.inputs
+    (_ATTR_PORT,) = _GETATTR.outputs
+
     links: list[ast.Attribute] = []
     current: ast.expr = node
     while isinstance(current, ast.Attribute):
@@ -116,7 +118,7 @@ def inject_attribute_chain(
     handle: edge_models.SourceHandle | None = None
     for link in links:
         label = label_helpers.unique_suffix(f"getattr_{link.attr}", nodes)
-        nodes[label] = std.getattr_.recipe
+        nodes[label] = std.get_attr.flowrep_recipe  # type: ignore[attr-defined]
         if handle is None:
             symbol_map.consume(root.id, label, _OBJ_PORT)
         else:

--- a/src/flowrep/prospective/std.py
+++ b/src/flowrep/prospective/std.py
@@ -7,11 +7,8 @@ import operator
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
-from pyiron_snippets import versions
-
-from flowrep import base_models
 from flowrep.parsers import atomic_parser
-from flowrep.prospective import atomic_recipe, helper_models
+from flowrep.prospective import atomic_recipe
 
 
 @atomic_parser.atomic("absolute", unpack_mode=atomic_recipe.UnpackMode.NONE)
@@ -19,798 +16,254 @@ def abs(a, /):
     return operator.abs(a)
 
 
-add = helper_models.LabeledRecipe(
-    label="add",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.add),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["added"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("added", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def add(a, b, /):
+    return operator.add(a, b)
 
-index = helper_models.LabeledRecipe(
-    label="index",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.index),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["index"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-inv = helper_models.LabeledRecipe(
-    label="inv",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.inv),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["inverted"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("index", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def index(a, /):
+    return operator.index(a)
 
-invert = helper_models.LabeledRecipe(
-    label="invert",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.invert),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["inverted"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-neg = helper_models.LabeledRecipe(
-    label="neg",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.neg),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["negative"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("inverted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def inv(a, /):
+    return operator.inv(a)
 
-pos = helper_models.LabeledRecipe(
-    label="pos",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.pos),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["positive"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-not_ = helper_models.LabeledRecipe(
-    label="not_",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.not_),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["negated"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("inverted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def invert(a, /):
+    return operator.invert(a)
 
-truth = helper_models.LabeledRecipe(
-    label="truth",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.truth),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["truth"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-length_hint = helper_models.LabeledRecipe(
-    label="length_hint",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.length_hint),
-            restricted_input_kinds={
-                "obj": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["obj"],
-        outputs=["length"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("negative", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def neg(a, /):
+    return operator.neg(a)
 
-sub = helper_models.LabeledRecipe(
-    label="sub",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.sub),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["difference"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-isub = helper_models.LabeledRecipe(
-    label="isub",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.isub),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["difference"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("positive", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def pos(a, /):
+    return operator.pos(a)
 
-iadd = helper_models.LabeledRecipe(
-    label="iadd",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.iadd),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["added"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-mul = helper_models.LabeledRecipe(
-    label="mul",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.mul),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["product"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("negated", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def not_(a, /):
+    return operator.not_(a)
 
-imul = helper_models.LabeledRecipe(
-    label="imul",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.imul),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["product"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-floordiv = helper_models.LabeledRecipe(
-    label="floordiv",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.floordiv),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["quotient"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("truth", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def truth(a, /):
+    return operator.truth(a)
 
-ifloordiv = helper_models.LabeledRecipe(
-    label="ifloordiv",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.ifloordiv),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["quotient"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-truediv = helper_models.LabeledRecipe(
-    label="truediv",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.truediv),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["quotient"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("length", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def length_hint(obj, /):
+    return operator.length_hint(obj)
 
-itruediv = helper_models.LabeledRecipe(
-    label="itruediv",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.itruediv),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["quotient"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-mod = helper_models.LabeledRecipe(
-    label="mod",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.mod),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["remainder"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("difference", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def sub(a, b, /):
+    return operator.sub(a, b)
 
-imod = helper_models.LabeledRecipe(
-    label="imod",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.imod),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["remainder"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-pow = helper_models.LabeledRecipe(
-    label="pow",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.pow),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["power"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("difference", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def isub(a, b, /):
+    return operator.isub(a, b)
 
-ipow = helper_models.LabeledRecipe(
-    label="ipow",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.ipow),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["power"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-and_ = helper_models.LabeledRecipe(
-    label="and_",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.and_),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["conjunction"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("added", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def iadd(a, b, /):
+    return operator.iadd(a, b)
 
-iand = helper_models.LabeledRecipe(
-    label="iand",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.iand),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["conjunction"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-or_ = helper_models.LabeledRecipe(
-    label="or_",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.or_),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["disjunction"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def mul(a, b, /):
+    return operator.mul(a, b)
 
-ior = helper_models.LabeledRecipe(
-    label="ior",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.ior),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["disjunction"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-xor = helper_models.LabeledRecipe(
-    label="xor",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.xor),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["exclusive_or"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def imul(a, b, /):
+    return operator.imul(a, b)
 
-ixor = helper_models.LabeledRecipe(
-    label="ixor",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.ixor),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["exclusive_or"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-lshift = helper_models.LabeledRecipe(
-    label="lshift",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.lshift),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["left_shifted"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def floordiv(a, b, /):
+    return operator.floordiv(a, b)
 
-ilshift = helper_models.LabeledRecipe(
-    label="ilshift",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.ilshift),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["left_shifted"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-rshift = helper_models.LabeledRecipe(
-    label="rshift",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.rshift),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["right_shifted"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def ifloordiv(a, b, /):
+    return operator.ifloordiv(a, b)
 
-irshift = helper_models.LabeledRecipe(
-    label="irshift",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.irshift),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["right_shifted"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-matmul = helper_models.LabeledRecipe(
-    label="matmul",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.matmul),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["matrix_product"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def truediv(a, b, /):
+    return operator.truediv(a, b)
 
-imatmul = helper_models.LabeledRecipe(
-    label="imatmul",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.imatmul),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["matrix_product"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-eq = helper_models.LabeledRecipe(
-    label="eq",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.eq),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["equal"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def itruediv(a, b, /):
+    return operator.itruediv(a, b)
 
-ne = helper_models.LabeledRecipe(
-    label="ne",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.ne),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["not_equal"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-lt = helper_models.LabeledRecipe(
-    label="lt",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.lt),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["less"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("remainder", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def mod(a, b, /):
+    return operator.mod(a, b)
 
-le = helper_models.LabeledRecipe(
-    label="le",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.le),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["less_equal"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-gt = helper_models.LabeledRecipe(
-    label="gt",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.gt),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["greater"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("remainder", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def imod(a, b, /):
+    return operator.imod(a, b)
 
-ge = helper_models.LabeledRecipe(
-    label="ge",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.ge),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["greater_equal"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-is_ = helper_models.LabeledRecipe(
-    label="is_",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.is_),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["identical"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("power", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def pow(a, b, /):
+    return operator.pow(a, b)
 
-is_not = helper_models.LabeledRecipe(
-    label="is_not",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.is_not),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["not_identical"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-contains = helper_models.LabeledRecipe(
-    label="contains",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.contains),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["contains"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("power", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def ipow(a, b, /):
+    return operator.ipow(a, b)
 
-countOf = helper_models.LabeledRecipe(
-    label="countOf",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.countOf),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["count"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-indexOf = helper_models.LabeledRecipe(
-    label="indexOf",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.indexOf),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["index"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("conjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def and_(a, b, /):
+    return operator.and_(a, b)
 
-concat = helper_models.LabeledRecipe(
-    label="concat",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.concat),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["concatenated"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-iconcat = helper_models.LabeledRecipe(
-    label="iconcat",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.iconcat),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["concatenated"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("conjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def iand(a, b, /):
+    return operator.iand(a, b)
 
-getitem = helper_models.LabeledRecipe(
-    label="getitem",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.getitem),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["item"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
 
-setitem = helper_models.LabeledRecipe(
-    label="setitem",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.setitem),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "c": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b", "c"],
-        outputs=["set"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+@atomic_parser.atomic("disjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def or_(a, b, /):
+    return operator.or_(a, b)
 
-delitem = helper_models.LabeledRecipe(
-    label="delitem",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.delitem),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "b": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a", "b"],
-        outputs=["deleted"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+
+@atomic_parser.atomic("disjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def ior(a, b, /):
+    return operator.ior(a, b)
+
+
+@atomic_parser.atomic("exclusive_or", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def xor(a, b, /):
+    return operator.xor(a, b)
+
+
+@atomic_parser.atomic("exclusive_or", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def ixor(a, b, /):
+    return operator.ixor(a, b)
+
+
+@atomic_parser.atomic("left_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def lshift(a, b, /):
+    return operator.lshift(a, b)
+
+
+@atomic_parser.atomic("left_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def ilshift(a, b, /):
+    return operator.ilshift(a, b)
+
+
+@atomic_parser.atomic("right_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def rshift(a, b, /):
+    return operator.rshift(a, b)
+
+
+@atomic_parser.atomic("right_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def irshift(a, b, /):
+    return operator.irshift(a, b)
+
+
+@atomic_parser.atomic("matrix_product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def matmul(a, b, /):
+    return operator.matmul(a, b)
+
+
+@atomic_parser.atomic("matrix_product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def imatmul(a, b, /):
+    return operator.imatmul(a, b)
+
+
+@atomic_parser.atomic("equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def eq(a, b, /):
+    return operator.eq(a, b)
+
+
+@atomic_parser.atomic("not_equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def ne(a, b, /):
+    return operator.ne(a, b)
+
+
+@atomic_parser.atomic("less", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def lt(a, b, /):
+    return operator.lt(a, b)
+
+
+@atomic_parser.atomic("less_equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def le(a, b, /):
+    return operator.le(a, b)
+
+
+@atomic_parser.atomic("greater", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def gt(a, b, /):
+    return operator.gt(a, b)
+
+
+@atomic_parser.atomic("greater_equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def ge(a, b, /):
+    return operator.ge(a, b)
+
+
+@atomic_parser.atomic("identical", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def is_(a, b, /):
+    return operator.is_(a, b)
+
+
+@atomic_parser.atomic("not_identical", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def is_not(a, b, /):
+    return operator.is_not(a, b)
+
+
+@atomic_parser.atomic("contains", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def contains(a, b, /):
+    return operator.contains(a, b)
+
+
+@atomic_parser.atomic("count", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def countOf(a, b, /):
+    return operator.countOf(a, b)
+
+
+@atomic_parser.atomic("index", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def indexOf(a, b, /):
+    return operator.indexOf(a, b)
+
+
+@atomic_parser.atomic("concatenated", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def concat(a, b, /):
+    return operator.concat(a, b)
+
+
+@atomic_parser.atomic("concatenated", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def iconcat(a, b, /):
+    return operator.iconcat(a, b)
+
+
+@atomic_parser.atomic("item", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def getitem(a, b, /):
+    return operator.getitem(a, b)
+
+
+@atomic_parser.atomic("set", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def setitem(a, b, c, /):
+    return operator.setitem(a, b, c)
+
+
+@atomic_parser.atomic("deleted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def delitem(a, b, /):
+    return operator.delitem(a, b)
 
 
 @atomic_parser.atomic("result", unpack_mode=atomic_recipe.UnpackMode.NONE)

--- a/src/flowrep/prospective/std.py
+++ b/src/flowrep/prospective/std.py
@@ -10,22 +10,14 @@ from typing import Any
 from pyiron_snippets import versions
 
 from flowrep import base_models
+from flowrep.parsers import atomic_parser
 from flowrep.prospective import atomic_recipe, helper_models
 
-abs = helper_models.LabeledRecipe(
-    label="abs",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(operator.abs),
-            restricted_input_kinds={
-                "a": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["a"],
-        outputs=["absolute"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
+
+@atomic_parser.atomic("absolute", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def abs(a, /):
+    return operator.abs(a)
+
 
 add = helper_models.LabeledRecipe(
     label="add",
@@ -821,8 +813,11 @@ delitem = helper_models.LabeledRecipe(
 )
 
 
-def _call_wrapper(
+@atomic_parser.atomic("result", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def call(
     obj: Callable,
+    /,
+    *,
     args_: Iterable[Any] | None = None,
     kwargs_: Mapping[str, Any] | None = None,
 ):
@@ -831,28 +826,8 @@ def _call_wrapper(
     return obj(*args_, **kwargs_)
 
 
-call = helper_models.LabeledRecipe(
-    label="call",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(_call_wrapper),
-            restricted_input_kinds={
-                "obj": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "args_": base_models.RestrictedParamKind.KEYWORD_ONLY,
-                "kwargs_": base_models.RestrictedParamKind.KEYWORD_ONLY,
-            },
-        ),
-        inputs=["obj", "args_", "kwargs_"],
-        outputs=["result"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
-
-
-def _getattr_wrapper(
-    obj: object,
-    name: str,
-):
+@atomic_parser.atomic("attr", unpack_mode=atomic_recipe.UnpackMode.NONE)
+def get_attr(obj: object, name: str, /):
     """
     getattr doesn't have an inspectable signature until python 3.13, so provide a
     well-formed wrapper.
@@ -860,35 +835,6 @@ def _getattr_wrapper(
     return getattr(obj, name)
 
 
-getattr_ = helper_models.LabeledRecipe(
-    label="getattr_",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(_getattr_wrapper),
-            restricted_input_kinds={
-                "obj": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-                "name": base_models.RestrictedParamKind.POSITIONAL_ONLY,
-            },
-        ),
-        inputs=["obj", "name"],
-        outputs=["attr"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)
-
-
-def _identity_function(x):
+@atomic_parser.atomic
+def identity(x):
     return x
-
-
-identity = helper_models.LabeledRecipe(
-    label="identity",
-    recipe=atomic_recipe.AtomicRecipe(
-        reference=base_models.PythonReference(
-            info=versions.VersionInfo.of(_identity_function),
-        ),
-        inputs=["x"],
-        outputs=["x"],
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
-    ),
-)

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -2396,7 +2396,7 @@ class TestAttributeSugar(unittest.TestCase):
             inputs=[],
             outputs=["attr"],
             nodes={
-                "getattr_0": std.getattr_.recipe,
+                "getattr_0": std.get_attr.flowrep_recipe,
                 "constant_obj": constant_recipe.ConstantRecipe(constant="hi"),
                 "constant_0": constant_recipe.ConstantRecipe(constant="val"),
             },
@@ -2432,7 +2432,7 @@ class TestAttributeSugar(unittest.TestCase):
             nodes={
                 "constant_obj": constant_recipe.ConstantRecipe(constant=3),
                 "constant_0": constant_recipe.ConstantRecipe(constant="real"),
-                "getattr_0": std.getattr_.recipe,
+                "getattr_0": std.get_attr.flowrep_recipe,
             },
             input_edges={},
             edges={
@@ -2446,7 +2446,7 @@ class TestAttributeSugar(unittest.TestCase):
             output_edges={OT(port="attr"): SH(node="getattr_0", port="attr")},
         )
         rendered = source._workflow2python(wf, function_name="const_obj_getattr")
-        self.assertIn("_getattr_wrapper", rendered.source)
+        self.assertIn("get_attr", rendered.source)
         fn = rendered.build()
         self.assertEqual(fn(), 3)
 
@@ -2462,7 +2462,7 @@ class TestAttributeSugar(unittest.TestCase):
             outputs=["attr"],
             nodes={
                 "identity_0": library.identity.flowrep_recipe,
-                "getattr_0": std.getattr_.recipe,
+                "getattr_0": std.get_attr.flowrep_recipe,
             },
             input_edges={
                 TH(node="identity_0", port="x"): IS(port="name_in"),
@@ -2474,7 +2474,7 @@ class TestAttributeSugar(unittest.TestCase):
             output_edges={OT(port="attr"): SH(node="getattr_0", port="attr")},
         )
         rendered = source._workflow2python(wf, function_name="nonsugar")
-        self.assertIn("_getattr_wrapper", rendered.source)
+        self.assertIn("get_attr", rendered.source)
         fn = rendered.build()
         self.assertEqual(fn(library.ComplexData(val=42), "val"), 42)
 

--- a/tests/unit/compiler/test_sugar.py
+++ b/tests/unit/compiler/test_sugar.py
@@ -16,7 +16,7 @@ def _wf(x0: int, comp: library.ComplexData):
 
 class TestIsStdGetattr(unittest.TestCase):
     def test_true_for_std_getattr_recipe(self):
-        self.assertTrue(sugar.is_std_getattr(std.getattr_.recipe))
+        self.assertTrue(sugar.is_std_getattr(std.get_attr.flowrep_recipe))
 
     def test_false_for_other_atomic(self):
         self.assertFalse(sugar.is_std_getattr(library.my_add.flowrep_recipe))
@@ -94,11 +94,11 @@ class TestPortConstantsTrackTheRecipe(unittest.TestCase):
 
     def test_input_ports_come_from_the_recipe(self):
         self.assertEqual(
-            (sugar.OBJ_PORT, sugar.NAME_PORT), tuple(std.getattr_.recipe.inputs)
+            (sugar.OBJ_PORT, sugar.NAME_PORT), tuple(std.get_attr.flowrep_recipe.inputs)
         )
 
     def test_output_port_comes_from_the_recipe(self):
-        self.assertEqual((sugar.ATTR_PORT,), tuple(std.getattr_.recipe.outputs))
+        self.assertEqual((sugar.ATTR_PORT,), tuple(std.get_attr.flowrep_recipe.outputs))
 
 
 if __name__ == "__main__":

--- a/tests/unit/parsers/test_attribute_parser.py
+++ b/tests/unit/parsers/test_attribute_parser.py
@@ -70,7 +70,7 @@ class TestInjectAttributeChain(unittest.TestCase):
         handle = attribute_parser.inject_attribute_chain(node, scope, nodes)
 
         self.assertEqual(set(nodes), {"getattr_a_0", "constant_0"})
-        self.assertIs(nodes["getattr_a_0"], std.getattr_.recipe)
+        self.assertIs(nodes["getattr_a_0"], std.get_attr.flowrep_recipe)
         self.assertIsInstance(nodes["constant_0"], constant_recipe.ConstantRecipe)
         self.assertEqual(nodes["constant_0"].constant, "a")
         self.assertEqual(
@@ -171,8 +171,8 @@ class TestInjectionUsesTheRecipePorts(unittest.TestCase):
     """The injected edges must target whatever ports std.getattr_ actually declares."""
 
     def test_edges_and_handle_track_the_recipe(self):
-        obj_port, name_port = std.getattr_.recipe.inputs
-        (attr_port,) = std.getattr_.recipe.outputs
+        obj_port, name_port = std.get_attr.flowrep_recipe.inputs
+        (attr_port,) = std.get_attr.flowrep_recipe.outputs
         scope = symbol_scope.SymbolScope(
             {"dc": _make_source("MyDataclass_0", "instance")}
         )

--- a/tests/unit/prospective/test_std.py
+++ b/tests/unit/prospective/test_std.py
@@ -41,7 +41,7 @@ class _HasAttrs:
 class TestStdExecution(unittest.TestCase):
 
     def test_abs(self):
-        out = wfms.run_recipe(std.abs.recipe, a=-3)
+        out = wfms.run_recipe(std.abs.flowrep_recipe, a=-3)
         self.assertEqual(3, out.output_ports["absolute"].value)
 
     def test_add(self):
@@ -250,19 +250,22 @@ class TestStdExecution(unittest.TestCase):
 
     def test_call(self):
         with self.subTest("no variadics"):
-            out = wfms.run_recipe(std.call.recipe, obj=_return_42)
+            out = wfms.run_recipe(std.call.flowrep_recipe, obj=_return_42)
             self.assertEqual(42, out.output_ports["result"].value)
         with self.subTest("args"):
-            out = wfms.run_recipe(std.call.recipe, obj=_return_42, args_=(1, 2))
+            out = wfms.run_recipe(std.call.flowrep_recipe, obj=_return_42, args_=(1, 2))
             self.assertEqual((42, (1, 2)), out.output_ports["result"].value)
         with self.subTest("kwargs"):
             out = wfms.run_recipe(
-                std.call.recipe, obj=_return_42, kwargs_={"a": 3, "b": 4}
+                std.call.flowrep_recipe, obj=_return_42, kwargs_={"a": 3, "b": 4}
             )
             self.assertEqual((42, {"a": 3, "b": 4}), out.output_ports["result"].value)
         with self.subTest("both"):
             out = wfms.run_recipe(
-                std.call.recipe, obj=_return_42, args_=(1, 2), kwargs_={"a": 3, "b": 4}
+                std.call.flowrep_recipe,
+                obj=_return_42,
+                args_=(1, 2),
+                kwargs_={"a": 3, "b": 4},
             )
             self.assertEqual(
                 (42, (1, 2), {"a": 3, "b": 4}), out.output_ports["result"].value
@@ -271,23 +274,25 @@ class TestStdExecution(unittest.TestCase):
     def test_getattr_(self):
         with self.subTest("instance attribute"):
             out = wfms.run_recipe(
-                std.getattr_.recipe, obj=_HasAttrs(), name="instance_attr"
+                std.get_attr.flowrep_recipe, obj=_HasAttrs(), name="instance_attr"
             )
             self.assertEqual(42, out.output_ports["attr"].value)
 
         with self.subTest("class attribute"):
             out = wfms.run_recipe(
-                std.getattr_.recipe, obj=_HasAttrs(), name="class_attr"
+                std.get_attr.flowrep_recipe, obj=_HasAttrs(), name="class_attr"
             )
             self.assertEqual("shared", out.output_ports["attr"].value)
 
         with self.subTest("bound method"):
-            out = wfms.run_recipe(std.getattr_.recipe, obj=_HasAttrs(), name="method")
+            out = wfms.run_recipe(
+                std.get_attr.flowrep_recipe, obj=_HasAttrs(), name="method"
+            )
             self.assertEqual("called", out.output_ports["attr"].value())
 
         with self.subTest("tuple attributes are delivered whole"):
             out = wfms.run_recipe(
-                std.getattr_.recipe, obj=_HasAttrs(), name="tuple_attr"
+                std.get_attr.flowrep_recipe, obj=_HasAttrs(), name="tuple_attr"
             )
             self.assertEqual(
                 (1, 2),
@@ -302,19 +307,21 @@ class TestStdExecution(unittest.TestCase):
                 AttributeError, msg="Failed lookups should surface to the caller"
             ),
         ):
-            wfms.run_recipe(std.getattr_.recipe, obj=_HasAttrs(), name="not_here")
+            wfms.run_recipe(
+                std.get_attr.flowrep_recipe, obj=_HasAttrs(), name="not_here"
+            )
 
     def test_identity(self):
         with self.subTest("value"):
-            out = wfms.run_recipe(std.identity.recipe, x=42)
+            out = wfms.run_recipe(std.identity.flowrep_recipe, x=42)
             self.assertEqual(42, out.output_ports["x"].value)
 
         with self.subTest("none"):
-            out = wfms.run_recipe(std.identity.recipe, x=None)
+            out = wfms.run_recipe(std.identity.flowrep_recipe, x=None)
             self.assertIsNone(out.output_ports["x"].value)
 
         with self.subTest("tuples are delivered whole"):
-            out = wfms.run_recipe(std.identity.recipe, x=(1, 2))
+            out = wfms.run_recipe(std.identity.flowrep_recipe, x=(1, 2))
             self.assertEqual(
                 (1, 2),
                 out.output_ports["x"].value,
@@ -324,7 +331,7 @@ class TestStdExecution(unittest.TestCase):
 
         with self.subTest("passthrough is not a copy"):
             obj = _HasAttrs()
-            out = wfms.run_recipe(std.identity.recipe, x=obj)
+            out = wfms.run_recipe(std.identity.flowrep_recipe, x=obj)
             self.assertIs(
                 obj,
                 out.output_ports["x"].value,

--- a/tests/unit/prospective/test_std.py
+++ b/tests/unit/prospective/test_std.py
@@ -45,207 +45,207 @@ class TestStdExecution(unittest.TestCase):
         self.assertEqual(3, out.output_ports["absolute"].value)
 
     def test_add(self):
-        out = wfms.run_recipe(std.add.recipe, a=1, b=2)
+        out = wfms.run_recipe(std.add.flowrep_recipe, a=1, b=2)
         self.assertEqual(3, out.output_ports["added"].value)
 
     def test_index(self):
-        out = wfms.run_recipe(std.index.recipe, a=5)
+        out = wfms.run_recipe(std.index.flowrep_recipe, a=5)
         self.assertEqual(5, out.output_ports["index"].value)
 
     def test_inv(self):
-        out = wfms.run_recipe(std.inv.recipe, a=0)
+        out = wfms.run_recipe(std.inv.flowrep_recipe, a=0)
         self.assertEqual(-1, out.output_ports["inverted"].value)
 
     def test_invert(self):
-        out = wfms.run_recipe(std.invert.recipe, a=0)
+        out = wfms.run_recipe(std.invert.flowrep_recipe, a=0)
         self.assertEqual(-1, out.output_ports["inverted"].value)
 
     def test_neg(self):
-        out = wfms.run_recipe(std.neg.recipe, a=2)
+        out = wfms.run_recipe(std.neg.flowrep_recipe, a=2)
         self.assertEqual(-2, out.output_ports["negative"].value)
 
     def test_pos(self):
-        out = wfms.run_recipe(std.pos.recipe, a=-2)
+        out = wfms.run_recipe(std.pos.flowrep_recipe, a=-2)
         self.assertEqual(-2, out.output_ports["positive"].value)
 
     def test_not_(self):
-        out = wfms.run_recipe(std.not_.recipe, a=False)
+        out = wfms.run_recipe(std.not_.flowrep_recipe, a=False)
         self.assertEqual(True, out.output_ports["negated"].value)
 
     def test_truth(self):
-        out = wfms.run_recipe(std.truth.recipe, a=[])
+        out = wfms.run_recipe(std.truth.flowrep_recipe, a=[])
         self.assertEqual(False, out.output_ports["truth"].value)
 
     def test_length_hint(self):
-        out = wfms.run_recipe(std.length_hint.recipe, obj=[1, 2, 3])
+        out = wfms.run_recipe(std.length_hint.flowrep_recipe, obj=[1, 2, 3])
         self.assertEqual(3, out.output_ports["length"].value)
 
     def test_sub(self):
-        out = wfms.run_recipe(std.sub.recipe, a=5, b=2)
+        out = wfms.run_recipe(std.sub.flowrep_recipe, a=5, b=2)
         self.assertEqual(3, out.output_ports["difference"].value)
 
     def test_isub(self):
-        out = wfms.run_recipe(std.isub.recipe, a=5, b=2)
+        out = wfms.run_recipe(std.isub.flowrep_recipe, a=5, b=2)
         self.assertEqual(3, out.output_ports["difference"].value)
 
     def test_iadd(self):
-        out = wfms.run_recipe(std.iadd.recipe, a=1, b=2)
+        out = wfms.run_recipe(std.iadd.flowrep_recipe, a=1, b=2)
         self.assertEqual(3, out.output_ports["added"].value)
 
     def test_mul(self):
-        out = wfms.run_recipe(std.mul.recipe, a=2, b=3)
+        out = wfms.run_recipe(std.mul.flowrep_recipe, a=2, b=3)
         self.assertEqual(6, out.output_ports["product"].value)
 
     def test_imul(self):
-        out = wfms.run_recipe(std.imul.recipe, a=2, b=3)
+        out = wfms.run_recipe(std.imul.flowrep_recipe, a=2, b=3)
         self.assertEqual(6, out.output_ports["product"].value)
 
     def test_floordiv(self):
-        out = wfms.run_recipe(std.floordiv.recipe, a=7, b=2)
+        out = wfms.run_recipe(std.floordiv.flowrep_recipe, a=7, b=2)
         self.assertEqual(3, out.output_ports["quotient"].value)
 
     def test_ifloordiv(self):
-        out = wfms.run_recipe(std.ifloordiv.recipe, a=7, b=2)
+        out = wfms.run_recipe(std.ifloordiv.flowrep_recipe, a=7, b=2)
         self.assertEqual(3, out.output_ports["quotient"].value)
 
     def test_truediv(self):
-        out = wfms.run_recipe(std.truediv.recipe, a=6, b=2)
+        out = wfms.run_recipe(std.truediv.flowrep_recipe, a=6, b=2)
         self.assertEqual(3.0, out.output_ports["quotient"].value)
 
     def test_itruediv(self):
-        out = wfms.run_recipe(std.itruediv.recipe, a=6, b=2)
+        out = wfms.run_recipe(std.itruediv.flowrep_recipe, a=6, b=2)
         self.assertEqual(3.0, out.output_ports["quotient"].value)
 
     def test_mod(self):
-        out = wfms.run_recipe(std.mod.recipe, a=7, b=3)
+        out = wfms.run_recipe(std.mod.flowrep_recipe, a=7, b=3)
         self.assertEqual(1, out.output_ports["remainder"].value)
 
     def test_imod(self):
-        out = wfms.run_recipe(std.imod.recipe, a=7, b=3)
+        out = wfms.run_recipe(std.imod.flowrep_recipe, a=7, b=3)
         self.assertEqual(1, out.output_ports["remainder"].value)
 
     def test_pow(self):
-        out = wfms.run_recipe(std.pow.recipe, a=2, b=3)
+        out = wfms.run_recipe(std.pow.flowrep_recipe, a=2, b=3)
         self.assertEqual(8, out.output_ports["power"].value)
 
     def test_ipow(self):
-        out = wfms.run_recipe(std.ipow.recipe, a=2, b=3)
+        out = wfms.run_recipe(std.ipow.flowrep_recipe, a=2, b=3)
         self.assertEqual(8, out.output_ports["power"].value)
 
     def test_and_(self):
-        out = wfms.run_recipe(std.and_.recipe, a=6, b=3)
+        out = wfms.run_recipe(std.and_.flowrep_recipe, a=6, b=3)
         self.assertEqual(2, out.output_ports["conjunction"].value)
 
     def test_iand(self):
-        out = wfms.run_recipe(std.iand.recipe, a=6, b=3)
+        out = wfms.run_recipe(std.iand.flowrep_recipe, a=6, b=3)
         self.assertEqual(2, out.output_ports["conjunction"].value)
 
     def test_or_(self):
-        out = wfms.run_recipe(std.or_.recipe, a=6, b=1)
+        out = wfms.run_recipe(std.or_.flowrep_recipe, a=6, b=1)
         self.assertEqual(7, out.output_ports["disjunction"].value)
 
     def test_ior(self):
-        out = wfms.run_recipe(std.ior.recipe, a=6, b=1)
+        out = wfms.run_recipe(std.ior.flowrep_recipe, a=6, b=1)
         self.assertEqual(7, out.output_ports["disjunction"].value)
 
     def test_xor(self):
-        out = wfms.run_recipe(std.xor.recipe, a=6, b=3)
+        out = wfms.run_recipe(std.xor.flowrep_recipe, a=6, b=3)
         self.assertEqual(5, out.output_ports["exclusive_or"].value)
 
     def test_ixor(self):
-        out = wfms.run_recipe(std.ixor.recipe, a=6, b=3)
+        out = wfms.run_recipe(std.ixor.flowrep_recipe, a=6, b=3)
         self.assertEqual(5, out.output_ports["exclusive_or"].value)
 
     def test_lshift(self):
-        out = wfms.run_recipe(std.lshift.recipe, a=1, b=3)
+        out = wfms.run_recipe(std.lshift.flowrep_recipe, a=1, b=3)
         self.assertEqual(8, out.output_ports["left_shifted"].value)
 
     def test_ilshift(self):
-        out = wfms.run_recipe(std.ilshift.recipe, a=1, b=3)
+        out = wfms.run_recipe(std.ilshift.flowrep_recipe, a=1, b=3)
         self.assertEqual(8, out.output_ports["left_shifted"].value)
 
     def test_rshift(self):
-        out = wfms.run_recipe(std.rshift.recipe, a=8, b=2)
+        out = wfms.run_recipe(std.rshift.flowrep_recipe, a=8, b=2)
         self.assertEqual(2, out.output_ports["right_shifted"].value)
 
     def test_irshift(self):
-        out = wfms.run_recipe(std.irshift.recipe, a=8, b=2)
+        out = wfms.run_recipe(std.irshift.flowrep_recipe, a=8, b=2)
         self.assertEqual(2, out.output_ports["right_shifted"].value)
 
     def test_matmul(self):
-        out = wfms.run_recipe(std.matmul.recipe, a=_Mat(1), b=_Mat(2))
+        out = wfms.run_recipe(std.matmul.flowrep_recipe, a=_Mat(1), b=_Mat(2))
         result = out.output_ports["matrix_product"].value
         self.assertEqual(("mm", 1, 2), result)
 
     def test_imatmul(self):
-        out = wfms.run_recipe(std.imatmul.recipe, a=_Mat(1), b=_Mat(2))
+        out = wfms.run_recipe(std.imatmul.flowrep_recipe, a=_Mat(1), b=_Mat(2))
         result = out.output_ports["matrix_product"].value
         self.assertEqual(("imm", 1, 2), result)
 
     def test_eq(self):
-        out = wfms.run_recipe(std.eq.recipe, a=1, b=1)
+        out = wfms.run_recipe(std.eq.flowrep_recipe, a=1, b=1)
         self.assertEqual(True, out.output_ports["equal"].value)
 
     def test_ne(self):
-        out = wfms.run_recipe(std.ne.recipe, a=1, b=2)
+        out = wfms.run_recipe(std.ne.flowrep_recipe, a=1, b=2)
         self.assertEqual(True, out.output_ports["not_equal"].value)
 
     def test_lt(self):
-        out = wfms.run_recipe(std.lt.recipe, a=1, b=2)
+        out = wfms.run_recipe(std.lt.flowrep_recipe, a=1, b=2)
         self.assertEqual(True, out.output_ports["less"].value)
 
     def test_le(self):
-        out = wfms.run_recipe(std.le.recipe, a=2, b=2)
+        out = wfms.run_recipe(std.le.flowrep_recipe, a=2, b=2)
         self.assertEqual(True, out.output_ports["less_equal"].value)
 
     def test_gt(self):
-        out = wfms.run_recipe(std.gt.recipe, a=2, b=1)
+        out = wfms.run_recipe(std.gt.flowrep_recipe, a=2, b=1)
         self.assertEqual(True, out.output_ports["greater"].value)
 
     def test_ge(self):
-        out = wfms.run_recipe(std.ge.recipe, a=2, b=2)
+        out = wfms.run_recipe(std.ge.flowrep_recipe, a=2, b=2)
         self.assertEqual(True, out.output_ports["greater_equal"].value)
 
     def test_is_(self):
-        out = wfms.run_recipe(std.is_.recipe, a=None, b=None)
+        out = wfms.run_recipe(std.is_.flowrep_recipe, a=None, b=None)
         self.assertEqual(True, out.output_ports["identical"].value)
 
     def test_is_not(self):
-        out = wfms.run_recipe(std.is_not.recipe, a=1, b=2)
+        out = wfms.run_recipe(std.is_not.flowrep_recipe, a=1, b=2)
         self.assertEqual(True, out.output_ports["not_identical"].value)
 
     def test_contains(self):
-        out = wfms.run_recipe(std.contains.recipe, a=[1, 2, 3], b=2)
+        out = wfms.run_recipe(std.contains.flowrep_recipe, a=[1, 2, 3], b=2)
         self.assertEqual(True, out.output_ports["contains"].value)
 
     def test_countOf(self):
-        out = wfms.run_recipe(std.countOf.recipe, a=[1, 2, 2, 3], b=2)
+        out = wfms.run_recipe(std.countOf.flowrep_recipe, a=[1, 2, 2, 3], b=2)
         self.assertEqual(2, out.output_ports["count"].value)
 
     def test_indexOf(self):
-        out = wfms.run_recipe(std.indexOf.recipe, a=[1, 2, 3], b=3)
+        out = wfms.run_recipe(std.indexOf.flowrep_recipe, a=[1, 2, 3], b=3)
         self.assertEqual(2, out.output_ports["index"].value)
 
     def test_concat(self):
-        out = wfms.run_recipe(std.concat.recipe, a=[1], b=[2])
+        out = wfms.run_recipe(std.concat.flowrep_recipe, a=[1], b=[2])
         self.assertEqual([1, 2], out.output_ports["concatenated"].value)
 
     def test_iconcat(self):
-        out = wfms.run_recipe(std.iconcat.recipe, a=[1], b=[2])
+        out = wfms.run_recipe(std.iconcat.flowrep_recipe, a=[1], b=[2])
         self.assertEqual([1, 2], out.output_ports["concatenated"].value)
 
     def test_getitem(self):
-        out = wfms.run_recipe(std.getitem.recipe, a=[10, 20], b=1)
+        out = wfms.run_recipe(std.getitem.flowrep_recipe, a=[10, 20], b=1)
         self.assertEqual(20, out.output_ports["item"].value)
 
     def test_setitem(self):
         d = {}
-        wfms.run_recipe(std.setitem.recipe, a=d, b="k", c=1)
+        wfms.run_recipe(std.setitem.flowrep_recipe, a=d, b="k", c=1)
         self.assertEqual(1, d["k"])
 
     def test_delitem(self):
         d = {"k": 1}
-        wfms.run_recipe(std.delitem.recipe, a=d, b="k")
+        wfms.run_recipe(std.delitem.flowrep_recipe, a=d, b="k")
         self.assertNotIn("k", d)
 
     def test_call(self):


### PR DESCRIPTION
This reformulates the std lib labeled recipes into `@atomic` decorated functions, per the discussion in #258.

I also corrected a minor oversight and exposed `std` at the module root instead of just in the API. Now that these use a parser to generate themselves, I think it makes sense to pull `std.py` up to the root from inside `prospective/`, but it's not important and I'll leave it for later to keep the diff here clearer.

One slightly annoying thing is that the attribute parser relies on the getattr std node as the single source of truth for port names; now that std uses the parser, this created a circular import I had to break. I can live with it.

Something interesting that occurred to me is that now the version info in the std nodes will come from `flowrep` instead of from python itself (`VersionInfo`'s standard practice for stuff from the python stdlib like `operator`). I'll let it percolate, but I _think_ this is a net win; hopefully it will make recipe compatibility easier to track over the long-haul.