### PR TITLE
Inject `std.getitem` on parsing `ast.Subscript`

### DIFF
--- a/src/flowrep/parsers/attribute_parser.py
+++ b/src/flowrep/parsers/attribute_parser.py
@@ -1,198 +1,51 @@
-"""Parse attribute access on workflow data into injected ``std.getattr_`` nodes.
+"""The ``.attr`` link of a data-access chain (see :mod:`chain_parser`).
 
-An attribute chain rooted at a known *symbol* (``dc.a``, ``dc.a.val``) becomes one
-``std.getattr_`` node per link, each with a ``ConstantRecipe`` peer carrying the
-attribute name. The symbol map deliberately shadows the object scope, so a workflow
-input named ``os`` makes ``os.path`` an attribute access on that input, exactly as it
-would be at runtime.
-
-Attribute access is allowed anywhere a value is, with one exception: the workflow's
-``return``. The rule is
-
-    a port name may be *generated* when the port is internal to the recipe; it must
-    come from a *symbol* only when the port is public IO.
-
-Ports get their names from four places:
-
-===============================  ==========================================
-Port                             Name comes from
-===============================  ==========================================
-Workflow output port             the returned symbol
-Flow-control input port          the enclosing symbol feeding it, or -- for a
-                                 constant or an attribute chain, which have no
-                                 symbol -- a generated name (see
-                                 :func:`generate_port_name`)
-For-body output port             the appended symbol, or a generated name
-Atomic/workflow node input port  the *callee's* own parameter
-===============================  ==========================================
-
-Only the first is public IO. A workflow's output ports are its interface, and a
-consumer wiring into them should be able to read their names straight off the source,
-so ``return dc.a`` is refused (see :func:`reject_unbound_attribute`). Everywhere else
-the port is internal wiring, and a generated name costs the reader nothing: the
-compiler emits ``val_0 = x.val`` and re-parsing regenerates exactly that port, so the
-sugared form and the bound form are not merely equivalent recipes -- they are the same
-recipe.
-
-(``@atomic`` stays laxer about its own returns. That asymmetry is deliberate: atomic
-parsing must swallow arbitrary Python functions, including ones the caller did not
-write, whereas a ``@workflow`` author controls their own source.)
-
-Two things a generated name cannot rescue, both refused elsewhere: a method call on
-workflow data (``dc.method(x)``), which needs a callable reference rather than a port
-name, and an attribute in a ``while`` condition rooted at a symbol the loop body
-reassigns (see :func:`while_parser._reject_looped_attribute_roots`), where hoisting the
-getattr out of the loop would silently diverge from Python's per-iteration re-read.
+``obj.attr`` becomes one ``std.get_attr`` node whose ``name`` input is fed by a
+``ConstantRecipe`` peer carrying the attribute name.
 """
 
 from __future__ import annotations
 
 import ast
-from collections.abc import Iterable
 
-from flowrep import edge_models
-from flowrep.parsers import constant_parser, label_helpers, symbol_scope
-from flowrep.prospective import union_types
+from flowrep.parsers import constant_parser, symbol_scope
+from flowrep.prospective import atomic_recipe, union_types
 
 
-def chain_root(node: ast.expr) -> ast.Name | None:
-    """The innermost ``ast.Name`` of a pure Attribute/Name chain, else ``None``."""
-    while isinstance(node, ast.Attribute):
-        node = node.value
-    return node if isinstance(node, ast.Name) else None
+def _link(node: ast.expr) -> ast.Attribute:
+    """Narrow a dispatched link; ``chain_parser`` only routes Attributes here."""
+    assert isinstance(node, ast.Attribute)
+    return node
 
 
-def is_data_attribute(node: ast.expr, symbol_map: symbol_scope.SymbolScope) -> bool:
-    """True if *node* is attribute access rooted at a symbol known to the graph.
+class AttributeHandler:
+    """One ``std.get_attr`` node per ``.attr`` link, plus its name constant."""
 
-    The symbol map deliberately shadows the object scope: a workflow input named
-    ``os`` makes ``os.path`` a data attribute access on that input, not a module
-    lookup, exactly as it would be at runtime.
-    """
-    if not isinstance(node, ast.Attribute):
-        return False
-    root = chain_root(node)
-    return root is not None and root.id in symbol_map
+    @property
+    def recipe(self) -> atomic_recipe.AtomicRecipe:
+        # Imported lazily: `flowrep.std` imports the parsers, so a module-level
+        # import here would cycle.
+        from flowrep import std
 
+        return std.get_attr.flowrep_recipe  # type: ignore[attr-defined,no-any-return]
 
-def inject_attribute_chain(
-    node: ast.expr,
-    symbol_map: symbol_scope.SymbolScope,
-    nodes: union_types.Recipes,
-) -> edge_models.SourceHandle:
-    """Add one ``std.getattr_`` node (plus its name constant) per link of *node*.
+    def label_base(self, link: ast.expr) -> str:
+        return f"getattr_{_link(link).attr}"
 
-    Walks the chain root-outward so that node insertion order -- and therefore
-    labels and the enclosing scope's input ordering -- are a deterministic
-    function of the source. Returns the handle of the outermost link's ``attr``
-    output.
+    def port_base(self, link: ast.expr) -> str:
+        return _link(link).attr
 
