### PR TITLE
Simplify parsed getattr node label

### DIFF
--- a/src/flowrep/parsers/attribute_parser.py
+++ b/src/flowrep/parsers/attribute_parser.py
@@ -29,9 +29,6 @@ class AttributeHandler:
 
         return std.get_attr.flowrep_recipe  # type: ignore[attr-defined,no-any-return]
 
-    def label_base(self, link: ast.expr) -> str:
-        return f"getattr_{_link(link).attr}"
-
     def port_base(self, link: ast.expr) -> str:
         return _link(link).attr
 

--- a/src/flowrep/parsers/chain_parser.py
+++ b/src/flowrep/parsers/chain_parser.py
@@ -66,10 +66,6 @@ class LinkHandler(Protocol):
         """The std recipe injected per link. Two inputs (obj, key), one output."""
         ...
 
-    def label_base(self, link: ast.expr) -> str:
-        """The node label prefix, before :func:`label_helpers.unique_suffix`."""
-        ...
-
     def port_base(self, link: ast.expr) -> str:
         """The generated port name base, before :func:`label_helpers.unique_suffix`."""
         ...
@@ -97,6 +93,22 @@ def _handler_for(link: ast.expr) -> LinkHandler:
         return _HANDLERS[type(link)]
     except KeyError:  # pragma: no cover - callers gate on is_data_access
         raise TypeError(f"Not a data-access link: {ast.dump(link)}") from None
+
+
+def _label_base(recipe: atomic_recipe.AtomicRecipe) -> str:
+    """The callee's own name, as ``atomic_parser`` would label an equivalent call.
+
+    An injected link must carry the label the explicit call form produces: that identity
+    is what makes ``dc.a`` and ``std.get_attr(dc, "a")`` the same recipe, and so what
+    lets the compiler round-trip a link by emitting *either* rendering. Without it the
+    compiler would be obliged to emit one specific rendering, and its sugar would be
+    load-bearing rather than cosmetic.
+
+    Deliberately duplicates ``atomic_parser._infer_node_name``'s rule rather than
+    importing it: ``atomic_parser`` imports ``parser_helpers``, which imports this
+    module, so the import would cycle. Keep the two in step.
+    """
+    return recipe.reference.info.qualname.rsplit(".", 1)[-1]
 
 
 def chain_root(node: ast.expr) -> ast.Name | None:
