### PR TITLE
Dataclass unpacking

### DIFF
--- a/src/flowrep/parsers/dataclass_parser.py
+++ b/src/flowrep/parsers/dataclass_parser.py
@@ -53,7 +53,13 @@ def dataclass(cls=None, /, *output_labels, **kwargs):
 
 
 def dataclass_fields_to_outputs(dataclass):
-    return tuple(getattr(dataclass, f.name) for f in dataclasses.fields(dataclass))
+    field_values = tuple(
+        getattr(dataclass, f.name) for f in dataclasses.fields(dataclass)
+    )
+    if len(field_values) == 1:
+        return field_values[0]
+    else:
+        return field_values
 
 
 def _bind_inverse_recipe(
@@ -118,7 +124,12 @@ def _parse_dataclass_unpacking(cls):
     input_name = "dataclass"
     outputs = [f.name for f in fields]
     # tuple[t0, t1, ...]; __class_getitem__ dodges the type-checker false positive
-    return_annotation = tuple.__class_getitem__(tuple(hints[name] for name in outputs))
+    if len(fields) == 1:
+        return_annotation = hints[outputs[0]]
+    else:
+        return_annotation = tuple.__class_getitem__(
+            tuple(hints[name] for name in outputs)
+        )
     func_sig = inspect.Signature(
         parameters=[
             inspect.Parameter(

--- a/src/flowrep/parsers/dataclass_parser.py
+++ b/src/flowrep/parsers/dataclass_parser.py
@@ -1,9 +1,15 @@
 import dataclasses
+import functools
 import inspect
+import types
 from collections.abc import Callable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_type_hints, overload
 
+from pyiron_snippets import versions
+
+from flowrep import base_models
 from flowrep.parsers import atomic_parser
+from flowrep.prospective import atomic_recipe
 
 _Cls = TypeVar("_Cls", bound=type)
 
@@ -12,6 +18,8 @@ _DATACLASS_KWARGS = frozenset(
     for name, param in inspect.signature(dataclasses.dataclass).parameters.items()
     if param.kind is inspect.Parameter.KEYWORD_ONLY
 )
+
+INVERSE_RECIPE_ATTR = "flowrep_recipe_inverse"
 
 
 @overload
@@ -37,6 +45,106 @@ def dataclass(cls=None, /, *output_labels, **kwargs):
 
     def wrap(c):
         c = dataclasses.dataclass(**dataclass_kwargs)(c)
-        return atomic_parser.atomic(*labels, **atomic_kwargs)(c)
+        c = atomic_parser.atomic(*labels, **atomic_kwargs)(c)
+        c = _bind_inverse_recipe(c, **atomic_kwargs)
+        return c
 
     return wrap(cls) if bare else wrap
+
+
+def dataclass_fields_to_outputs(dataclass):
+    return tuple(getattr(dataclass, f.name) for f in dataclasses.fields(dataclass))
+
+
+def _bind_inverse_recipe(
+    cls,
+    version_scraping: versions.VersionScrapingMap | None = None,
+    forbid_main: bool = False,
+    forbid_locals: bool = False,
+    require_version: bool = False,
+    **kwargs,  # ignore others
+):
+    _bound_unpacker = f"_{cls.__name__}_fields_to_outputs"
+    _require_absent(cls, _bound_unpacker, INVERSE_RECIPE_ATTR)
+
+    input_name, outputs, func_sig = _parse_dataclass_unpacking(cls)
+    unpack = _clone_unpacker_with_signature(func_sig)
+    unpack.__name__ = _bound_unpacker
+    unpack.__qualname__ = f"{cls.__qualname__}.{_bound_unpacker}"
+    unpack.__module__ = cls.__module__
+    setattr(cls, _bound_unpacker, staticmethod(unpack))
+
+    dc_version = versions.VersionInfo.of(
+        cls,
+        version_scraping=version_scraping,
+        forbid_main=forbid_main,
+        forbid_locals=forbid_locals,
+        require_version=require_version,
+    )
+    reverse_recipe = atomic_recipe.AtomicRecipe(
+        inputs=[input_name],
+        outputs=outputs,
+        description=f"Unpacks {cls.__name__!r} fields into separate outputs into {outputs!r}",
+        reference=base_models.PythonReference(
+            info=versions.VersionInfo(
+                module=dc_version.module,
+                qualname=dc_version.qualname + "." + _bound_unpacker,
+                version=dc_version.version,
+                # A bit of a fib, since we depend on the DC version _and_ flowrep
+                # version for complete functionality here. DC is more likely to matter.
+            ),
+            restricted_input_kinds={
+                "dataclass": base_models.RestrictedParamKind.POSITIONAL_ONLY
+            },
+        ),
+        unpack_mode=atomic_recipe.UnpackMode.TUPLE,
+    )
+    setattr(cls, INVERSE_RECIPE_ATTR, reverse_recipe)
+    return cls
+
+
+def _require_absent(cls, *names):
+    for name in names:
+        if hasattr(cls, name):
+            raise AttributeError(
+                f"{cls.__name__!r} already defines {name!r}; refusing to overwrite"
+            )
+
+
+def _parse_dataclass_unpacking(cls):
+    hints = get_type_hints(cls)
+    fields = dataclasses.fields(cls)
+
+    input_name = "dataclass"
+    outputs = [f.name for f in fields]
+    # tuple[t0, t1, ...]; __class_getitem__ dodges the type-checker false positive
+    return_annotation = tuple.__class_getitem__(tuple(hints[name] for name in outputs))
+    func_sig = inspect.Signature(
+        parameters=[
+            inspect.Parameter(
+                input_name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=cls,
+            )
+        ],
+        return_annotation=return_annotation,
+    )
+    return input_name, outputs, func_sig
+
+
+def _clone_unpacker_with_signature(signature: inspect.Signature):
+    clone = functools.wraps(dataclass_fields_to_outputs)(
+        types.FunctionType(
+            dataclass_fields_to_outputs.__code__,
+            dataclass_fields_to_outputs.__globals__,
+        )
+    )
+    setattr(clone, "__signature__", signature)  # noqa: B010
+    clone.__annotations__ = {
+        name: param.annotation
+        for name, param in signature.parameters.items()
+        if param.annotation is not inspect.Parameter.empty
+    }
+    if signature.return_annotation is not inspect.Signature.empty:
+        clone.__annotations__["return"] = signature.return_annotation
+    return clone

--- a/src/flowrep/parsers/dataclass_parser.py
+++ b/src/flowrep/parsers/dataclass_parser.py
@@ -52,7 +52,7 @@ def dataclass(cls=None, /, *output_labels, **kwargs):
     return wrap(cls) if bare else wrap
 
 
-def dataclass_fields_to_outputs(dataclass):
+def dataclass_fields_to_outputs(dataclass, /):
     field_values = tuple(
         getattr(dataclass, f.name) for f in dataclasses.fields(dataclass)
     )

--- a/tests/flowrep_static/library.py
+++ b/tests/flowrep_static/library.py
@@ -187,3 +187,31 @@ def val(x):
     what forces the compiler-side namespace collision.
     """
     return x
+
+
+# test_parsing_atomic_classes -- inverse recipe
+
+
+@dataclass_parser.dataclass
+class Pair:
+    foo: int
+    bar: str
+
+
+@dataclass_parser.dataclass
+class Single:
+    only: int
+
+
+@workflow_parser.workflow
+def autoencoder(foo, bar):
+    dc = Pair(foo, bar)
+    f, b = Pair.flowrep_recipe_inverse(dc)
+    return f, b
+
+
+@workflow_parser.workflow
+def single_autoencoder(only):
+    dc = Single(only)
+    o = Single.flowrep_recipe_inverse(dc)
+    return o

--- a/tests/integration/parsers/test_parsing_atomic_classes.py
+++ b/tests/integration/parsers/test_parsing_atomic_classes.py
@@ -18,6 +18,8 @@ import flowrep as fr
 from flowrep import base_models
 from flowrep.retrospective.datastructures import NotData
 
+from flowrep_static import library
+
 _KEYWORD_ONLY = base_models.RestrictedParamKind.KEYWORD_ONLY
 
 
@@ -152,6 +154,42 @@ class TestAtomicDeepGenericLimitation(unittest.TestCase):
             "implementation",
         )
         self.assertEqual(port.annotation.__name__, "_TReal")
+
+
+class TestInverseRecipeExecution(unittest.TestCase):
+    def test_autoencoder_round_trip_direct(self):
+        self.assertEqual(library.autoencoder(42, "towel"), (42, "towel"))
+
+    def test_autoencoder_round_trip_run_recipe(self):
+        out = fr.tools.run_recipe(
+            library.autoencoder.flowrep_recipe, foo=42, bar="towel"
+        )
+        self.assertEqual(out.output_ports["f"].value, 42)
+        self.assertEqual(out.output_ports["b"].value, "towel")
+
+    def test_single_autoencoder_round_trip_direct(self):
+        self.assertEqual(library.single_autoencoder(7), 7)
+
+    def test_single_autoencoder_round_trip_run_recipe(self):
+        out = fr.tools.run_recipe(library.single_autoencoder.flowrep_recipe, only=7)
+        self.assertEqual(out.output_ports["o"].value, 7)
+
+    def test_inverse_recipe_run_directly(self):
+        out = fr.tools.run_recipe(
+            library.Pair.flowrep_recipe_inverse, dataclass=library.Pair(1, "a")
+        )
+        self.assertEqual(out.output_ports["foo"].value, 1)
+        self.assertEqual(out.output_ports["bar"].value, "a")
+
+    def test_inverse_recipe_with_defaulted_field(self):
+        # MyDataclass(a: ComplexData, x: int = 1) -- the default is irrelevant
+        # when unpacking an existing instance.
+        instance = library.MyDataclass(library.ComplexData(3), 7)
+        out = fr.tools.run_recipe(
+            library.MyDataclass.flowrep_recipe_inverse, dataclass=instance
+        )
+        self.assertEqual(out.output_ports["a"].value.val, 3)
+        self.assertEqual(out.output_ports["x"].value, 7)
 
 
 if __name__ == "__main__":

--- a/tests/unit/parsers/test_dataclass_parser.py
+++ b/tests/unit/parsers/test_dataclass_parser.py
@@ -1,9 +1,14 @@
 import dataclasses
 import inspect
+import typing
 import unittest
 
+from flowrep import base_models
 from flowrep.parsers import atomic_parser, dataclass_parser
 from flowrep.prospective import atomic_recipe
+from flowrep.retrospective import datastructures
+
+from flowrep_static import library
 
 
 class TestDataclassDecorator(unittest.TestCase):
@@ -108,6 +113,100 @@ class TestNamespaceOverlap(unittest.TestCase):
             set(dataclass_parser._DATACLASS_KWARGS).intersection(atomic_kwargs),
             msg="Ensure that dataclass and atomic kwargs don't overlap.",
         )
+
+
+# `datastructures.recipe2data` resolves the bound unpacker via its fully qualified
+# name, which requires it to be importable. Classes defined inline inside a test
+# method have "<locals>" in their qualname and cannot be resolved this way, so the
+# fixtures feeding recipe2data-based assertions must live at module scope.
+@dataclass_parser.dataclass
+class _ModuleWithClassVar:
+    x: int
+    tag: typing.ClassVar[str] = "t"
+
+
+class TestInverseRecipeStructure(unittest.TestCase):
+    def test_multi_field_recipe_shape(self):
+        recipe = library.Pair.flowrep_recipe_inverse
+        self.assertIsInstance(recipe, atomic_recipe.AtomicRecipe)
+        self.assertEqual(recipe.inputs, ["dataclass"])
+        self.assertEqual(recipe.outputs, ["foo", "bar"])
+        self.assertIs(recipe.unpack_mode, atomic_recipe.UnpackMode.TUPLE)
+        self.assertEqual(
+            recipe.reference.restricted_input_kinds,
+            {"dataclass": base_models.RestrictedParamKind.POSITIONAL_ONLY},
+        )
+
+    def test_multi_field_output_annotations(self):
+        ports = datastructures.recipe2data(
+            library.Pair.flowrep_recipe_inverse
+        ).output_ports
+        self.assertEqual(list(ports), ["foo", "bar"])
+        self.assertIs(ports["foo"].annotation, int)
+        self.assertIs(ports["bar"].annotation, str)
+
+    def test_reference_and_unpacker_follow_the_class(self):
+        unpacker = library.Pair._Pair_fields_to_outputs
+        self.assertEqual(unpacker.__name__, "_Pair_fields_to_outputs")
+        self.assertEqual(
+            unpacker.__qualname__,
+            f"{library.Pair.__qualname__}._Pair_fields_to_outputs",
+        )
+        self.assertEqual(unpacker.__module__, library.Pair.__module__)
+
+        info = library.Pair.flowrep_recipe_inverse.reference.info
+        self.assertEqual(
+            info.qualname, f"{library.Pair.__qualname__}._Pair_fields_to_outputs"
+        )
+        self.assertEqual(info.module, library.Pair.__module__)
+
+    def test_single_field_recipe_shape(self):
+        recipe = library.Single.flowrep_recipe_inverse
+        self.assertEqual(recipe.outputs, ["only"])
+        ports = datastructures.recipe2data(recipe).output_ports
+        self.assertEqual(list(ports), ["only"])
+        self.assertIs(ports["only"].annotation, int)
+
+    def test_single_field_return_annotation_is_bare_not_tuple(self):
+        sig = inspect.signature(library.Single._Single_fields_to_outputs)
+        self.assertIs(sig.return_annotation, int)
+
+    def test_classvar_excluded_from_outputs(self):
+        recipe = _ModuleWithClassVar.flowrep_recipe_inverse
+        self.assertEqual(recipe.outputs, ["x"])
+        ports = datastructures.recipe2data(recipe).output_ports
+        self.assertEqual(list(ports), ["x"])
+
+    def test_unpacker_returns_tuple_for_multi_bare_for_single(self):
+        self.assertEqual(
+            library.Pair._Pair_fields_to_outputs(library.Pair(1, "a")), (1, "a")
+        )
+        self.assertEqual(library.Single._Single_fields_to_outputs(library.Single(5)), 5)
+
+    def test_single_field_cannot_be_tuple_unpacked(self):
+        result = library.Single._Single_fields_to_outputs(library.Single(5))
+        self.assertEqual(result, 5)  # `o = ...` form works
+        with self.assertRaises(TypeError):
+            iter(result)  # `(o,) = ...` would raise: bare value, not a 1-tuple
+
+
+class TestInverseRecipeFailures(unittest.TestCase):
+    def test_forward_reference_annotation_raises_at_decoration(self):
+        # We greedily resolve hints via get_type_hints; an unresolvable forward
+        # reference fails at decoration time. This is an accepted limitation.
+        with self.assertRaises(NameError):
+
+            @dataclass_parser.dataclass
+            class Fwd:
+                val: "Undefined"  # noqa: F821
+
+    def test_predefined_inverse_attr_is_guarded(self):
+        with self.assertRaisesRegex(AttributeError, "refusing to overwrite"):
+
+            @dataclass_parser.dataclass
+            class Collide:
+                foo: int
+                flowrep_recipe_inverse: int = 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@XzzX, this is what I was talking about with attaching unpackers directly to the `@fr.dataclass`-decorated types. I'm not hung up on the actual attribute names (i.e. `flowrep_recipe_inverse`), but I like being able to get both the creating and unpacking under the namespace of the dataclass itself:

```python
import flowrep as fr

@fr.dataclass
class MyData:
    foo: int
    bar: str

@fr.workflow
def autoencoder(foo, bar):
    dc = MyData(foo, bar)
    f, b = MyData.flowrep_recipe_inverse(dc)
    return f, b

print(
    autoencoder(42, "towel"),
    fr.tools.run_recipe(
        autoencoder.flowrep_recipe, foo=42, bar="towel"
    ).output_ports
)  # Come out the same
>>> (42, 'towel') {'f': OutputDataPort(value=42, annotation=None), 'b': OutputDataPort(value='towel', annotation=None)}

print(fr.tools.recipe2data(MyData.flowrep_recipe_inverse).output_ports)  # gets annotations
>>> {'foo': OutputDataPort(value=NOT_DATA, annotation=<class 'int'>), 'bar': OutputDataPort(value=NOT_DATA, annotation=<class 'str'>)}
```

Out of scope: updating the user guide. This only adds new stuff, it's fine if it's "hidden" for now. I'll update the notebook on removing the dataclass `unpack_mode`