-    *node* must be a data attribute chain (see :func:`is_data_attribute`); callers
-    are expected to gate on that before calling.
-    """
-    # Port names are derived from the recipe, never spelled out: editing `std.getattr_`
-    # must not require editing strings anywhere else in the source.
-    from flowrep import std
-
-    _GETATTR = std.get_attr.flowrep_recipe  # type: ignore[attr-defined]
-    _OBJ_PORT, _NAME_PORT = _GETATTR.inputs
-    (_ATTR_PORT,) = _GETATTR.outputs
-
-    links: list[ast.Attribute] = []
-    current: ast.expr = node
-    while isinstance(current, ast.Attribute):
-        links.append(current)
-        current = current.value
-    links.reverse()
-
-    root = chain_root(node)
-    if root is None:  # pragma: no cover - callers gate on is_data_attribute
-        raise TypeError(f"Not an attribute chain rooted at a symbol: {ast.dump(node)}")
-    if root.id in symbol_map.all_accumulators:
-        raise ValueError(
-            f"Cannot take an attribute of accumulator '{root.id}'. Accumulators are "
-            f"name-tracked list declarations, not graph data; append to it and take "
-            f"attributes of the resulting collection outside the loop instead."
+    def feed_key(
+        self,
+        link: ast.expr,
+        symbol_map: symbol_scope.SymbolScope,
+        nodes: union_types.Recipes,
+        label: str,
+        port: str,
+    ) -> None:
+        constant_parser.inject_constant(
+            nodes, symbol_map, _link(link).attr, label, port
         )
 
-    handle: edge_models.SourceHandle | None = None
-    for link in links:
-        label = label_helpers.unique_suffix(f"getattr_{link.attr}", nodes)
-        nodes[label] = std.get_attr.flowrep_recipe  # type: ignore[attr-defined]
-        if handle is None:
-            symbol_map.consume(root.id, label, _OBJ_PORT)
-        else:
-            symbol_map.consume_source(handle, label, _OBJ_PORT)
-        constant_parser.inject_constant(nodes, symbol_map, link.attr, label, _NAME_PORT)
-        handle = edge_models.SourceHandle(node=label, port=_ATTR_PORT)
-    assert handle is not None  # links is non-empty: node is an ast.Attribute
-    return handle
 
-
-def hoist_call_arguments(
-    call: ast.Call,
-    symbol_map: symbol_scope.SymbolScope,
-    nodes: union_types.Recipes,
-) -> dict[ast.expr, edge_models.SourceHandle]:
-    """Inject every data-attribute argument of *call* before the call's own node.
-
-    Hoisting is what makes ``f(x0, comp.val)`` and ``v = comp.val; f(x0, v)`` parse
-    to identical recipes: the getattr nodes are created (and their sources consumed)
-    ahead of the call in both forms.
-    """
-    hoisted: dict[ast.expr, edge_models.SourceHandle] = {}
-    arguments = list(call.args) + [kw.value for kw in call.keywords]
-    for argument in arguments:
-        if is_data_attribute(argument, symbol_map):
-            hoisted[argument] = inject_attribute_chain(argument, symbol_map, nodes)
-    return hoisted
-
-
-def generate_port_name(node: ast.expr, taken: Iterable[str]) -> str:
-    """A deterministic port name for an attribute chain that has no symbol.
-
-    Takes the outermost attribute name -- what the author would have called the
-    binding, and what the compiler will literally emit as the binding symbol -- and
-    unique-suffixes it against *taken*. ``x.a.val`` gives ``val_0``.
-
-    *taken* must include every symbol in the enclosing scope, not merely the ports
-    allocated so far: a flow-control node's inputs are its condition's inputs *plus
-    its body's*, and a body input port is always an enclosing symbol.
-    """
-    if not isinstance(node, ast.Attribute):  # pragma: no cover - callers gate on
-        # is_data_attribute, which implies ast.Attribute
-        raise TypeError(f"Not an attribute chain: {ast.dump(node)}")
-    return label_helpers.unique_suffix(node.attr, taken)
-
-
-def reject_unbound_attribute(
-    node: ast.expr, symbol_map: symbol_scope.SymbolScope, context: str
-) -> None:
-    """Raise if *node* is an attribute chain used where the port name is public IO.
-
-    A workflow's output ports are its interface. Flowrep names them after the returned
-    symbol, and an attribute chain has no symbol -- so the port would carry a generated
-    name that a consumer cannot read off the source. Everywhere else in a workflow a
-    generated name is fine (the port is internal wiring); here it is not, so we ask for
-    the binding.
-    """
-    if not is_data_attribute(node, symbol_map):
-        return
-    chain = ast.unparse(node)
-    raise ValueError(
-        f"Attribute access must be bound to a symbol before it can be {context}: "
-        f"got {chain!r}. The port name is taken from the symbol, and {chain!r} has "
-        f"no symbol to take it from. Bind it first -- e.g. `my_value = {chain}` -- "
-        f"and use `my_value` instead."
-    )
-
-
-def reject_method_call(call: ast.Call, symbol_map: symbol_scope.SymbolScope) -> None:
-    """Raise if *call* invokes an attribute of a known symbol (``dc.method(x)``)."""
-    if is_data_attribute(call.func, symbol_map):
-        chain = ast.unparse(call.func)
-        raise ValueError(
-            f"Workflow python definitions cannot call methods on workflow data: "
-            f"'{chain}(...)'. Bind the attribute to a symbol and call it via a "
-            f"node, or wrap the method call in an @atomic function."
-        )
+HANDLER = AttributeHandler()

--- a/src/flowrep/parsers/case_helpers.py
+++ b/src/flowrep/parsers/case_helpers.py
@@ -8,7 +8,7 @@ from pyiron_snippets import versions
 from flowrep import edge_models, subgraph_validation
 from flowrep.parsers import (
     atomic_parser,
-    attribute_parser,
+    chain_parser,
     object_scope,
     parser_helpers,
     parser_protocol,
@@ -40,7 +40,7 @@ def parse_case(
         raise ValueError(
             "Test conditions must be a function call, but got " f"{type(test).__name__}"
         )
-    attribute_parser.reject_method_call(test, symbol_map)
+    chain_parser.reject_method_call(test, symbol_map)
 
     condition = atomic_parser.get_labeled_recipe(test, set(), scope, info_factory)
     if len(condition.recipe.outputs) != 1:
@@ -52,7 +52,7 @@ def parse_case(
     # A flow-control recipe has no room to host a peer, so an attribute argument
     # becomes a getattr peer of the flow-control node in the *enclosing* scope, and
     # reaches the condition through a generated input port.
-    hoisted = attribute_parser.hoist_call_arguments(test, symbol_map, nodes)
+    hoisted = chain_parser.hoist_call_arguments(test, symbol_map, nodes)
 
     scope_copy = symbol_map.fork()
     condition_bindings: parser_helpers.FlowControlBindings = {}

--- a/src/flowrep/parsers/chain_parser.py
+++ b/src/flowrep/parsers/chain_parser.py
@@ -1,0 +1,254 @@
+"""Parse data-access chains on workflow data into injected ``std`` nodes.
+
+A chain rooted at a known *symbol* -- ``dc.a``, ``d[k]``, ``dc.sub["item"].val`` --
+becomes one node per link: ``std.get_attr`` for an attribute link, ``std.getitem`` for
+an item link. The symbol map deliberately shadows the object scope, so a workflow input
+named ``os`` makes ``os.path`` an attribute access on that input, exactly as it would be
+at runtime.
+
+``chain_parser`` owns the walk; a :class:`LinkHandler` owns only what differs between
+the two access syntaxes Python has. That set is closed, so the dispatch is total.
+
+Data access is allowed anywhere a value is, with one exception: the workflow's
+``return``. The rule is
+
+    a port name may be *generated* when the port is internal to the recipe; it must
+    come from a *symbol* only when the port is public IO.
+
+Ports get their names from four places:
+
+===============================  ==========================================
+Port                             Name comes from
+===============================  ==========================================
+Workflow output port             the returned symbol
+Flow-control input port          the enclosing symbol feeding it, or -- for a
+                                 constant or an access chain, which have no
+                                 symbol -- a generated name (see
+                                 :func:`generate_port_name`)
+For-body output port             the appended symbol, or a generated name
+Atomic/workflow node input port  the *callee's* own parameter
+===============================  ==========================================
+
+Only the first is public IO. A workflow's output ports are its interface, and a
+consumer wiring into them should be able to read their names straight off the source,
+so ``return dc.a`` is refused (see :func:`reject_unbound_access`). Everywhere else the
+port is internal wiring, and a generated name costs the reader nothing: the compiler
+emits ``val_0 = x.val`` and re-parsing regenerates exactly that port, so the sugared
+form and the bound form are not merely equivalent recipes -- they are the same recipe.
+
+(``@atomic`` stays laxer about its own returns. That asymmetry is deliberate: atomic
+parsing must swallow arbitrary Python functions, including ones the caller did not
+write, whereas a ``@workflow`` author controls their own source.)
+
+Two things a generated name cannot rescue, both refused elsewhere: a method call on
+workflow data (``dc.method(x)``), which needs a callable reference rather than a port
+name, and a chain in a ``while`` condition that depends on a symbol the loop body
+reassigns (see :func:`while_parser._reject_looped_chain_symbols`), where hoisting the
+access out of the loop would silently diverge from Python's per-iteration re-read.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable
+from typing import Protocol
+
+from flowrep import edge_models
+from flowrep.parsers import attribute_parser, item_parser, label_helpers, symbol_scope
+from flowrep.prospective import atomic_recipe, union_types
+
+
+class LinkHandler(Protocol):
+    """How one kind of chain link (``.attr`` or ``[key]``) becomes a node."""
+
+    @property
+    def recipe(self) -> atomic_recipe.AtomicRecipe:
+        """The std recipe injected per link. Two inputs (obj, key), one output."""
+        ...
+
+    def label_base(self, link: ast.expr) -> str:
+        """The node label prefix, before :func:`label_helpers.unique_suffix`."""
+        ...
+
+    def port_base(self, link: ast.expr) -> str:
+        """The generated port name base, before :func:`label_helpers.unique_suffix`."""
+        ...
+
+    def feed_key(
+        self,
+        link: ast.expr,
+        symbol_map: symbol_scope.SymbolScope,
+        nodes: union_types.Recipes,
+        label: str,
+        port: str,
+    ) -> None:
+        """Wire this link's second input: the attribute name, or the item key."""
+        ...
+
+
+_HANDLERS: dict[type[ast.expr], LinkHandler] = {
+    ast.Attribute: attribute_parser.HANDLER,
+    ast.Subscript: item_parser.HANDLER,
+}
+
+
+def _handler_for(link: ast.expr) -> LinkHandler:
+    try:
+        return _HANDLERS[type(link)]
+    except KeyError:  # pragma: no cover - callers gate on is_data_access
+        raise TypeError(f"Not a data-access link: {ast.dump(link)}") from None
+
+
+def chain_root(node: ast.expr) -> ast.Name | None:
+    """The innermost ``ast.Name`` of a pure access chain, else ``None``."""
+    while isinstance(node, ast.Attribute | ast.Subscript):
+        node = node.value
+    return node if isinstance(node, ast.Name) else None
+
+
+def _chain_links(node: ast.expr) -> list[ast.expr]:
+    """The chain's links, ordered root-outward."""
+    links: list[ast.expr] = []
+    current: ast.expr = node
+    while isinstance(current, ast.Attribute | ast.Subscript):
+        links.append(current)
+        current = current.value
+    links.reverse()
+    return links
+
+
+def is_data_access(node: ast.expr, symbol_map: symbol_scope.SymbolScope) -> bool:
+    """True if *node* is attribute or item access rooted at a symbol known to the graph.
+
+    The symbol map deliberately shadows the object scope: a workflow input named
+    ``os`` makes ``os.path`` a data attribute access on that input, not a module
+    lookup, exactly as it would be at runtime.
+    """
+    if not isinstance(node, ast.Attribute | ast.Subscript):
+        return False
+    root = chain_root(node)
+    return root is not None and root.id in symbol_map
+
+
+def inject_chain(
+    node: ast.expr,
+    symbol_map: symbol_scope.SymbolScope,
+    nodes: union_types.Recipes,
+) -> edge_models.SourceHandle:
+    """Add one node (plus any constant peer) per link of *node*.
+
+    Walks the chain root-outward so that node insertion order -- and therefore
+    labels and the enclosing scope's input ordering -- are a deterministic
+    function of the source. Returns the handle of the outermost link's output.
+
+    *node* must be a data access chain (see :func:`is_data_access`); callers are
+    expected to gate on that before calling.
+    """
+    root = chain_root(node)
+    if root is None:  # pragma: no cover - callers gate on is_data_access
+        raise TypeError(f"Not an access chain rooted at a symbol: {ast.dump(node)}")
+    if root.id in symbol_map.all_accumulators:
+        raise ValueError(
+            f"Cannot take an attribute or item of accumulator '{root.id}'. "
+            f"Accumulators are name-tracked list declarations, not graph data; append "
+            f"to it and take attributes of the resulting collection outside the loop "
+            f"instead."
+        )
+
+    handle: edge_models.SourceHandle | None = None
+    for link in _chain_links(node):
+        handler = _handler_for(link)
+        recipe = handler.recipe
+        obj_port, key_port = recipe.inputs
+        (out_port,) = recipe.outputs
+        label = label_helpers.unique_suffix(handler.label_base(link), nodes)
+        nodes[label] = recipe
+        if handle is None:
+            symbol_map.consume(root.id, label, obj_port)
+        else:
+            symbol_map.consume_source(handle, label, obj_port)
+        handler.feed_key(link, symbol_map, nodes, label, key_port)
+        handle = edge_models.SourceHandle(node=label, port=out_port)
+    assert handle is not None  # links is non-empty: node is a link node
+    return handle
+
+
+def hoist_call_arguments(
+    call: ast.Call,
+    symbol_map: symbol_scope.SymbolScope,
+    nodes: union_types.Recipes,
+) -> dict[ast.expr, edge_models.SourceHandle]:
+    """Inject every data-access argument of *call* before the call's own node.
+
+    Hoisting is what makes ``f(x0, comp.val)`` and ``v = comp.val; f(x0, v)`` parse
+    to identical recipes: the injected nodes are created (and their sources consumed)
+    ahead of the call in both forms.
+    """
+    hoisted: dict[ast.expr, edge_models.SourceHandle] = {}
+    arguments = list(call.args) + [kw.value for kw in call.keywords]
+    for argument in arguments:
+        if is_data_access(argument, symbol_map):
+            hoisted[argument] = inject_chain(argument, symbol_map, nodes)
+    return hoisted
+
+
+def generate_port_name(node: ast.expr, taken: Iterable[str]) -> str:
+    """A deterministic port name for an access chain that has no symbol.
+
+    Takes the outermost link's base -- for an attribute, the attribute name; for an
+    item, the ``std.getitem`` output port -- and unique-suffixes it against *taken*.
+    ``x.a.val`` gives ``val_0``; ``x["a"]`` gives ``item_0``.
+
+    *taken* must include every symbol in the enclosing scope, not merely the ports
+    allocated so far: a flow-control node's inputs are its condition's inputs *plus
+    its body's*, and a body input port is always an enclosing symbol.
+    """
+    return label_helpers.unique_suffix(_handler_for(node).port_base(node), taken)
+
+
+def reject_unbound_access(
+    node: ast.expr, symbol_map: symbol_scope.SymbolScope, context: str
+) -> None:
+    """Raise if *node* is an access chain used where the port name is public IO.
+
+    A workflow's output ports are its interface. Flowrep names them after the returned
+    symbol, and an access chain has no symbol -- so the port would carry a generated
+    name that a consumer cannot read off the source. Everywhere else in a workflow a
+    generated name is fine (the port is internal wiring); here it is not, so we ask for
+    the binding.
+    """
+    if not is_data_access(node, symbol_map):
+        return
+    chain = ast.unparse(node)
+    raise ValueError(
+        f"Attribute or item access must be bound to a symbol before it can be "
+        f"{context}: got {chain!r}. The port name is taken from the symbol, and "
+        f"{chain!r} has no symbol to take it from. Bind it first -- e.g. "
+        f"`my_value = {chain}` -- and use `my_value` instead."
+    )
+
+
+def dependency_symbols(node: ast.expr) -> set[str]:
+    """Every symbol an access chain reads: its root, plus any symbol used as an item key.
+
+    An attribute name is a constant, but an item key can be a symbol, so ``d[k]``
+    depends on both ``d`` and ``k``. The ``while`` guard needs the distinction: a chain
+    that depends on a symbol the loop body reassigns cannot be hoisted faithfully.
+    """
+    root = chain_root(node)
+    symbols = set() if root is None else {root.id}
+    for link in _chain_links(node):
+        if isinstance(link, ast.Subscript) and isinstance(link.slice, ast.Name):
+            symbols.add(link.slice.id)
+    return symbols
+
+
+def reject_method_call(call: ast.Call, symbol_map: symbol_scope.SymbolScope) -> None:
+    """Raise if *call* invokes an attribute or item of a known symbol."""
+    if is_data_access(call.func, symbol_map):
+        chain = ast.unparse(call.func)
+        raise ValueError(
+            f"Workflow python definitions cannot call methods on workflow data: "
+            f"'{chain}(...)'. Bind the attribute or item to a symbol and call it via "
+            f"a node, or wrap the method call in an @atomic function."
+        )

