### PR TITLE
No constant symbols

### DIFF
--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -116,7 +116,8 @@ def _identity_materialization(value: Any, emitter: function.Emitter) -> str:
     inlined constant argument, which then round-trips exactly.
     """
     call_path = _set_call_path_from_info(
-        std.identity.flowrep_recipe.reference.info, emitter.module_imports
+        std.identity.flowrep_recipe.reference.info,  # type: ignore[attr-defined]
+        emitter.module_imports,
     )
     return f"{call_path}(x={value!r})"
 

--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
-from typing import TypeAlias, cast
+from typing import Any, TypeAlias, cast
 
 from pyiron_snippets import versions
 
@@ -11,6 +11,7 @@ from flowrep.compiler import flow_control, function, sugar
 from flowrep.prospective import (
     atomic_recipe,
     constant_recipe,
+    std,
     union_types,
     workflow_recipe,
 )
@@ -104,6 +105,22 @@ def _set_call_path_from_info(
     return call_path
 
 
+def _identity_materialization(value: Any, emitter: function.Emitter) -> str:
+    """Render an ``identity`` call wrapping a constant that cannot be inlined.
+
+    A bare ``name = <literal>`` statement no longer re-parses (constants are only
+    valid as call arguments), so a constant feeding a workflow output or a bare
+    flow-control body is emitted as ``identity(x=<literal>)``. The
+    ``flowrep.prospective.std`` import is hoisted via ``_set_call_path_from_info``.
+    On re-parse this canonicalises to a std ``identity`` atomic node fed by an
+    inlined constant argument, which then round-trips exactly.
+    """
+    call_path = _set_call_path_from_info(
+        std.identity.flowrep_recipe.reference.info, emitter.module_imports
+    )
+    return f"{call_path}(x={value!r})"
+
+
 def _topological_nodes(
     recipe: workflow_recipe.WorkflowRecipe,
 ) -> list[str]:
@@ -194,8 +211,9 @@ def emit_workflow_body(
     lines: list[str] = []
 
     # Constants feeding a workflow output cannot be inlined (a bare `return <literal>`
-    # is not re-parseable), so they are materialized as `sym = repr(value)` below and
-    # resolved to that symbol everywhere.
+    # is not re-parseable, and a bare `sym = <literal>` statement is no longer
+    # re-parseable either), so they are wrapped as `sym = identity(x=<literal>)` below
+    # and resolved to that symbol everywhere.
     materialized_constants = {
         src.node
         for src in recipe.output_edges.values()
@@ -308,7 +326,9 @@ def emit_workflow_body(
                 _output_name_suggestion(label, constant_label, 1)
             )
             produced[(label, constant_label)] = name
-            lines.append(f"{name} = {repr(node.constant)}")
+            lines.append(
+                f"{name} = {_identity_materialization(node.constant, emitter)}"
+            )
             continue
 
         if label in sugared:
@@ -375,7 +395,10 @@ def emit_body(
         name = required.get(constant_label) or alloc.fresh(
             _output_name_suggestion(label, constant_label, 1)
         )
-        return [f"{name} = {repr(recipe.constant)}"], {constant_label: name}
+        return (
+            [f"{name} = {_identity_materialization(recipe.constant, emitter)}"],
+            {constant_label: name},
+        )
     return _emit_single_node_body(recipe, label, in_syms, required, alloc, emitter)
 
 

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -311,22 +311,11 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
                     label=handle.node, recipe=self.nodes[handle.node]
                 ),
             )
-        elif rhs is not None and (parsed := constant_parser.try_parse_constant(rhs))[0]:
-            if len(new_symbols) != 1:
-                raise ValueError(
-                    f"Literal constant assignment must target exactly one symbol, "
-                    f"got {new_symbols}"
-                )
-            value = parsed[1]
-            label = label_helpers.unique_suffix(
-                constant_recipe.ConstantRecipe.std_label, self.nodes
-            )
-            node: constant_recipe.ConstantRecipe = constant_parser.make_constant(
-                value, f"Assignment to '{new_symbols[0]}'"
-            )
-            self.nodes[label] = node
-            self.symbol_map.register(
-                new_symbols, helper_models.LabeledRecipe(label=label, recipe=node)
+        elif rhs is not None and constant_parser.try_parse_constant(rhs)[0]:
+            raise ValueError(
+                "Workflow python definitions accept constants only as call "
+                "arguments (e.g. f(x, 5)); a bare literal assignment like "
+                "'some_var = 5' is no longer supported."
             )
         elif isinstance(rhs, ast.Name):
             if len(new_symbols) != 1:
@@ -338,7 +327,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         else:
             raise ValueError(
                 f"Workflow python definitions can only interpret assignments with "
-                f"a call, empty list, literal constant, symbol alias, or attribute "
+                f"a call, empty list, symbol alias, or attribute "
                 f"access rooted at a known workflow symbol on the right-hand-side, "
                 f"but ast found {type(rhs)}"
             )

--- a/tests/integration/parsers/test_parsing_reassignment.py
+++ b/tests/integration/parsers/test_parsing_reassignment.py
@@ -125,16 +125,15 @@ class TestAliasNonRegression(unittest.TestCase):
         with self.assertRaises(ValueError):
             _parse(macro)
 
-    def test_constant_rebinding(self):
+    def test_constant_rebinding_raises(self):
         def macro():
             y = 5
             y = 6
             return y
 
-        recipe = _parse(macro)
-        self.assertEqual(recipe.outputs, ["y"])
-        # Two constant nodes exist; the output sources from the second.
-        self.assertEqual(len(recipe.nodes), 2)
+        with self.assertRaises(ValueError) as ctx:
+            _parse(macro)
+        self.assertIn("only as call arguments", str(ctx.exception))
 
 
 class TestAliasAccumulatorInteractions(unittest.TestCase):

--- a/tests/integration/parsers/test_parsing_reassignment.py
+++ b/tests/integration/parsers/test_parsing_reassignment.py
@@ -125,16 +125,6 @@ class TestAliasNonRegression(unittest.TestCase):
         with self.assertRaises(ValueError):
             _parse(macro)
 
-    def test_constant_rebinding_raises(self):
-        def macro():
-            y = 5
-            y = 6
-            return y
-
-        with self.assertRaises(ValueError) as ctx:
-            _parse(macro)
-        self.assertIn("only as call arguments", str(ctx.exception))
-
 
 class TestAliasAccumulatorInteractions(unittest.TestCase):
     def test_reassigning_accumulator_breaks_later_append(self):

--- a/tests/unit/compiler/test_compiler.py
+++ b/tests/unit/compiler/test_compiler.py
@@ -2056,78 +2056,48 @@ class TestConstantInlining(unittest.TestCase):
         self.assertIs(type(reparsed_const[1]), int)
 
 
-def _rt_inline_const(a):
-    half = 0.5
-    r = library.my_mul(a, half)
-    return r
-
-
-class TestLiteralAssignRoundTrip(unittest.TestCase):
-    def test_inline_path_round_trips(self):
-        free = makers.reference_free(_rt_inline_const)
-        self.assertTrue(
-            any(
-                isinstance(n, constant_recipe.ConstantRecipe)
-                for n in free.nodes.values()
-            ),
-            msg="Literal assignment should have injected a ConstantRecipe node",
-        )
-        fn = source._workflow2python(free).build()
-        self.assertEqual(
-            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
-        )
-
-    def test_inline_path_executes(self):
-        free = makers.reference_free(_rt_inline_const)
-        fn = source._workflow2python(free).build()
-        self.assertAlmostEqual(fn(4), 4 * 0.5)
-
-
-def _return_constant(a):
-    y = 5
-    return y
-
-
-def _if_body_constant(a):
-    if library.is_positive(a):  # noqa: SIM108
-        y = 5
-    else:
-        y = library.identity(a)
-    return y
-
-
 class TestConstantMaterialize(unittest.TestCase):
-    def test_return_constant_materializes_and_round_trips(self):
-        free = makers.reference_free(_return_constant)
-        rendered = source._workflow2python(free)
-        self.assertIn("= 5", rendered.source)
-        self.assertNotIn("return 5", rendered.source)  # materialized, not inlined
+    TH, IS, SH, OT = (
+        edge_models.TargetHandle,
+        edge_models.InputSource,
+        edge_models.SourceHandle,
+        edge_models.OutputTarget,
+    )
+
+    def _assert_canonical_round_trips(self, rendered):
+        """`rendered` (from a hand-built recipe) must build, and the parsed
+        canonical recipe must then compile/parse idempotently."""
         fn = rendered.build()
+        canonical = fn.flowrep_recipe.model_copy(update={"reference": None})
+        rebuilt = source._workflow2python(canonical).build()
+        self.assertEqual(
+            makers.dump_no_refs(rebuilt.flowrep_recipe),
+            makers.dump_no_refs(fn.flowrep_recipe),
+            msg="Canonical (post-parse) recipe must round-trip exactly",
+        )
+        return fn
+
+    def test_constant_feeding_output_wraps_in_identity(self):
+        wf = workflow_recipe.WorkflowRecipe(
+            inputs=["a"],
+            outputs=["y"],
+            nodes={"constant_0": constant_recipe.ConstantRecipe(constant=5)},
+            input_edges={},
+            edges={},
+            output_edges={
+                self.OT(port="y"): self.SH(node="constant_0", port="constant")
+            },
+        )
+        rendered = source._workflow2python(wf, function_name="returns_const")
+        self.assertIn("identity(", rendered.source)
+        self.assertNotIn("return 5", rendered.source)  # not inlined as a bare return
+        self.assertNotIn("constant = 5", rendered.source)  # not a bare assignment
+        fn = self._assert_canonical_round_trips(rendered)
         self.assertEqual(fn(99), 5)
-        self.assertEqual(
-            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
-        )
 
-    def test_constant_in_if_branch_body_materializes_and_round_trips(self):
-        free = makers.reference_free(_if_body_constant)
-        fn = source._workflow2python(free).build()
-        self.assertEqual(fn(5), 5)  # is_positive -> y = 5
-        self.assertEqual(fn(-3), -3)  # else -> identity(a)
-        self.assertEqual(
-            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
-        )
-
-    def test_bare_constant_flow_control_body_compiles_and_executes(self):
+    def test_constant_in_flow_control_body_wraps_in_identity(self):
         # Hand-built `if is_positive(n): m = 42 else: m = -1` with BARE ConstantRecipe
-        # bodies (a shape only hand-construction produces). Round-trip canonicalizes
-        # (parser wraps bodies in workflows), so we assert source + execution, not
-        # dump_no_refs equality.
-        TH, IS, SH, OT = (
-            edge_models.TargetHandle,
-            edge_models.InputSource,
-            edge_models.SourceHandle,
-            edge_models.OutputTarget,
-        )
+        # bodies (a shape only hand-construction produces).
         if_node = if_recipe.IfRecipe(
             inputs=["n"],
             outputs=["m"],
@@ -2137,32 +2107,35 @@ class TestConstantMaterialize(unittest.TestCase):
                         label="cond", recipe=library.is_positive.flowrep_recipe
                     ),
                     body=helper_models.LabeledRecipe(
-                        label="body", recipe=constant_recipe.ConstantRecipe(constant=42)
+                        label="body",
+                        recipe=constant_recipe.ConstantRecipe(constant=42),
                     ),
                 )
             ],
-            input_edges={TH(node="cond", port="n"): IS(port="n")},
+            input_edges={self.TH(node="cond", port="n"): self.IS(port="n")},
             prospective_output_edges={
-                OT(port="m"): [
-                    SH(node="body", port="constant"),
-                    SH(node="else_body", port="constant"),
+                self.OT(port="m"): [
+                    self.SH(node="body", port="constant"),
+                    self.SH(node="else_body", port="constant"),
                 ]
             },
             else_case=helper_models.LabeledRecipe(
-                label="else_body", recipe=constant_recipe.ConstantRecipe(constant=-1)
+                label="else_body",
+                recipe=constant_recipe.ConstantRecipe(constant=-1),
             ),
         )
         wf = workflow_recipe.WorkflowRecipe(
             inputs=["n"],
             outputs=["m"],
             nodes={"if_0": if_node},
-            input_edges={TH(node="if_0", port="n"): IS(port="n")},
+            input_edges={self.TH(node="if_0", port="n"): self.IS(port="n")},
             edges={},
-            output_edges={OT(port="m"): SH(node="if_0", port="m")},
+            output_edges={self.OT(port="m"): self.SH(node="if_0", port="m")},
         )
         rendered = source._workflow2python(wf, function_name="branchy")
-        self.assertIn("= 42", rendered.source)
-        fn = rendered.build()
+        self.assertIn("identity(", rendered.source)
+        self.assertNotIn("m = 42", rendered.source)  # not a bare assignment
+        fn = self._assert_canonical_round_trips(rendered)
         self.assertEqual(fn(5), 42)
         self.assertEqual(fn(-3), -1)
 

--- a/tests/unit/parsers/test_for_parser.py
+++ b/tests/unit/parsers/test_for_parser.py
@@ -293,9 +293,9 @@ class TestForParserErrors(unittest.TestCase):
         self.assertIn("results", str(ctx.exception))
 
     def test_assigning_non_empty_list_raises(self):
-        """A non-empty list literal is a valid ``ConstantRecipe`` assignment (not an
-        accumulator), so ``results`` is never registered as an accumulator and the
-        later ``.append()`` is what raises."""
+        """A non-empty list literal is a bare literal assignment, which is rejected
+        outright -- ``results`` never gets a chance to become (or fail to become) an
+        accumulator."""
 
         def wf(xs):
             results = [0]
@@ -306,10 +306,7 @@ class TestForParserErrors(unittest.TestCase):
 
         with self.assertRaises(ValueError) as ctx:
             workflow_parser.parse_workflow(wf)
-        self.assertIn(
-            "not found among available accumulator symbols", str(ctx.exception)
-        )
-        self.assertIn("results", str(ctx.exception))
+        self.assertIn("only as call arguments", str(ctx.exception))
 
     def test_accumulator_reassigned_in_nested_while_raises(self):
         """Reassigning an accumulator symbol inside a nested while is rejected."""

--- a/tests/unit/parsers/test_workflow_parser.py
+++ b/tests/unit/parsers/test_workflow_parser.py
@@ -1175,12 +1175,6 @@ def _assign_list_constant(seed):
     return r
 
 
-def _assign_tuple_constant(a):
-    bad = (1, 2)
-    r = library.identity(bad)
-    return r
-
-
 def _assign_non_literal(a):
     bad = a + 1
     r = library.identity(bad)
@@ -1205,6 +1199,21 @@ def _constant_as_argument(a):
     return r
 
 
+def _list_as_argument(a):
+    r = library.my_add(a, [1, 2])
+    return r
+
+
+def _tuple_as_argument(a):
+    r = library.my_add(a, (1, 2))
+    return r
+
+
+def _nonliteral_as_argument(a):
+    r = library.identity(a + 1)
+    return r
+
+
 class TestLiteralAssignment(unittest.TestCase):
     def _constants(self, recipe):
         return [
@@ -1217,15 +1226,6 @@ class TestLiteralAssignment(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             workflow_parser.parse_workflow(_assign_scalar_constant)
         self.assertIn("only as call arguments", str(ctx.exception))
-
-    def test_list_literal_assignment_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            workflow_parser.parse_workflow(_assign_list_constant)
-        self.assertIn("only as call arguments", str(ctx.exception))
-
-    def test_tuple_literal_assignment_raises(self):
-        with self.assertRaises(ValueError):
-            workflow_parser.parse_workflow(_assign_tuple_constant)
 
     def test_non_literal_expr_assignment_still_raises(self):
         with self.assertRaises(ValueError):
@@ -1241,12 +1241,27 @@ class TestLiteralAssignment(unittest.TestCase):
             workflow_parser.parse_workflow(_assign_literal_to_multiple_targets)
         self.assertIn("only as call arguments", str(ctx.exception))
 
-    def test_constant_still_valid_as_call_argument(self):
+    def test_constant_valid_as_call_argument(self):
         recipe = workflow_parser.parse_workflow(_constant_as_argument)
         self.assertTrue(
             any(c.constant == 5 for c in self._constants(recipe)),
             msg="A literal passed as a call argument must still inject a constant node",
         )
+
+    def test_list_valid_as_call_argument(self):
+        recipe = workflow_parser.parse_workflow(_list_as_argument)
+        self.assertTrue(
+            any(c.constant == [1, 2] for c in self._constants(recipe)),
+            msg="A literal passed as a call argument must still inject a constant node",
+        )
+
+    def test_non_jsonable_as_argument_raises(self):
+        with self.assertRaises(ValueError):
+            workflow_parser.parse_workflow(_tuple_as_argument)
+
+    def test_nonliteral_as_argument_raises(self):
+        with self.assertRaises(TypeError):
+            workflow_parser.parse_workflow(_nonliteral_as_argument(5))
 
 
 class TestParseWorkflowOutputUniqueness(unittest.TestCase):

--- a/tests/unit/parsers/test_workflow_parser.py
+++ b/tests/unit/parsers/test_workflow_parser.py
@@ -1200,6 +1200,11 @@ def _assign_literal_to_multiple_targets(a):
     return a
 
 
+def _constant_as_argument(a):
+    r = library.my_add(a, 5)
+    return r
+
+
 class TestLiteralAssignment(unittest.TestCase):
     def _constants(self, recipe):
         return [
@@ -1208,13 +1213,15 @@ class TestLiteralAssignment(unittest.TestCase):
             if isinstance(n, constant_recipe.ConstantRecipe)
         ]
 
-    def test_scalar_literal_injects_constant(self):
-        recipe = workflow_parser.parse_workflow(_assign_scalar_constant)
-        self.assertTrue(any(c.constant == 0.5 for c in self._constants(recipe)))
+    def test_scalar_literal_assignment_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(_assign_scalar_constant)
+        self.assertIn("only as call arguments", str(ctx.exception))
 
-    def test_list_literal_injects_constant(self):
-        recipe = workflow_parser.parse_workflow(_assign_list_constant)
-        self.assertTrue(any(c.constant == [1, 2, 3] for c in self._constants(recipe)))
+    def test_list_literal_assignment_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(_assign_list_constant)
+        self.assertIn("only as call arguments", str(ctx.exception))
 
     def test_tuple_literal_assignment_raises(self):
         with self.assertRaises(ValueError):
@@ -1232,7 +1239,14 @@ class TestLiteralAssignment(unittest.TestCase):
     def test_literal_assigned_to_multiple_targets_raises(self):
         with self.assertRaises(ValueError) as ctx:
             workflow_parser.parse_workflow(_assign_literal_to_multiple_targets)
-        self.assertIn("exactly one symbol", str(ctx.exception))
+        self.assertIn("only as call arguments", str(ctx.exception))
+
+    def test_constant_still_valid_as_call_argument(self):
+        recipe = workflow_parser.parse_workflow(_constant_as_argument)
+        self.assertTrue(
+            any(c.constant == 5 for c in self._constants(recipe)),
+            msg="A literal passed as a call argument must still inject a constant node",
+        )
 
 
 class TestParseWorkflowOutputUniqueness(unittest.TestCase):


### PR DESCRIPTION
Per [@samwaseda's suggestion](), rolls back the parsing of symbols so that `val = "some JSONable constant"` is not longer acceptable. Leaves constants inside calls alone, such that `y = some_func(x, 42)` is fine.

This resolves the conflict between constants assigned to symbols and using `acc = []` to indicate to the parser to start parsing a `ForEachRecipe`, and deprecates #285.

In hand-written recipes, it's still possible to manually construct a situation where constants play a role akin to variable assignment, e.g. feeding workflow output or a conditional branch. If the compiler runs into these, it inserts a `var = flowrep.std.identity({THE CONSTANT})` to coerce it into following the "constants as arguments" rule. This makes the compiled python re-parseable at the cost of its new recipe being not byte-identical to the compiled one. Since it differs only by identity wrappers, I find this to be a fair compromise.

~I want to push at some edge cases to make sure there are no sneak surprises before merging it, but it lgtm so far.~ I poked at a couple of cases I was suspicious of and they behaved perfectly well.