@@ -161,7 +173,7 @@ def inject_chain(
         recipe = handler.recipe
         obj_port, key_port = recipe.inputs
         (out_port,) = recipe.outputs
-        label = label_helpers.unique_suffix(handler.label_base(link), nodes)
+        label = label_helpers.unique_suffix(_label_base(recipe), nodes)
         nodes[label] = recipe
         if handle is None:
             symbol_map.consume(root.id, label, obj_port)

--- a/src/flowrep/parsers/item_parser.py
+++ b/src/flowrep/parsers/item_parser.py
@@ -3,8 +3,8 @@
 ``d[k]`` becomes one ``std.getitem`` node. Its key comes from a symbol (``d[i]``) or a
 ``ConstantRecipe`` peer (``d[0]``, ``d["mass"]``).
 
-The label base is read off the recipe rather than spelled out, so an injected node
-carries exactly the label -- and its constant peer exactly the numbering -- that parsing
+Labels come from :func:`chain_parser._label_base`, so an injected node carries exactly
+the label -- and its constant peer exactly the numbering -- that parsing
 ``std.getitem(d, k)`` would produce. That makes ``d[k]`` and ``std.getitem(d, k)`` the
 *same recipe*, which is why item access round-trips through the compiler with no
 desugaring: the compiler emits the call form, and re-parsing it lands back here.
@@ -34,10 +34,6 @@ class ItemHandler:
         from flowrep import std
 
         return std.getitem.flowrep_recipe  # type: ignore[attr-defined,no-any-return]
-
-    def label_base(self, link: ast.expr) -> str:
-        # The callee's own name, exactly as `atomic_parser` labels `std.getitem(d, k)`.
-        return self.recipe.reference.info.qualname.rsplit(".", 1)[-1]
 
     def port_base(self, link: ast.expr) -> str:
         (item_port,) = self.recipe.outputs

--- a/tests/integration/parsers/test_parsing_attribute_access.py
+++ b/tests/integration/parsers/test_parsing_attribute_access.py
@@ -15,6 +15,17 @@ def wf(x0: int, comp: library.ComplexData):
     return repeated
 
 
+@workflow_parser.workflow
+def attribute_std_form(x0: int, comp: library.ComplexData):
+    """The explicit call the sugar must be indistinguishable from."""
+    dc = library.MyDataclass(comp, x0)
+    a_0 = std.get_attr(dc, "a")
+    my_val = std.get_attr(a_0, "val")
+    x_0 = std.get_attr(dc, "x")
+    repeated = std.mul(x_0, my_val)
+    return repeated
+
+
 class TestAttributeAccessEndToEnd(unittest.TestCase):
     def test_parses_expected_graph(self):
         recipe = wf.flowrep_recipe
@@ -23,9 +34,9 @@ class TestAttributeAccessEndToEnd(unittest.TestCase):
             set(recipe.nodes),
             {
                 "MyDataclass_0",
-                "getattr_a_0",
-                "getattr_val_0",
-                "getattr_x_0",
+                "get_attr_0",
+                "get_attr_1",
+                "get_attr_2",
                 "mul_0",
                 "constant_0",
                 "constant_1",
@@ -33,24 +44,24 @@ class TestAttributeAccessEndToEnd(unittest.TestCase):
             },
         )
         self.assertEqual(
-            recipe.edges[edge_models.TargetHandle(node="getattr_a_0", port="obj")],
+            recipe.edges[edge_models.TargetHandle(node="get_attr_0", port="obj")],
             edge_models.SourceHandle(node="MyDataclass_0", port="instance"),
         )
         self.assertEqual(
-            recipe.edges[edge_models.TargetHandle(node="getattr_val_0", port="obj")],
-            edge_models.SourceHandle(node="getattr_a_0", port="attr"),
+            recipe.edges[edge_models.TargetHandle(node="get_attr_1", port="obj")],
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
         self.assertEqual(
-            recipe.edges[edge_models.TargetHandle(node="getattr_x_0", port="obj")],
+            recipe.edges[edge_models.TargetHandle(node="get_attr_2", port="obj")],
             edge_models.SourceHandle(node="MyDataclass_0", port="instance"),
         )
         self.assertEqual(
             recipe.edges[edge_models.TargetHandle(node="mul_0", port="a")],
-            edge_models.SourceHandle(node="getattr_x_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_2", port="attr"),
         )
         self.assertEqual(
             recipe.edges[edge_models.TargetHandle(node="mul_0", port="b")],
-            edge_models.SourceHandle(node="getattr_val_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_1", port="attr"),
         )
 
     def test_executes_via_run_recipe(self):
@@ -80,6 +91,16 @@ class TestAttributeAccessEndToEnd(unittest.TestCase):
         self.assertRegex(rendered.source, r"\n\s*(\w+) = \w+\.a\n\s*\w+ = \1\.val\n")
         self.assertRegex(rendered.source, r"\n\s*\w+ = \w+\.x\n")
         self.assertNotIn("_getattr_wrapper", rendered.source)
+
+    def test_identical_to_the_std_call_form(self):
+        """The label rule, stated as a test: `dc.a` is not merely equivalent to
+        `std.get_attr(dc, 'a')` -- it is the same recipe. That identity is what frees
+        the compiler to emit either rendering, and so demotes `sugar.py` from
+        load-bearing to cosmetic."""
+        self.assertEqual(
+            makers.dump_no_refs(makers.reference_free(wf)),
+            makers.dump_no_refs(makers.reference_free(attribute_std_form)),
+        )
 
 
 @workflow_parser.workflow
@@ -120,7 +141,7 @@ class TestAttributeInCondition(unittest.TestCase):
         recipe = if_attribute_condition.flowrep_recipe
         self.assertEqual(
             recipe.edges[edge_models.TargetHandle(node="if_0", port="val_0")],
-            edge_models.SourceHandle(node="getattr_val_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
 
     def test_identical_to_the_bound_form(self):
@@ -268,7 +289,7 @@ class TestAttributeAsForIterable(unittest.TestCase):
         recipe = for_attribute_iterable.flowrep_recipe
         self.assertEqual(
             recipe.edges[edge_models.TargetHandle(node="for_each_0", port="xs_0")],
-            edge_models.SourceHandle(node="getattr_xs_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
 
     def test_identical_to_the_bound_form(self):
@@ -370,7 +391,7 @@ class TestAppendingAnAttribute(unittest.TestCase):
     def test_getattr_lives_inside_the_body(self):
         """It must re-execute every iteration, exactly as the attribute access would."""
         body = for_appending_attribute.flowrep_recipe.nodes["for_each_0"].body_node
-        self.assertIn("getattr_x_0", body.recipe.nodes)
+        self.assertIn("get_attr_0", body.recipe.nodes)
 
     def test_identical_to_the_bound_form(self):
         self.assertEqual(
@@ -482,7 +503,7 @@ class TestAttributeInsideTryBranches(unittest.TestCase):
 
     def test_getattr_lives_inside_the_branch(self):
         try_node = try_attribute_in_branches.flowrep_recipe.nodes["try_0"]
-        self.assertIn("getattr_num_0", try_node.try_node.recipe.nodes)
+        self.assertIn("get_attr_0", try_node.try_node.recipe.nodes)
 
     def test_executes_both_branches(self):
         ok = library.Payload(num=6, den=2)

--- a/tests/integration/parsers/test_parsing_item_access.py
+++ b/tests/integration/parsers/test_parsing_item_access.py
@@ -153,13 +153,13 @@ class TestMixedChain(unittest.TestCase):
         self.assertEqual(
             list(recipe.nodes),
             [
-                "getattr_sub_0",
+                "get_attr_0",
                 "constant_0",
                 "getitem_0",
                 "constant_1",
                 "getitem_1",
                 "constant_2",
-                "getattr_val_0",
+                "get_attr_1",
                 "constant_3",
             ],
         )
@@ -168,14 +168,14 @@ class TestMixedChain(unittest.TestCase):
         recipe = mixed_chain.flowrep_recipe
         self.assertEqual(
             recipe.edges[edge_models.TargetHandle(node="getitem_0", port="a")],
-            edge_models.SourceHandle(node="getattr_sub_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
         self.assertEqual(
             recipe.edges[edge_models.TargetHandle(node="getitem_1", port="a")],
             edge_models.SourceHandle(node="getitem_0", port="item"),
         )
         self.assertEqual(
-            recipe.edges[edge_models.TargetHandle(node="getattr_val_0", port="obj")],
+            recipe.edges[edge_models.TargetHandle(node="get_attr_1", port="obj")],
             edge_models.SourceHandle(node="getitem_1", port="item"),
         )
 

--- a/tests/integration/parsers/test_parsing_reassignment.py
+++ b/tests/integration/parsers/test_parsing_reassignment.py
@@ -114,7 +114,7 @@ class TestAliasNonRegression(unittest.TestCase):
             return y
 
         recipe = _parse(macro)
-        self.assertIn("getattr_real_0", recipe.nodes)
+        self.assertIn("get_attr_0", recipe.nodes)
         self.assertEqual(recipe.outputs, ["y"])
 
     def test_alias_to_undefined_symbol_raises(self):

--- a/tests/unit/compiler/test_sugar.py
+++ b/tests/unit/compiler/test_sugar.py
@@ -54,7 +54,7 @@ class TestIsAttributeSyntax(unittest.TestCase):
 class TestAttributeName(unittest.TestCase):
     def test_returns_name_for_parsed_access(self):
         recipe = makers.reference_free(_wf)
-        self.assertEqual(sugar.attribute_name("getattr_a_0", recipe), "a")
+        self.assertEqual(sugar.attribute_name("get_attr_0", recipe), "a")
 
     def test_none_when_name_port_fed_by_non_constant_node(self):
         recipe = workflow_parser.parse_workflow(_wf).model_copy(

--- a/tests/unit/parsers/test_attribute_parser.py
+++ b/tests/unit/parsers/test_attribute_parser.py
@@ -28,12 +28,12 @@ class TestInjectionUsesTheRecipePorts(unittest.TestCase):
 
         handle = chain_parser.inject_chain(_expr("dc.a"), scope, nodes)
 
-        self.assertEqual(handle, _make_source("getattr_a_0", attr_port))
+        self.assertEqual(handle, _make_source("get_attr_0", attr_port))
         self.assertIn(
-            edge_models.TargetHandle(node="getattr_a_0", port=obj_port), scope.edges
+            edge_models.TargetHandle(node="get_attr_0", port=obj_port), scope.edges
         )
         self.assertIn(
-            edge_models.TargetHandle(node="getattr_a_0", port=name_port), scope.edges
+            edge_models.TargetHandle(node="get_attr_0", port=name_port), scope.edges
         )
 
 
@@ -42,11 +42,6 @@ class TestHandlerTracksTheRecipe(unittest.TestCase):
 
     def test_recipe_is_std_get_attr(self):
         self.assertIs(attribute_parser.HANDLER.recipe, std.get_attr.flowrep_recipe)
-
-    def test_label_base_embeds_the_attribute_name(self):
-        self.assertEqual(
-            attribute_parser.HANDLER.label_base(_expr("dc.a")), "getattr_a"
-        )
 
     def test_port_base_is_the_attribute_name(self):
         self.assertEqual(attribute_parser.HANDLER.port_base(_expr("dc.a")), "a")

--- a/tests/unit/parsers/test_chain_parser.py
+++ b/tests/unit/parsers/test_chain_parser.py
@@ -79,22 +79,22 @@ class TestInjectChain(unittest.TestCase):
         assert isinstance(node, ast.Attribute)
         handle = chain_parser.inject_chain(node, scope, nodes)
 
-        self.assertEqual(set(nodes), {"getattr_a_0", "constant_0"})
-        self.assertIs(nodes["getattr_a_0"], std.get_attr.flowrep_recipe)
+        self.assertEqual(set(nodes), {"get_attr_0", "constant_0"})
+        self.assertIs(nodes["get_attr_0"], std.get_attr.flowrep_recipe)
         self.assertIsInstance(nodes["constant_0"], constant_recipe.ConstantRecipe)
         self.assertEqual(nodes["constant_0"].constant, "a")
         self.assertEqual(
             scope.edges,
             {
-                edge_models.TargetHandle(node="getattr_a_0", port="obj"): _make_source(
+                edge_models.TargetHandle(node="get_attr_0", port="obj"): _make_source(
                     "MyDataclass_0", "instance"
                 ),
-                edge_models.TargetHandle(node="getattr_a_0", port="name"): _make_source(
+                edge_models.TargetHandle(node="get_attr_0", port="name"): _make_source(
                     "constant_0", "constant"
                 ),
             },
         )
-        self.assertEqual(handle, _make_source("getattr_a_0", "attr"))
+        self.assertEqual(handle, _make_source("get_attr_0", "attr"))
 
     def test_chain_of_two_links(self):
         scope = symbol_scope.SymbolScope(
@@ -106,13 +106,13 @@ class TestInjectChain(unittest.TestCase):
         handle = chain_parser.inject_chain(node, scope, nodes)
 
         self.assertEqual(
-            list(nodes), ["getattr_a_0", "constant_0", "getattr_val_0", "constant_1"]
+            list(nodes), ["get_attr_0", "constant_0", "get_attr_1", "constant_1"]
         )
         self.assertEqual(
-            scope.edges[edge_models.TargetHandle(node="getattr_val_0", port="obj")],
-            _make_source("getattr_a_0", "attr"),
+            scope.edges[edge_models.TargetHandle(node="get_attr_1", port="obj")],
+            _make_source("get_attr_0", "attr"),
         )
-        self.assertEqual(handle, _make_source("getattr_val_0", "attr"))
+        self.assertEqual(handle, _make_source("get_attr_1", "attr"))
 
     def test_root_is_workflow_input_creates_input_edge(self):
         scope = symbol_scope.SymbolScope({"comp": _make_input("comp")})
@@ -124,7 +124,7 @@ class TestInjectChain(unittest.TestCase):
         self.assertEqual(
             scope.input_edges,
             {
-                edge_models.TargetHandle(node="getattr_val_0", port="obj"): _make_input(
+                edge_models.TargetHandle(node="get_attr_0", port="obj"): _make_input(
                     "comp"
                 )
             },
@@ -140,7 +140,7 @@ class TestInjectChain(unittest.TestCase):
         assert isinstance(node1, ast.Attribute) and isinstance(node2, ast.Attribute)
         chain_parser.inject_chain(node1, scope, nodes)
         handle2 = chain_parser.inject_chain(node2, scope, nodes)
-        self.assertEqual(handle2.node, "getattr_a_1")
+        self.assertEqual(handle2.node, "get_attr_1")
 
     def test_accumulator_root_raises(self):
         scope = symbol_scope.SymbolScope({}, available_accumulators={"acc"})
@@ -149,6 +149,26 @@ class TestInjectChain(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             chain_parser.inject_chain(node, scope, {})
         self.assertIn("accumulator", str(ctx.exception).lower())
+
+
+class TestLabelBase(unittest.TestCase):
+    """Injected links carry the label the explicit call form mints.
+
+    The meaning of this rule is pinned end-to-end by
+    `test_parsing_attribute_access.TestAttributeAccessEndToEnd
+    .test_identical_to_the_std_call_form` and its item twin; this is the unit-level
+    statement of it.
+    """
+
+    def test_getattr_label_is_the_callee_name(self):
+        self.assertEqual(
+            chain_parser._label_base(std.get_attr.flowrep_recipe), "get_attr"
+        )
+
+    def test_getitem_label_is_the_callee_name(self):
+        self.assertEqual(
+            chain_parser._label_base(std.getitem.flowrep_recipe), "getitem"
+        )
 
 
 class TestRejectMethodCall(unittest.TestCase):
@@ -234,17 +254,17 @@ class TestInjectMixedChain(unittest.TestCase):
         self.assertEqual(
             list(nodes),
             [
-                "getattr_sub_0",
+                "get_attr_0",
                 "constant_0",
                 "getitem_0",
                 "constant_1",
                 "getitem_1",
                 "constant_2",
-                "getattr_val_0",
+                "get_attr_1",
                 "constant_3",
             ],
         )
-        self.assertEqual(handle, _make_source("getattr_val_0", "attr"))
+        self.assertEqual(handle, _make_source("get_attr_1", "attr"))
 
     def test_each_link_reads_from_the_previous(self):
         scope = symbol_scope.SymbolScope({"holder": _make_input("holder")})
@@ -252,7 +272,7 @@ class TestInjectMixedChain(unittest.TestCase):
         chain_parser.inject_chain(_expr("holder.sub['item']"), scope, nodes)
         self.assertEqual(
             scope.edges[edge_models.TargetHandle(node="getitem_0", port="a")],
-            _make_source("getattr_sub_0", "attr"),
+            _make_source("get_attr_0", "attr"),
         )
 
     def test_item_label_numbering_matches_the_std_call_form(self):

--- a/tests/unit/parsers/test_for_parser.py
+++ b/tests/unit/parsers/test_for_parser.py
@@ -169,9 +169,9 @@ class TestParseSingleForHeader(unittest.TestCase):
         self.assertEqual(axes[0].variable, "x")
         self.assertEqual(axes[0].port, "xs_0")
         self.assertEqual(
-            axes[0].binding, edge_models.SourceHandle(node="getattr_xs_0", port="attr")
+            axes[0].binding, edge_models.SourceHandle(node="get_attr_0", port="attr")
         )
-        self.assertIn("getattr_xs_0", nodes)
+        self.assertIn("get_attr_0", nodes)
 
 
 # ===================================================================

--- a/tests/unit/parsers/test_item_parser.py
+++ b/tests/unit/parsers/test_item_parser.py
@@ -22,11 +22,6 @@ class TestHandlerTracksTheRecipe(unittest.TestCase):
     def test_recipe_is_std_getitem(self):
         self.assertIs(item_parser.HANDLER.recipe, std.getitem.flowrep_recipe)
 
-    def test_label_base_matches_the_std_call_form(self):
-        """`d[k]` must mint the label `std.getitem(d, k)` would: that identity is what
-        lets the compiler round-trip item access without desugaring it."""
-        self.assertEqual(item_parser.HANDLER.label_base(_expr("d[0]")), "getitem")
-
     def test_port_base_is_the_recipes_output_port(self):
         (item_port,) = std.getitem.flowrep_recipe.outputs
         self.assertEqual(item_parser.HANDLER.port_base(_expr("d[0]")), item_port)

--- a/tests/unit/parsers/test_workflow_parser.py
+++ b/tests/unit/parsers/test_workflow_parser.py
@@ -1361,7 +1361,7 @@ class TestAttributeAccess(unittest.TestCase):
             return r
 
         node = workflow_parser.parse_workflow(wf)
-        self.assertIn("getattr_x_0", node.nodes)
+        self.assertIn("get_attr_0", node.nodes)
         constants = [
             n
             for n in node.nodes.values()
@@ -1369,7 +1369,7 @@ class TestAttributeAccess(unittest.TestCase):
         ]
         self.assertTrue(any(c.constant == "x" for c in constants))
         self.assertEqual(
-            node.edges[edge_models.TargetHandle(node="getattr_x_0", port="obj")],
+            node.edges[edge_models.TargetHandle(node="get_attr_0", port="obj")],
             edge_models.SourceHandle(node="MyDataclass_0", port="instance"),
         )
 
@@ -1380,11 +1380,11 @@ class TestAttributeAccess(unittest.TestCase):
             return v
 
         node = workflow_parser.parse_workflow(wf)
-        self.assertIn("getattr_a_0", node.nodes)
-        self.assertIn("getattr_val_0", node.nodes)
+        self.assertIn("get_attr_0", node.nodes)
+        self.assertIn("get_attr_1", node.nodes)
         self.assertEqual(
-            node.edges[edge_models.TargetHandle(node="getattr_val_0", port="obj")],
-            edge_models.SourceHandle(node="getattr_a_0", port="attr"),
+            node.edges[edge_models.TargetHandle(node="get_attr_1", port="obj")],
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
 
     def test_call_argument_each_access_is_its_own_node(self):
@@ -1394,8 +1394,8 @@ class TestAttributeAccess(unittest.TestCase):
             return r
 
         node = workflow_parser.parse_workflow(wf)
-        self.assertIn("getattr_x_0", node.nodes)
-        self.assertIn("getattr_x_1", node.nodes)
+        self.assertIn("get_attr_0", node.nodes)
+        self.assertIn("get_attr_1", node.nodes)
 
     def test_hoisting_invariant_call_argument_form(self):
         def hoisted(x0: int, comp: library.ComplexData):
@@ -1442,9 +1442,7 @@ class TestAttributeAccess(unittest.TestCase):
 
         node = workflow_parser.parse_workflow(wf)
         self.assertEqual(
-            node.input_edges[
-                edge_models.TargetHandle(node="getattr_val_0", port="obj")
-            ],
+            node.input_edges[edge_models.TargetHandle(node="get_attr_0", port="obj")],
             edge_models.InputSource(port="comp"),
         )
 
@@ -1506,13 +1504,13 @@ class TestAttributeAccess(unittest.TestCase):
 
         node = workflow_parser.parse_workflow(wf)
         # The getattr node is a peer of the `if`, not inside it.
-        self.assertIn("getattr_x_0", node.nodes)
+        self.assertIn("get_attr_0", node.nodes)
         self.assertIn("if_0", node.nodes)
         # ...and it feeds the flow control through a port named after the symbol.
         self.assertIn("flag", node.nodes["if_0"].inputs)
         self.assertEqual(
             node.edges[edge_models.TargetHandle(node="if_0", port="flag")],
-            edge_models.SourceHandle(node="getattr_x_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
 
     def test_multi_target_attribute_assignment_raises(self):
@@ -1583,7 +1581,7 @@ class TestAttributeAccess(unittest.TestCase):
         self.assertEqual(node.outputs, ["v"])
         self.assertEqual(
             node.output_edges[edge_models.OutputTarget(port="v")],
-            edge_models.SourceHandle(node="getattr_a_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
 
     def test_return_no_value_raises(self):
@@ -1641,16 +1639,16 @@ class TestAttributeAccess(unittest.TestCase):
         body = for_node.body_node.recipe
         # Two accesses to the same attribute of two different objects are two
         # distinct nodes feeding two distinctly-named ports. This is the defect.
-        self.assertIn("getattr_a_0", body.nodes)
-        self.assertIn("getattr_a_1", body.nodes)
+        self.assertIn("get_attr_0", body.nodes)
+        self.assertIn("get_attr_1", body.nodes)
         self.assertEqual(body.outputs, ["first", "second"])
         self.assertEqual(
             body.output_edges[edge_models.OutputTarget(port="first")],
-            edge_models.SourceHandle(node="getattr_a_0", port="attr"),
+            edge_models.SourceHandle(node="get_attr_0", port="attr"),
         )
         self.assertEqual(
             body.output_edges[edge_models.OutputTarget(port="second")],
-            edge_models.SourceHandle(node="getattr_a_1", port="attr"),
+            edge_models.SourceHandle(node="get_attr_1", port="attr"),
         )
 
 


### PR DESCRIPTION
So that parsing `dc.a` renders the _exact_ same recipe as parsing `std.get_attr(dc, "a")`. This way the compiler can safely render to either -- before this round-tripping depended on `flowrep.compiler.sugar` behaving perfectly.