--- a/src/flowrep/parsers/for_parser.py
+++ b/src/flowrep/parsers/for_parser.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 from flowrep import edge_models
 from flowrep.parsers import (
-    attribute_parser,
+    chain_parser,
     parser_helpers,
     parser_protocol,
     symbol_scope,
@@ -207,20 +207,20 @@ def _resolve_collection(
 
     A for recipe has no room to host a peer, so an attribute chain becomes a getattr
     peer of the for node in the enclosing scope and reaches it through a generated
-    port. See :func:`attribute_parser.generate_port_name` for the naming rule.
+    port. See :func:`chain_parser.generate_port_name` for the naming rule.
     """
     if isinstance(iter_expr, ast.Name):
         return iter_expr.id, None
-    if attribute_parser.is_data_attribute(iter_expr, symbol_map):
-        handle = attribute_parser.inject_attribute_chain(iter_expr, symbol_map, nodes)
-        port = attribute_parser.generate_port_name(
+    if chain_parser.is_data_access(iter_expr, symbol_map):
+        handle = chain_parser.inject_chain(iter_expr, symbol_map, nodes)
+        port = chain_parser.generate_port_name(
             iter_expr, symbol_map.unavailable_names | reserved_ports
         )
         reserved_ports.add(port)
         return port, handle
     raise ValueError(
-        f"For iteration must iterate over a symbol, or an attribute of one, but got "
-        f"'{ast.unparse(iter_expr)}'."
+        f"For iteration must iterate over a symbol, or an attribute or item of one, "
+        f"but got '{ast.unparse(iter_expr)}'."
     )
 
 

--- a/src/flowrep/parsers/item_parser.py
+++ b/src/flowrep/parsers/item_parser.py
@@ -1,0 +1,77 @@
+"""The ``[key]`` link of a data-access chain (see :mod:`chain_parser`).
+
+``d[k]`` becomes one ``std.getitem`` node. Its key comes from a symbol (``d[i]``) or a
+``ConstantRecipe`` peer (``d[0]``, ``d["mass"]``).
+
+The label base is read off the recipe rather than spelled out, so an injected node
+carries exactly the label -- and its constant peer exactly the numbering -- that parsing
+``std.getitem(d, k)`` would produce. That makes ``d[k]`` and ``std.getitem(d, k)`` the
+*same recipe*, which is why item access round-trips through the compiler with no
+desugaring: the compiler emits the call form, and re-parsing it lands back here.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from flowrep.parsers import constant_parser, symbol_scope
+from flowrep.prospective import atomic_recipe, union_types
+
+
+def _link(node: ast.expr) -> ast.Subscript:
+    """Narrow a dispatched link; ``chain_parser`` only routes Subscripts here."""
+    assert isinstance(node, ast.Subscript)
+    return node
+
+
+class ItemHandler:
+    """One ``std.getitem`` node per ``[key]`` link, plus any key constant."""
+
+    @property
+    def recipe(self) -> atomic_recipe.AtomicRecipe:
+        # Imported lazily: `flowrep.std` imports the parsers, so a module-level
+        # import here would cycle.
+        from flowrep import std
+
+        return std.getitem.flowrep_recipe  # type: ignore[attr-defined,no-any-return]
+
+    def label_base(self, link: ast.expr) -> str:
+        # The callee's own name, exactly as `atomic_parser` labels `std.getitem(d, k)`.
+        return self.recipe.reference.info.qualname.rsplit(".", 1)[-1]
+
+    def port_base(self, link: ast.expr) -> str:
+        (item_port,) = self.recipe.outputs
+        return item_port
+
+    def feed_key(
+        self,
+        link: ast.expr,
+        symbol_map: symbol_scope.SymbolScope,
+        nodes: union_types.Recipes,
+        label: str,
+        port: str,
+    ) -> None:
+        key = _link(link).slice
+        if isinstance(key, ast.Slice):
+            raise ValueError(
+                f"Workflow python definitions cannot parse slices yet: "
+                f"'{ast.unparse(link)}'. A slice needs a `std.slice` node to carry its "
+                f"start/stop/step, and that node does not exist yet. Index and key "
+                f"access -- `d[0]`, `d['mass']`, `d[k]` -- are supported. In the "
+                f"meantime, you could make a slice node for your application."
+            )
+        if isinstance(key, ast.Name):
+            symbol_map.consume(key.id, label, port)
+            return
+        is_literal, value = constant_parser.try_parse_constant(key)
+        if not is_literal:
+            raise ValueError(
+                f"An item key must be a symbol or a literal constant, but "
+                f"'{ast.unparse(link)}' keys on {type(key).__name__}. Bind the key to "
+                f"a symbol first -- e.g. `k = {ast.unparse(key)}` -- and then "
+                f"`{ast.unparse(_link(link).value)}[k]`."
+            )
+        constant_parser.inject_constant(nodes, symbol_map, value, label, port)
+
+
+HANDLER = ItemHandler()

--- a/src/flowrep/parsers/parser_helpers.py
+++ b/src/flowrep/parsers/parser_helpers.py
@@ -10,7 +10,7 @@ from typing import Any, TypeAlias, TypeVar, cast
 
 from flowrep import base_models, edge_models
 from flowrep.parsers import (
-    attribute_parser,
+    chain_parser,
     constant_parser,
     label_helpers,
     symbol_scope,
@@ -193,7 +193,7 @@ def consume_call_arguments(
     multiple literals -- across an if/elif chain -- get distinct, deterministic ports.
 
     Data-attribute arguments are injected ahead of the call by
-    ``attribute_parser.hoist_call_arguments`` and arrive here in *hoisted*, mapping the
+    ``chain_parser.hoist_call_arguments`` and arrive here in *hoisted*, mapping the
     argument's AST node to the ``SourceHandle`` of its outermost getattr node. Outside
     condition mode the consuming node is a peer of that getattr and simply reads from
     it. In condition mode the consumer lives *inside* a flow-control recipe, which has
@@ -296,10 +296,10 @@ def _bind_condition_source(
     The getattr peer already sits in the enclosing walker's ``nodes`` -- the
     flow-control node just needs a port to receive it through. The ``SourceHandle``
     twin of :func:`_bind_condition_constant`; see
-    :func:`attribute_parser.generate_port_name` for why the name is deduped against
+    :func:`chain_parser.generate_port_name` for why the name is deduped against
     every enclosing symbol.
     """
-    generated = attribute_parser.generate_port_name(
+    generated = chain_parser.generate_port_name(
         arg_node, scope.unavailable_names | reserved_ports
     )
     reserved_ports.add(generated)

--- a/src/flowrep/parsers/while_parser.py
+++ b/src/flowrep/parsers/while_parser.py
@@ -5,8 +5,8 @@ from ast import While
 
 from flowrep import edge_models
 from flowrep.parsers import (
-    attribute_parser,
     case_helpers,
+    chain_parser,
     parser_helpers,
     parser_protocol,
     symbol_scope,
@@ -47,7 +47,7 @@ def parse_while_node(
     reassigned_symbols = body_walker.symbol_map.reassigned_symbols
 
     _validate_some_output_exists(reassigned_symbols)
-    _reject_looped_attribute_roots(tree.test, walker.symbol_map, reassigned_symbols)
+    _reject_looped_chain_symbols(tree.test, walker.symbol_map, reassigned_symbols)
     parser_helpers.reject_input_alias_outputs(
         body_walker.symbol_map, reassigned_symbols, "while-loop"
     )
@@ -92,24 +92,29 @@ def _validate_some_output_exists(reassigned_symbols: list[str]):
         )
 
 
-def _reject_looped_attribute_roots(
+def _reject_looped_chain_symbols(
     test: ast.expr,
     symbol_map: symbol_scope.SymbolScope,
     reassigned_symbols: list[str],
 ) -> None:
-    """Raise if a condition attribute chain is rooted at a symbol the body reassigns.
+    """Raise if a condition chain depends on a symbol the body reassigns.
 
     Python re-evaluates a while condition every iteration, so ``x.val`` is re-read
-    against the *updated* ``x``. A flowrep condition is a single call fed by hoisted
-    inputs: its getattr peer sits outside the loop, is never re-read, and is not a
-    while output, so it never feeds back. Rather than silently diverge from Python we
-    refuse. An attribute on a symbol the loop does not touch hoists faithfully and is
-    allowed -- which is why the guard is on the *root*, not on attribute access.
+    against the *updated* ``x`` -- and ``d[k]`` against the updated ``k``. A flowrep
+    condition is a single call fed by hoisted inputs: its injected nodes sit outside the
+    loop, are never re-read, and are not while outputs, so they never feed back. Rather
+    than silently diverge from Python we refuse. A chain whose symbols the loop does not
+    touch hoists faithfully and is allowed -- which is why the guard is on the chain's
+    *dependencies*, not on data access itself.
+
+    An attribute name is a constant, so an attribute chain can only depend on its root;
+    an item key can be a symbol, so ``d[k]`` is caught by a body that reassigns ``k``
+    even though ``d`` is untouched.
 
     Runs after the body walk, because ``reassigned_symbols`` is the parser's ground
     truth (it includes symbols reassigned by nested flow control, not just bare
-    assignments). By then the getattr peers have already been injected into the
-    enclosing scope; that is harmless, since the exception aborts the whole parse.
+    assignments). By then the injected peers are already in the enclosing scope; that is
+    harmless, since the exception aborts the whole parse.
     """
     if not isinstance(
         test, ast.Call
@@ -118,19 +123,19 @@ def _reject_looped_attribute_roots(
     looped = set(reassigned_symbols)
     arguments = list(test.args) + [kw.value for kw in test.keywords]
     for argument in arguments:
-        if not attribute_parser.is_data_attribute(argument, symbol_map):
+        if not chain_parser.is_data_access(argument, symbol_map):
             continue
-        root = attribute_parser.chain_root(argument)
-        if root is not None and root.id in looped:
+        offenders = sorted(chain_parser.dependency_symbols(argument) & looped)
+        if offenders:
             chain = ast.unparse(argument)
+            named = ", ".join(repr(s) for s in offenders)
             raise ValueError(
-                f"While-condition attribute access {chain!r} is rooted at "
-                f"{root.id!r}, which the loop body reassigns. Python would re-read "
-                f"{chain!r} every iteration, but a flowrep while-condition is a "
-                f"single call fed by hoisted inputs -- there is no place inside the "
-                f"loop for the attribute access. Either bind it outside the loop "
-                f"(e.g. `v = {chain}`) if you meant to read it once, or move the "
-                f"attribute access into the condition function itself."
+                f"While-condition data access {chain!r} depends on {named}, which the "
+                f"loop body reassigns. Python would re-read {chain!r} every iteration, "
+                f"but a flowrep while-condition is a single call fed by hoisted inputs "
+                f"-- there is no place inside the loop for the access. Either bind it "
+                f"outside the loop (e.g. `v = {chain}`) if you meant to read it once, "
+                f"or move the access into the condition function itself."
             )
 
 

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -12,7 +12,7 @@ from pyiron_snippets import versions
 from flowrep import base_models, edge_models
 from flowrep.parsers import (
     atomic_parser,
-    attribute_parser,
+    chain_parser,
     constant_parser,
     for_parser,
     if_parser,
@@ -272,8 +272,8 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
 
         rhs = body.value
         if isinstance(rhs, ast.Call):
-            attribute_parser.reject_method_call(rhs, self.symbol_map)
-            hoisted = attribute_parser.hoist_call_arguments(
+            chain_parser.reject_method_call(rhs, self.symbol_map)
+            hoisted = chain_parser.hoist_call_arguments(
                 rhs, self.symbol_map, self.nodes
             )
             child = atomic_parser.get_labeled_recipe(
@@ -294,17 +294,13 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
                     f"got {new_symbols}"
                 )
             self.symbol_map.register_accumulator(new_symbols[0])
-        elif rhs is not None and attribute_parser.is_data_attribute(
-            rhs, self.symbol_map
-        ):
+        elif rhs is not None and chain_parser.is_data_access(rhs, self.symbol_map):
             if len(new_symbols) != 1:
                 raise ValueError(
-                    f"Attribute-access assignment must target exactly one symbol, "
+                    f"Attribute/item access assignment must target exactly one symbol, "
                     f"got {new_symbols}"
                 )
-            handle = attribute_parser.inject_attribute_chain(
-                rhs, self.symbol_map, self.nodes
-            )
+            handle = chain_parser.inject_chain(rhs, self.symbol_map, self.nodes)
             self.symbol_map.register(
                 new_symbols,
                 helper_models.LabeledRecipe(
@@ -327,7 +323,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         else:
             raise ValueError(
                 f"Workflow python definitions can only interpret assignments with "
-                f"a call, empty list, symbol alias, or attribute "
+                f"a call, empty list, symbol alias, or attribute/item "
                 f"access rooted at a known workflow symbol on the right-hand-side, "
                 f"but ast found {type(rhs)}"
             )
@@ -439,13 +435,13 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
             ast.Name, cast(ast.Attribute, append_call.func).value
         ).id
         appended = append_call.args[0]
-        if attribute_parser.is_data_attribute(appended, self.symbol_map):
-            self._append_attribute(used_accumulator, appended)
+        if chain_parser.is_data_access(appended, self.symbol_map):
+            self._append_chain(used_accumulator, appended)
             return
         if not isinstance(appended, ast.Name):
             raise TypeError(
                 f"Workflow python definitions can only append a symbol, or an "
-                f"attribute of one, to an accumulator, but "
+                f"attribute or item of one, to an accumulator, but "
                 f"'{used_accumulator}.append(...)' got {type(appended).__name__}. "
                 f"Bind the value to a symbol first."
             )
@@ -455,7 +451,7 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         if isinstance(appended_source, edge_models.SourceHandle):
             self.symbol_map.produce(appended_symbol)
 
-    def _append_attribute(self, used_accumulator: str, appended: ast.expr) -> None:
+    def _append_chain(self, used_accumulator: str, appended: ast.expr) -> None:
         """Append an attribute chain, giving its output port a generated name.
 
         The getattr nodes go *inside* this body -- an ordinary workflow, which has room
@@ -463,10 +459,8 @@ class WorkflowParser(ast.NodeVisitor, parser_protocol.BodyWalker):
         would in Python. Only the port name is invented, and it is deduped against every
         symbol in scope and every port already produced, so it cannot collide.
         """
-        handle = attribute_parser.inject_attribute_chain(
-            appended, self.symbol_map, self.nodes
-        )
-        port = attribute_parser.generate_port_name(
+        handle = chain_parser.inject_chain(appended, self.symbol_map, self.nodes)
+        port = chain_parser.generate_port_name(
             appended, self.symbol_map.unavailable_names
         )
         self.symbol_map.use_accumulator(used_accumulator, port)
@@ -525,7 +519,7 @@ class _WorkflowFunctionParser(WorkflowParser):
                 body.value.elts if isinstance(body.value, ast.Tuple) else [body.value]
             )
             for element in elements:
-                attribute_parser.reject_unbound_attribute(
+                chain_parser.reject_unbound_access(
                     element, self.symbol_map, "returned from a workflow"
                 )
 

--- a/tests/flowrep_static/library.py
+++ b/tests/flowrep_static/library.py
@@ -165,6 +165,31 @@ def val(x):
     return x
 
 
+class CustomKey:
+    """A hashable non-string key.
+
+    Deliberately not a string: a ``dict[CustomKey, int]`` cannot degrade into
+    string-keyed or attribute access, so a test keyed on one is really exercising the
+    item-access path.
+    """
+
+    def __init__(self, name: str = "k"):
+        self.name = name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, CustomKey) and self.name == other.name
+
+
+class Nested:
+    """A holder for mixed attribute/item chains: ``holder.sub["item"]["subitem"].val``."""
+
+    def __init__(self, sub: dict | None = None):
+        self.sub = {"item": {"subitem": ComplexData(val=7)}} if sub is None else sub
+
+
 # test_parsing_atomic_classes -- inverse recipe
 
 

--- a/tests/integration/parsers/test_parsing_item_access.py
+++ b/tests/integration/parsers/test_parsing_item_access.py
@@ -1,0 +1,466 @@
+import unittest
+
+from flowrep import edge_models, std, wfms
+from flowrep.compiler import source
+from flowrep.parsers import workflow_parser
+
+from flowrep_static import library, makers
+
+
+@workflow_parser.workflow
+def item_symbol_key(
+    input_dict: dict[library.CustomKey, int], input_obj: library.CustomKey
+):
+    d = std.identity(input_dict)
+    i = std.identity(input_obj)
+    accessed = d[i]
+    return accessed
+
+
+@workflow_parser.workflow
+def item_symbol_key_std_form(
+    input_dict: dict[library.CustomKey, int], input_obj: library.CustomKey
+):
+    """The explicit call the sugar must be indistinguishable from."""
+    d = std.identity(input_dict)
+    i = std.identity(input_obj)
+    accessed = std.getitem(d, i)
+    return accessed
+
+
+class TestComplexKeyFromAnotherStep(unittest.TestCase):
+    def test_parses_expected_graph(self):
+        recipe = item_symbol_key.flowrep_recipe
+        self.assertEqual(set(recipe.nodes), {"identity_0", "identity_1", "getitem_0"})
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node="getitem_0", port="a")],
+            edge_models.SourceHandle(node="identity_0", port="x"),
+        )
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node="getitem_0", port="b")],
+            edge_models.SourceHandle(node="identity_1", port="x"),
+        )
+
+    def test_identical_to_the_std_call_form(self):
+        """The headline invariant: `d[i]` is not merely equivalent to
+        `std.getitem(d, i)` -- it is the same recipe. That identity is what lets the
+        compiler round-trip item access without knowing item access exists."""
+        self.assertEqual(
+            makers.dump_no_refs(makers.reference_free(item_symbol_key)),
+            makers.dump_no_refs(makers.reference_free(item_symbol_key_std_form)),
+        )
+
+    def test_executes_via_run_recipe(self):
+        key = library.CustomKey("a")
+        data = {key: 7}
+        result = wfms.run_recipe(
+            item_symbol_key.flowrep_recipe, input_dict=data, input_obj=key
+        )
+        self.assertEqual(result.output_ports["accessed"].value, 7)
+        self.assertEqual(item_symbol_key(data, key), 7)
+
+    def test_round_trips_through_source(self):
+        free = makers.reference_free(item_symbol_key)
+        rendered = source._workflow2python(free)
+        fn = rendered.build()
+        key = library.CustomKey("a")
+        self.assertEqual(fn({key: 7}, key), item_symbol_key({key: 7}, key))
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+@workflow_parser.workflow
+def item_from_inputs(
+    input_dict: dict[library.CustomKey, int], input_obj: library.CustomKey
+):
+    accessed = input_dict[input_obj]
+    return accessed
+
+
+class TestComplexKeyFromParentInput(unittest.TestCase):
+    def test_both_ports_are_input_edges(self):
+        recipe = item_from_inputs.flowrep_recipe
+        self.assertEqual(set(recipe.nodes), {"getitem_0"})
+        self.assertEqual(
+            recipe.input_edges[edge_models.TargetHandle(node="getitem_0", port="a")],
+            edge_models.InputSource(port="input_dict"),
+        )
+        self.assertEqual(
+            recipe.input_edges[edge_models.TargetHandle(node="getitem_0", port="b")],
+            edge_models.InputSource(port="input_obj"),
+        )
+
+    def test_executes_via_run_recipe(self):
+        key = library.CustomKey("a")
+        result = wfms.run_recipe(
+            item_from_inputs.flowrep_recipe, input_dict={key: 7}, input_obj=key
+        )
+        self.assertEqual(result.output_ports["accessed"].value, 7)
+
+    def test_round_trips_through_source(self):
+        free = makers.reference_free(item_from_inputs)
+        rendered = source._workflow2python(free)
+        fn = rendered.build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+@workflow_parser.workflow
+def item_constant_keys(xs: list, d: dict):
+    first = xs[0]
+    named = d["mass"]
+    total = std.add(first, named)
+    return total
+
+
+class TestConstantKeys(unittest.TestCase):
+    def test_each_key_gets_a_constant_peer(self):
+        recipe = item_constant_keys.flowrep_recipe
+        self.assertEqual(
+            list(recipe.nodes),
+            ["getitem_0", "constant_0", "getitem_1", "constant_1", "add_0"],
+        )
+        self.assertEqual(recipe.nodes["constant_0"].constant, 0)
+        self.assertEqual(recipe.nodes["constant_1"].constant, "mass")
+
+    def test_executes_via_run_recipe(self):
+        result = wfms.run_recipe(
+            item_constant_keys.flowrep_recipe, xs=[1, 2], d={"mass": 10}
+        )
+        self.assertEqual(result.output_ports["total"].value, 11)
+        self.assertEqual(item_constant_keys([1, 2], {"mass": 10}), 11)
+
+    def test_round_trips_through_source(self):
+        free = makers.reference_free(item_constant_keys)
+        rendered = source._workflow2python(free)
+        fn = rendered.build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+@workflow_parser.workflow
+def mixed_chain(holder: library.Nested):
+    value = holder.sub["item"]["subitem"].val
+    return value
+
+
+class TestMixedChain(unittest.TestCase):
+    def test_one_node_per_link_root_outward(self):
+        recipe = mixed_chain.flowrep_recipe
+        self.assertEqual(
+            list(recipe.nodes),
+            [
+                "getattr_sub_0",
+                "constant_0",
+                "getitem_0",
+                "constant_1",
+                "getitem_1",
+                "constant_2",
+                "getattr_val_0",
+                "constant_3",
+            ],
+        )
+
+    def test_links_are_chained_in_order(self):
+        recipe = mixed_chain.flowrep_recipe
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node="getitem_0", port="a")],
+            edge_models.SourceHandle(node="getattr_sub_0", port="attr"),
+        )
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node="getitem_1", port="a")],
+            edge_models.SourceHandle(node="getitem_0", port="item"),
+        )
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node="getattr_val_0", port="obj")],
+            edge_models.SourceHandle(node="getitem_1", port="item"),
+        )
+
+    def test_executes_via_run_recipe(self):
+        holder = library.Nested()
+        result = wfms.run_recipe(mixed_chain.flowrep_recipe, holder=holder)
+        self.assertEqual(result.output_ports["value"].value, 7)
+        self.assertEqual(mixed_chain(holder), 7)
+
+    def test_round_trips_through_source(self):
+        """Mixed sugar: the compiler emits attribute syntax for the getattr links and
+        the plain call form for the getitem links, and both re-parse to the originals.
+        """
+        free = makers.reference_free(mixed_chain)
+        rendered = source._workflow2python(free)
+        fn = rendered.build()
+        self.assertEqual(fn(library.Nested()), mixed_chain(library.Nested()))
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+class TestRejections(unittest.TestCase):
+    def test_literal_slice_raises(self):
+        def wf(xs: list):
+            sliced = xs[1:2]
+            return sliced
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        message = str(ctx.exception)
+        self.assertIn("slice", message.lower())
+        self.assertIn("std.slice", message)
+
+    def test_chain_in_key_position_raises_and_names_the_bind(self):
+        """Out of scope by design; the message must hand the reader the workaround."""
+
+        def wf(d: dict, holder: library.Nested):
+            v = d[holder.sub]
+            return v
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        message = str(ctx.exception)
+        self.assertIn("k = holder.sub", message)
+        self.assertIn("d[k]", message)
+
+    def test_returned_item_raises(self):
+        """A workflow's outputs are public IO; their names may not be generated."""
+
+        def wf(d: dict, k):
+            return d[k]
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("returned from a workflow", str(ctx.exception))
+
+    def test_call_on_item_raises(self):
+        def wf(d: dict, k, x):
+            y = d[k](x)
+            return y
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("workflow data", str(ctx.exception))
+
+    def test_unknown_key_symbol_raises(self):
+        def wf(d: dict):
+            v = d[nope]  # noqa: F821
+            return v
+
+        with self.assertRaises(KeyError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("not in scope", str(ctx.exception))
+
+
+class TestOnlyLoadContextIsParsed(unittest.TestCase):
+    """Item access is parsed only where a value is read. Every other subscript context
+    is refused upstream, before chain parsing ever sees the node -- which is why the
+    chain code carries no `ctx` guard of its own."""
+
+    def test_store_raises(self):
+        def wf(dd: dict, v):
+            d = std.identity(dd)
+            d["k"] = v
+            return d
+
+        with self.assertRaises(TypeError):
+            workflow_parser.parse_workflow(wf)
+
+    def test_augmented_store_raises(self):
+        def wf(dd: dict):
+            d = std.identity(dd)
+            d["k"] += 1
+            return d
+
+        with self.assertRaises(TypeError):
+            workflow_parser.parse_workflow(wf)
+
+    def test_delete_raises(self):
+        def wf(dd: dict):
+            d = std.identity(dd)
+            del d["k"]
+            return d
+
+        with self.assertRaises(TypeError):
+            workflow_parser.parse_workflow(wf)
+
+
+@workflow_parser.workflow
+def if_item_condition(d: dict, x: int):
+    if library.my_condition(d["threshold"], 3):  # noqa: SIM108
+        y = library.increment(x)
+    else:
+        y = library.decrement(x)
+    return y
+
+
+@workflow_parser.workflow
+def if_bound_item_condition(d: dict, x: int):
+    """The form the compiler emits: the generated port name, spelled out."""
+    item_0 = d["threshold"]
+    if library.my_condition(item_0, 3):  # noqa: SIM108
+        y = library.increment(x)
+    else:
+        y = library.decrement(x)
+    return y
+
+
+class TestItemInCondition(unittest.TestCase):
+    def test_generated_port_uses_the_item_base(self):
+        recipe = if_item_condition.flowrep_recipe
+        self.assertEqual(recipe.nodes["if_0"].inputs, ["item_0", "constant_0", "x"])
+
+    def test_getitem_peer_feeds_the_generated_port(self):
+        recipe = if_item_condition.flowrep_recipe
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node="if_0", port="item_0")],
+            edge_models.SourceHandle(node="getitem_0", port="item"),
+        )
+
+    def test_identical_to_the_bound_form(self):
+        self.assertEqual(
+            makers.dump_no_refs(makers.reference_free(if_item_condition)),
+            makers.dump_no_refs(makers.reference_free(if_bound_item_condition)),
+        )
+
+    def test_executes_via_run_recipe(self):
+        d = {"threshold": 1}
+        result = wfms.run_recipe(if_item_condition.flowrep_recipe, d=d, x=1)
+        self.assertEqual(result.output_ports["y"].value, if_item_condition(d, 1))
+
+    def test_round_trips_through_source(self):
+        free = makers.reference_free(if_item_condition)
+        rendered = source._workflow2python(free)
+        fn = rendered.build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+@workflow_parser.workflow
+def for_item_iterable(data: dict):
+    ys = []
+    for n in data["xs"]:
+        y = library.increment(n)
+        ys.append(y)
+    return ys
+
+
+class TestItemAsForIterable(unittest.TestCase):
+    def test_generated_port_uses_the_item_base(self):
+        recipe = for_item_iterable.flowrep_recipe
+        self.assertEqual(recipe.nodes["for_each_0"].inputs, ["item_0"])
+
+    def test_getitem_peer_feeds_the_generated_port(self):
+        recipe = for_item_iterable.flowrep_recipe
+        self.assertEqual(
+            recipe.edges[edge_models.TargetHandle(node="for_each_0", port="item_0")],
+            edge_models.SourceHandle(node="getitem_0", port="item"),
+        )
+
+    def test_executes_via_run_recipe(self):
+        data = {"xs": [1, 2, 3]}
+        result = wfms.run_recipe(for_item_iterable.flowrep_recipe, data=data)
+        self.assertEqual(result.output_ports["ys"].value, for_item_iterable(data))
+
+    def test_round_trips_through_source(self):
+        free = makers.reference_free(for_item_iterable)
+        rendered = source._workflow2python(free)
+        fn = rendered.build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+@workflow_parser.workflow
+def for_appending_item(lookup: dict, ns: list):
+    xs = []
+    for n in ns:
+        row = std.identity(lookup)
+        xs.append(row[n])
+    return xs
+
+
+class TestAppendingAnItem(unittest.TestCase):
+    def test_body_output_port_uses_the_item_base(self):
+        body = for_appending_item.flowrep_recipe.nodes["for_each_0"].body_node
+        self.assertEqual(body.recipe.outputs, ["item_0"])
+
+    def test_getitem_lives_inside_the_body(self):
+        """It must re-execute every iteration, exactly as the item access would."""
+        body = for_appending_item.flowrep_recipe.nodes["for_each_0"].body_node
+        self.assertIn("getitem_0", body.recipe.nodes)
+
+    def test_executes_via_run_recipe(self):
+        lookup = {1: "a", 2: "b"}
+        result = wfms.run_recipe(
+            for_appending_item.flowrep_recipe, lookup=lookup, ns=[1, 2]
+        )
+        self.assertEqual(
+            result.output_ports["xs"].value, for_appending_item(lookup, [1, 2])
+        )
+
+    def test_round_trips_through_source(self):
+        free = makers.reference_free(for_appending_item)
+        rendered = source._workflow2python(free)
+        fn = rendered.build()
+        self.assertEqual(
+            makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
+        )
+
+
+@workflow_parser.workflow
+def while_unlooped_item_condition(d: dict, k: int, seed: int):
+    """Neither `d` nor `k` is reassigned, so hoisting the getitem is faithful."""
+    x = std.identity(seed)
+    while library.my_condition(x, d[k]):
+        x = library.loop_inc(x)
+    return x
+
+
+class TestItemInWhileCondition(unittest.TestCase):
+    def test_unlooped_dependencies_are_allowed(self):
+        recipe = while_unlooped_item_condition.flowrep_recipe
+        self.assertEqual(recipe.nodes["while_0"].inputs, ["x", "item_0"])
+
+    def test_executes_via_run_recipe(self):
+        d = {1: 3}
+        result = wfms.run_recipe(
+            while_unlooped_item_condition.flowrep_recipe, d=d, k=1, seed=1
+        )
+        self.assertEqual(
+            result.output_ports["x"].value, while_unlooped_item_condition(d, 1, 1)
+        )
+
+    def test_looped_key_symbol_raises(self):
+        """The item-only half of the guard: `d` is untouched, but `x` -- the *key* --
+        is reassigned every iteration, so Python would re-read `d[x]` and a hoisted
+        getitem would not."""
+
+        def wf(d: dict, seed: int):
+            x = std.identity(seed)
+            while library.my_condition(x, d[x]):
+                x = library.loop_inc(x)
+            return x
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        message = str(ctx.exception)
+        self.assertIn("d[x]", message)
+        self.assertIn("'x'", message)
+        self.assertIn("re-read", message)
+
+    def test_looped_root_raises(self):
+        def wf(dd: dict, k):
+            d = std.identity(dd)
+            while library.my_condition(d, d[k]):
+                d = std.identity(d)
+            return d
+
+        with self.assertRaises(ValueError) as ctx:
+            workflow_parser.parse_workflow(wf)
+        self.assertIn("'d'", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/parsers/test_attribute_parser.py
+++ b/tests/unit/parsers/test_attribute_parser.py
@@ -2,12 +2,7 @@ import ast
 import unittest
 
 from flowrep import edge_models, std
-from flowrep.parsers import attribute_parser, symbol_scope
-from flowrep.prospective import constant_recipe
-
-
-def _make_input(port: str) -> edge_models.InputSource:
-    return edge_models.InputSource(port=port)
+from flowrep.parsers import attribute_parser, chain_parser, symbol_scope
 
 
 def _make_source(node: str, port: str) -> edge_models.SourceHandle:
@@ -18,153 +13,6 @@ def _expr(src: str) -> ast.expr:
     stmt = ast.parse(src).body[0]
     assert isinstance(stmt, ast.Expr)
     return stmt.value
-
-
-class TestIsDataAttribute(unittest.TestCase):
-    def test_true_for_single_access(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        self.assertTrue(attribute_parser.is_data_attribute(_expr("dc.a"), scope))
-
-    def test_true_for_chain(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        self.assertTrue(attribute_parser.is_data_attribute(_expr("dc.a.val"), scope))
-
-    def test_false_for_bare_name(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        self.assertFalse(attribute_parser.is_data_attribute(_expr("dc"), scope))
-
-    def test_false_when_root_not_a_symbol(self):
-        scope = symbol_scope.SymbolScope({})
-        self.assertFalse(attribute_parser.is_data_attribute(_expr("np.pi"), scope))
-
-    def test_false_when_chain_contains_call(self):
-        scope = symbol_scope.SymbolScope({"f": _make_source("f_0", "output_0")})
-        self.assertFalse(attribute_parser.is_data_attribute(_expr("f(x).a"), scope))
-
-    def test_false_when_chain_contains_subscript(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        self.assertFalse(attribute_parser.is_data_attribute(_expr("dc[0].a"), scope))
-
-    def test_symbol_scope_shadows_object_scope(self):
-        """`os.path` is a data attribute access when `os` is a bound symbol."""
-        scope = symbol_scope.SymbolScope({"os": _make_input("os")})
-        self.assertTrue(attribute_parser.is_data_attribute(_expr("os.path"), scope))
-
-
-class TestInjectAttributeChain(unittest.TestCase):
-    def test_single_link_adds_getattr_and_constant(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        nodes = {}
-        node = _expr("dc.a")
-        assert isinstance(node, ast.Attribute)
-        handle = attribute_parser.inject_attribute_chain(node, scope, nodes)
-
-        self.assertEqual(set(nodes), {"getattr_a_0", "constant_0"})
-        self.assertIs(nodes["getattr_a_0"], std.get_attr.flowrep_recipe)
-        self.assertIsInstance(nodes["constant_0"], constant_recipe.ConstantRecipe)
-        self.assertEqual(nodes["constant_0"].constant, "a")
-        self.assertEqual(
-            scope.edges,
-            {
-                edge_models.TargetHandle(node="getattr_a_0", port="obj"): _make_source(
-                    "MyDataclass_0", "instance"
-                ),
-                edge_models.TargetHandle(node="getattr_a_0", port="name"): _make_source(
-                    "constant_0", "constant"
-                ),
-            },
-        )
-        self.assertEqual(handle, _make_source("getattr_a_0", "attr"))
-
-    def test_chain_of_two_links(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        nodes = {}
-        node = _expr("dc.a.val")
-        assert isinstance(node, ast.Attribute)
-        handle = attribute_parser.inject_attribute_chain(node, scope, nodes)
-
-        self.assertEqual(
-            list(nodes), ["getattr_a_0", "constant_0", "getattr_val_0", "constant_1"]
-        )
-        self.assertEqual(
-            scope.edges[edge_models.TargetHandle(node="getattr_val_0", port="obj")],
-            _make_source("getattr_a_0", "attr"),
-        )
-        self.assertEqual(handle, _make_source("getattr_val_0", "attr"))
-
-    def test_root_is_workflow_input_creates_input_edge(self):
-        scope = symbol_scope.SymbolScope({"comp": _make_input("comp")})
-        nodes = {}
-        node = _expr("comp.val")
-        assert isinstance(node, ast.Attribute)
-        attribute_parser.inject_attribute_chain(node, scope, nodes)
-
-        self.assertEqual(
-            scope.input_edges,
-            {
-                edge_models.TargetHandle(node="getattr_val_0", port="obj"): _make_input(
-                    "comp"
-                )
-            },
-        )
-
-    def test_label_collision_increments_suffix(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        nodes = {}
-        node1 = _expr("dc.a")
-        node2 = _expr("dc.a")
-        assert isinstance(node1, ast.Attribute) and isinstance(node2, ast.Attribute)
-        attribute_parser.inject_attribute_chain(node1, scope, nodes)
-        handle2 = attribute_parser.inject_attribute_chain(node2, scope, nodes)
-        self.assertEqual(handle2.node, "getattr_a_1")
-
-    def test_accumulator_root_raises(self):
-        scope = symbol_scope.SymbolScope({}, available_accumulators={"acc"})
-        node = _expr("acc.a")
-        assert isinstance(node, ast.Attribute)
-        with self.assertRaises(ValueError) as ctx:
-            attribute_parser.inject_attribute_chain(node, scope, {})
-        self.assertIn("accumulator", str(ctx.exception).lower())
-
-
-class TestRejectMethodCall(unittest.TestCase):
-    def test_raises_for_method_call_on_symbol(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        call = _expr("dc.method(x)")
-        assert isinstance(call, ast.Call)
-        with self.assertRaises(ValueError) as ctx:
-            attribute_parser.reject_method_call(call, scope)
-        self.assertIn("method", str(ctx.exception).lower())
-
-    def test_noop_for_module_call(self):
-        scope = symbol_scope.SymbolScope(
-            {"dc": _make_source("MyDataclass_0", "instance")}
-        )
-        call = _expr("std.add(x)")
-        assert isinstance(call, ast.Call)
-        attribute_parser.reject_method_call(call, scope)  # does not raise
-
-    def test_noop_for_plain_call(self):
-        scope = symbol_scope.SymbolScope({})
-        call = _expr("f(x)")
-        assert isinstance(call, ast.Call)
-        attribute_parser.reject_method_call(call, scope)  # does not raise
 
 
 class TestInjectionUsesTheRecipePorts(unittest.TestCase):
@@ -178,7 +26,7 @@ class TestInjectionUsesTheRecipePorts(unittest.TestCase):
         )
         nodes: dict = {}
 
-        handle = attribute_parser.inject_attribute_chain(_expr("dc.a"), scope, nodes)
+        handle = chain_parser.inject_chain(_expr("dc.a"), scope, nodes)
 
         self.assertEqual(handle, _make_source("getattr_a_0", attr_port))
         self.assertIn(
@@ -189,50 +37,33 @@ class TestInjectionUsesTheRecipePorts(unittest.TestCase):
         )
 
 
-class TestRejectUnboundAttribute(unittest.TestCase):
-    def _scope(self) -> symbol_scope.SymbolScope:
-        return symbol_scope.SymbolScope(
+class TestHandlerTracksTheRecipe(unittest.TestCase):
+    """Labels and ports are read off std.get_attr, never spelled out."""
+
+    def test_recipe_is_std_get_attr(self):
+        self.assertIs(attribute_parser.HANDLER.recipe, std.get_attr.flowrep_recipe)
+
+    def test_label_base_embeds_the_attribute_name(self):
+        self.assertEqual(
+            attribute_parser.HANDLER.label_base(_expr("dc.a")), "getattr_a"
+        )
+
+    def test_port_base_is_the_attribute_name(self):
+        self.assertEqual(attribute_parser.HANDLER.port_base(_expr("dc.a")), "a")
+
+    def test_feed_key_injects_the_name_constant(self):
+        scope = symbol_scope.SymbolScope(
             {"dc": _make_source("MyDataclass_0", "instance")}
         )
-
-    def test_raises_for_chain_on_known_symbol(self):
-        with self.assertRaises(ValueError) as ctx:
-            attribute_parser.reject_unbound_attribute(
-                _expr("dc.a"), self._scope(), "returned from a workflow"
-            )
-        message = str(ctx.exception)
-        self.assertIn("returned from a workflow", message)
-        self.assertIn("dc.a", message)
-        self.assertIn("bind", message.lower())
-
-    def test_raises_for_chain_of_chains(self):
-        with self.assertRaises(ValueError) as ctx:
-            attribute_parser.reject_unbound_attribute(
-                _expr("dc.a.val"), self._scope(), "returned from a workflow"
-            )
-        self.assertIn("dc.a.val", str(ctx.exception))
-
-    def test_noop_for_bare_symbol(self):
-        attribute_parser.reject_unbound_attribute(
-            _expr("dc"), self._scope(), "returned from a workflow"
+        nodes: dict = {}
+        attribute_parser.HANDLER.feed_key(
+            _expr("dc.a"), scope, nodes, "getattr_a_0", "name"
         )
-
-    def test_noop_for_chain_on_unknown_root(self):
-        attribute_parser.reject_unbound_attribute(
-            _expr("numpy.pi"), self._scope(), "returned from a workflow"
-        )
-
-
-class TestGeneratedPort(unittest.TestCase):
-    def test_takes_the_outermost_attribute(self):
+        self.assertEqual(set(nodes), {"constant_0"})
+        self.assertEqual(nodes["constant_0"].constant, "a")
         self.assertEqual(
-            attribute_parser.generate_port_name(_expr("dc.a.val"), []), "val_0"
-        )
-
-    def test_dodges_taken_names(self):
-        self.assertEqual(
-            attribute_parser.generate_port_name(_expr("dc.val"), ["val_0", "val_1"]),
-            "val_2",
+            scope.edges[edge_models.TargetHandle(node="getattr_a_0", port="name")],
+            _make_source("constant_0", "constant"),
         )
 
 

--- a/tests/unit/parsers/test_chain_parser.py
+++ b/tests/unit/parsers/test_chain_parser.py
@@ -1,0 +1,306 @@
+import ast
+import unittest
+
+from flowrep import edge_models, std
+from flowrep.parsers import chain_parser, symbol_scope
+from flowrep.prospective import constant_recipe
+
+
+def _make_input(port: str) -> edge_models.InputSource:
+    return edge_models.InputSource(port=port)
+
+
+def _make_source(node: str, port: str) -> edge_models.SourceHandle:
+    return edge_models.SourceHandle(node=node, port=port)
+
+
+def _expr(src: str) -> ast.expr:
+    stmt = ast.parse(src).body[0]
+    assert isinstance(stmt, ast.Expr)
+    return stmt.value
+
+
+class TestIsDataAccess(unittest.TestCase):
+    def test_true_for_single_access(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        self.assertTrue(chain_parser.is_data_access(_expr("dc.a"), scope))
+
+    def test_true_for_chain(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        self.assertTrue(chain_parser.is_data_access(_expr("dc.a.val"), scope))
+
+    def test_false_for_bare_name(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        self.assertFalse(chain_parser.is_data_access(_expr("dc"), scope))
+
+    def test_false_when_root_not_a_symbol(self):
+        scope = symbol_scope.SymbolScope({})
+        self.assertFalse(chain_parser.is_data_access(_expr("np.pi"), scope))
+
+    def test_false_when_chain_contains_call(self):
+        scope = symbol_scope.SymbolScope({"f": _make_source("f_0", "output_0")})
+        self.assertFalse(chain_parser.is_data_access(_expr("f(x).a"), scope))
+
+    def test_true_for_mixed_chain(self):
+        """Item links are part of a chain now; this assertion is the inverse of the
+        one attribute-only parsing carried."""
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        self.assertTrue(chain_parser.is_data_access(_expr("dc[0].a"), scope))
+
+    def test_true_for_bare_item_access(self):
+        scope = symbol_scope.SymbolScope({"d": _make_source("identity_0", "x")})
+        self.assertTrue(chain_parser.is_data_access(_expr("d[0]"), scope))
+
+    def test_false_when_item_root_not_a_symbol(self):
+        scope = symbol_scope.SymbolScope({})
+        self.assertFalse(chain_parser.is_data_access(_expr("d[0]"), scope))
+
+    def test_symbol_scope_shadows_object_scope(self):
+        """`os.path` is a data attribute access when `os` is a bound symbol."""
+        scope = symbol_scope.SymbolScope({"os": _make_input("os")})
+        self.assertTrue(chain_parser.is_data_access(_expr("os.path"), scope))
+
+
+class TestInjectChain(unittest.TestCase):
+    def test_single_link_adds_getattr_and_constant(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        nodes = {}
+        node = _expr("dc.a")
+        assert isinstance(node, ast.Attribute)
+        handle = chain_parser.inject_chain(node, scope, nodes)
+
+        self.assertEqual(set(nodes), {"getattr_a_0", "constant_0"})
+        self.assertIs(nodes["getattr_a_0"], std.get_attr.flowrep_recipe)
+        self.assertIsInstance(nodes["constant_0"], constant_recipe.ConstantRecipe)
+        self.assertEqual(nodes["constant_0"].constant, "a")
+        self.assertEqual(
+            scope.edges,
+            {
+                edge_models.TargetHandle(node="getattr_a_0", port="obj"): _make_source(
+                    "MyDataclass_0", "instance"
+                ),
+                edge_models.TargetHandle(node="getattr_a_0", port="name"): _make_source(
+                    "constant_0", "constant"
+                ),
+            },
+        )
+        self.assertEqual(handle, _make_source("getattr_a_0", "attr"))
+
+    def test_chain_of_two_links(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        nodes = {}
+        node = _expr("dc.a.val")
+        assert isinstance(node, ast.Attribute)
+        handle = chain_parser.inject_chain(node, scope, nodes)
+
+        self.assertEqual(
+            list(nodes), ["getattr_a_0", "constant_0", "getattr_val_0", "constant_1"]
+        )
+        self.assertEqual(
+            scope.edges[edge_models.TargetHandle(node="getattr_val_0", port="obj")],
+            _make_source("getattr_a_0", "attr"),
+        )
+        self.assertEqual(handle, _make_source("getattr_val_0", "attr"))
+
+    def test_root_is_workflow_input_creates_input_edge(self):
+        scope = symbol_scope.SymbolScope({"comp": _make_input("comp")})
+        nodes = {}
+        node = _expr("comp.val")
+        assert isinstance(node, ast.Attribute)
+        chain_parser.inject_chain(node, scope, nodes)
+
+        self.assertEqual(
+            scope.input_edges,
+            {
+                edge_models.TargetHandle(node="getattr_val_0", port="obj"): _make_input(
+                    "comp"
+                )
+            },
+        )
+
+    def test_label_collision_increments_suffix(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        nodes = {}
+        node1 = _expr("dc.a")
+        node2 = _expr("dc.a")
+        assert isinstance(node1, ast.Attribute) and isinstance(node2, ast.Attribute)
+        chain_parser.inject_chain(node1, scope, nodes)
+        handle2 = chain_parser.inject_chain(node2, scope, nodes)
+        self.assertEqual(handle2.node, "getattr_a_1")
+
+    def test_accumulator_root_raises(self):
+        scope = symbol_scope.SymbolScope({}, available_accumulators={"acc"})
+        node = _expr("acc.a")
+        assert isinstance(node, ast.Attribute)
+        with self.assertRaises(ValueError) as ctx:
+            chain_parser.inject_chain(node, scope, {})
+        self.assertIn("accumulator", str(ctx.exception).lower())
+
+
+class TestRejectMethodCall(unittest.TestCase):
+    def test_raises_for_method_call_on_symbol(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        call = _expr("dc.method(x)")
+        assert isinstance(call, ast.Call)
+        with self.assertRaises(ValueError) as ctx:
+            chain_parser.reject_method_call(call, scope)
+        self.assertIn("method", str(ctx.exception).lower())
+
+    def test_noop_for_module_call(self):
+        scope = symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+        call = _expr("std.add(x)")
+        assert isinstance(call, ast.Call)
+        chain_parser.reject_method_call(call, scope)  # does not raise
+
+    def test_noop_for_plain_call(self):
+        scope = symbol_scope.SymbolScope({})
+        call = _expr("f(x)")
+        assert isinstance(call, ast.Call)
+        chain_parser.reject_method_call(call, scope)  # does not raise
+
+
+class TestRejectUnboundAccess(unittest.TestCase):
+    def _scope(self) -> symbol_scope.SymbolScope:
+        return symbol_scope.SymbolScope(
+            {"dc": _make_source("MyDataclass_0", "instance")}
+        )
+
+    def test_raises_for_chain_on_known_symbol(self):
+        with self.assertRaises(ValueError) as ctx:
+            chain_parser.reject_unbound_access(
+                _expr("dc.a"), self._scope(), "returned from a workflow"
+            )
+        message = str(ctx.exception)
+        self.assertIn("returned from a workflow", message)
+        self.assertIn("dc.a", message)
+        self.assertIn("bind", message.lower())
+
+    def test_raises_for_chain_of_chains(self):
+        with self.assertRaises(ValueError) as ctx:
+            chain_parser.reject_unbound_access(
+                _expr("dc.a.val"), self._scope(), "returned from a workflow"
+            )
+        self.assertIn("dc.a.val", str(ctx.exception))
+
+    def test_noop_for_bare_symbol(self):
+        chain_parser.reject_unbound_access(
+            _expr("dc"), self._scope(), "returned from a workflow"
+        )
+
+    def test_noop_for_chain_on_unknown_root(self):
+        chain_parser.reject_unbound_access(
+            _expr("numpy.pi"), self._scope(), "returned from a workflow"
+        )
+
+
+class TestGeneratedPort(unittest.TestCase):
+    def test_takes_the_outermost_attribute(self):
+        self.assertEqual(
+            chain_parser.generate_port_name(_expr("dc.a.val"), []), "val_0"
+        )
+
+    def test_dodges_taken_names(self):
+        self.assertEqual(
+            chain_parser.generate_port_name(_expr("dc.val"), ["val_0", "val_1"]),
+            "val_2",
+        )
+
+
+class TestInjectMixedChain(unittest.TestCase):
+    def test_links_inject_root_outward_with_interleaved_constants(self):
+        scope = symbol_scope.SymbolScope({"holder": _make_input("holder")})
+        nodes: dict = {}
+        handle = chain_parser.inject_chain(
+            _expr("holder.sub['item']['subitem'].val"), scope, nodes
+        )
+        self.assertEqual(
+            list(nodes),
+            [
+                "getattr_sub_0",
+                "constant_0",
+                "getitem_0",
+                "constant_1",
+                "getitem_1",
+                "constant_2",
+                "getattr_val_0",
+                "constant_3",
+            ],
+        )
+        self.assertEqual(handle, _make_source("getattr_val_0", "attr"))
+
+    def test_each_link_reads_from_the_previous(self):
+        scope = symbol_scope.SymbolScope({"holder": _make_input("holder")})
+        nodes: dict = {}
+        chain_parser.inject_chain(_expr("holder.sub['item']"), scope, nodes)
+        self.assertEqual(
+            scope.edges[edge_models.TargetHandle(node="getitem_0", port="a")],
+            _make_source("getattr_sub_0", "attr"),
+        )
+
+    def test_item_label_numbering_matches_the_std_call_form(self):
+        scope = symbol_scope.SymbolScope({"d": _make_source("identity_0", "x")})
+        nodes: dict = {}
+        handle = chain_parser.inject_chain(_expr("d[0]"), scope, nodes)
+        self.assertEqual(list(nodes), ["getitem_0", "constant_0"])
+        self.assertEqual(handle, _make_source("getitem_0", "item"))
+
+
+class TestGeneratedPortForItems(unittest.TestCase):
+    def test_item_port_uses_the_item_base(self):
+        self.assertEqual(chain_parser.generate_port_name(_expr("d[0]"), []), "item_0")
+
+    def test_item_port_dodges_taken_names(self):
+        self.assertEqual(
+            chain_parser.generate_port_name(_expr("d['k']"), ["item_0", "item_1"]),
+            "item_2",
+        )
+
+    def test_outermost_link_wins_in_a_mixed_chain(self):
+        self.assertEqual(
+            chain_parser.generate_port_name(_expr("d['k'].val"), []), "val_0"
+        )
+        self.assertEqual(
+            chain_parser.generate_port_name(_expr("d.sub['k']"), []), "item_0"
+        )
+
+
+class TestDependencySymbols(unittest.TestCase):
+    def test_attribute_chain_depends_only_on_its_root(self):
+        self.assertEqual(chain_parser.dependency_symbols(_expr("x.val")), {"x"})
+
+    def test_item_chain_depends_on_root_and_key(self):
+        self.assertEqual(chain_parser.dependency_symbols(_expr("d[k]")), {"d", "k"})
+
+    def test_constant_key_adds_no_dependency(self):
+        self.assertEqual(chain_parser.dependency_symbols(_expr("d['k']")), {"d"})
+
+    def test_mixed_chain_collects_every_key(self):
+        self.assertEqual(
+            chain_parser.dependency_symbols(_expr("d.sub[i]['c'][j].val")),
+            {"d", "i", "j"},
+        )
+
+    def test_rootless_chain_has_no_dependencies(self):
+        self.assertEqual(chain_parser.dependency_symbols(_expr("f(x)[k]")), {"k"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/parsers/test_item_parser.py
+++ b/tests/unit/parsers/test_item_parser.py
@@ -1,0 +1,85 @@
+import ast
+import unittest
+
+from flowrep import edge_models, std
+from flowrep.parsers import item_parser, symbol_scope
+from flowrep.prospective import constant_recipe
+
+
+def _make_source(node: str, port: str) -> edge_models.SourceHandle:
+    return edge_models.SourceHandle(node=node, port=port)
+
+
+def _expr(src: str) -> ast.expr:
+    stmt = ast.parse(src).body[0]
+    assert isinstance(stmt, ast.Expr)
+    return stmt.value
+
+
+class TestHandlerTracksTheRecipe(unittest.TestCase):
+    """Labels and ports are read off std.getitem, never spelled out."""
+
+    def test_recipe_is_std_getitem(self):
+        self.assertIs(item_parser.HANDLER.recipe, std.getitem.flowrep_recipe)
+
+    def test_label_base_matches_the_std_call_form(self):
+        """`d[k]` must mint the label `std.getitem(d, k)` would: that identity is what
+        lets the compiler round-trip item access without desugaring it."""
+        self.assertEqual(item_parser.HANDLER.label_base(_expr("d[0]")), "getitem")
+
+    def test_port_base_is_the_recipes_output_port(self):
+        (item_port,) = std.getitem.flowrep_recipe.outputs
+        self.assertEqual(item_parser.HANDLER.port_base(_expr("d[0]")), item_port)
+
+
+class TestFeedKey(unittest.TestCase):
+    def _scope(self) -> symbol_scope.SymbolScope:
+        return symbol_scope.SymbolScope(
+            {"d": _make_source("identity_0", "x"), "i": _make_source("identity_1", "x")}
+        )
+
+    def test_symbol_key_consumes_the_symbol(self):
+        scope = self._scope()
+        nodes: dict = {}
+        item_parser.HANDLER.feed_key(_expr("d[i]"), scope, nodes, "getitem_0", "b")
+        self.assertEqual(nodes, {})
+        self.assertEqual(
+            scope.edges[edge_models.TargetHandle(node="getitem_0", port="b")],
+            _make_source("identity_1", "x"),
+        )
+
+    def test_constant_key_injects_a_constant_peer(self):
+        scope = self._scope()
+        nodes: dict = {}
+        item_parser.HANDLER.feed_key(_expr("d['mass']"), scope, nodes, "getitem_0", "b")
+        self.assertEqual(set(nodes), {"constant_0"})
+        self.assertIsInstance(nodes["constant_0"], constant_recipe.ConstantRecipe)
+        self.assertEqual(nodes["constant_0"].constant, "mass")
+
+    def test_integer_key_injects_a_constant_peer(self):
+        scope = self._scope()
+        nodes: dict = {}
+        item_parser.HANDLER.feed_key(_expr("d[0]"), scope, nodes, "getitem_0", "b")
+        self.assertEqual(nodes["constant_0"].constant, 0)
+
+    def test_slice_raises_and_names_the_future_node(self):
+        with self.assertRaises(ValueError) as ctx:
+            item_parser.HANDLER.feed_key(
+                _expr("d[1:2]"), self._scope(), {}, "getitem_0", "b"
+            )
+        message = str(ctx.exception)
+        self.assertIn("slice", message.lower())
+        self.assertIn("std.slice", message)
+
+    def test_chain_key_raises_and_names_the_bind_workaround(self):
+        with self.assertRaises(ValueError) as ctx:
+            item_parser.HANDLER.feed_key(
+                _expr("d[dc.key]"), self._scope(), {}, "getitem_0", "b"
+            )
+        message = str(ctx.exception)
+        self.assertIn("k = dc.key", message)
+        self.assertIn("d[k]", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I.e. to parse things like `new_symbol = old_symbol[other_symbol]["constant"]`. Rides a lot of the same infrastructure has attribute access, so this was pulled up to a generic "chain" parser, and arbitrary attribute/item access chains work by injecting their respective stdlib nodes.

Required a bit of an extra guard on the while-node to protect against looped keys:

```python
def wf(d: dict, seed: int):
    x = std.identity(seed)
    while library.my_condition(x, d[x]):
        x = library.loop_inc(x)
    return x
```