### PR TITLE
Render compiled item access with []

### DIFF
--- a/src/flowrep/compiler/statements.py
+++ b/src/flowrep/compiler/statements.py
@@ -270,19 +270,22 @@ def emit_workflow_body(
             )
         required_by_handle[handle] = name
 
-    def _obj_source(
-        label: str,
+    def _port_source(
+        label: str, port: str
     ) -> edge_models.SourceHandle | edge_models.InputSource | None:
-        target = edge_models.TargetHandle(node=label, port=sugar.OBJ_PORT)
+        target = edge_models.TargetHandle(node=label, port=port)
         return recipe.input_edges.get(target) or recipe.edges.get(target)
 
-    def _obj_is_symbolic(label: str) -> bool:
-        """True if the getattr's object resolves to a symbol we can write '.' after.
+    def _obj_is_symbolic(label: str, obj_port: str) -> bool:
+        """True if the access node's object resolves to a symbol we can subscript or
+        write '.' after.
 
-        An object fed by an *inlined* constant would sugar to nonsense (``5 .a``), so
-        such a node keeps the plain-call emission. The parser cannot produce one.
+        An object fed by an *inlined* constant would sugar to nonsense (``5 .a``), or --
+        for an item -- to legal syntax that re-parses to a different recipe (``[1, 2][0]``
+        is not rooted at a symbol). Either way such a node keeps the plain-call emission.
+        The parser cannot produce one.
         """
-        source = _obj_source(label)
+        source = _port_source(label, obj_port)
         if source is None:
             return False
         if isinstance(source, edge_models.InputSource):
@@ -292,28 +295,41 @@ def emit_workflow_body(
             return source.node in materialized_constants
         return True
 
-    # A recognised getattr node is emitted as attribute syntax -- `sym = obj.attr`
-    # -- always as its own statement, never inlined into a consumer's argument list.
+    # A recognised getattr or getitem node is emitted as native syntax -- `sym = obj.attr`
+    # or `sym = obj[key]` -- always as its own statement, never inlined into a consumer's
+    # argument list.
     #
-    # Inlining would be prettier (`f(dc.a)`, `dc.a.val`) but it is not safe. The
-    # parser injects a getattr node together with a `ConstantRecipe` peer carrying the
-    # attribute name, and constant labels come from one shared `constant_N` counter
-    # over the whole workflow. Inlining moves a getattr's creation to its consumer's
-    # statement, which reorders that name-constant relative to every *other* constant
-    # in the workflow (e.g. a literal call argument) and permutes the counter. The
-    # recipe would still execute identically, but it would not re-parse to an equal
-    # one. Emitting one statement per getattr, in topological order, reproduces the
-    # parser's injection order exactly, so the round trip is exact.
+    # Inlining would be prettier (`f(dc.a)`, `dc.a.val`, `d['a']['b']`) but it is not
+    # safe. The parser injects an access node together with any `ConstantRecipe` peer,
+    # and constant labels come from one shared `constant_N` counter over the whole
+    # workflow. Inlining moves an access node's creation to its consumer's statement,
+    # which reorders that constant relative to every *other* constant in the workflow
+    # (e.g. a literal call argument) and permutes the counter. The recipe would still
+    # execute identically, but it would not re-parse to an equal one. Emitting one
+    # statement per access, in topological order, reproduces the parser's injection order
+    # exactly, so the round trip is exact.
     #
     # Materialising also gives the efficiency guarantee for free: one node, one
-    # statement, one symbol -- a getattr consumed by several nodes stays a single
+    # statement, one symbol -- an access consumed by several nodes stays a single
     # node on re-parse rather than being duplicated into each consumer.
-    sugared: dict[str, str] = {
+    sugared_attrs: dict[str, str] = {
         label: attr_name
         for label, node in recipe.nodes.items()
         if sugar.is_std_getattr(node)
         and (attr_name := sugar.attribute_name(label, recipe)) is not None
-        and _obj_is_symbolic(label)
+        and _obj_is_symbolic(label, sugar.ATTR_OBJ_PORT)
+    }
+
+    # The key-source check is the getitem analogue of `attribute_name` returning None: it
+    # refuses a hand-built recipe whose key edge is missing, which would otherwise reach
+    # `resolve(None)`. No syntax check is needed -- `resolve` renders a constant key as a
+    # literal and any other key as its symbol, and both are legal between brackets.
+    sugared_items: set[str] = {
+        label
+        for label, node in recipe.nodes.items()
+        if sugar.is_std_getitem(node)
+        and _port_source(label, sugar.KEY_PORT) is not None
+        and _obj_is_symbolic(label, sugar.ITEM_OBJ_PORT)
     }
 
     for label in _topological_nodes(recipe):
@@ -331,13 +347,23 @@ def emit_workflow_body(
             )
             continue
 
-        if label in sugared:
+        if label in sugared_attrs:
             name = required_by_handle.get((label, sugar.ATTR_PORT)) or alloc.fresh(
                 _output_name_suggestion(label, sugar.ATTR_PORT, 1)
             )
             produced[(label, sugar.ATTR_PORT)] = name
-            obj = resolve(_obj_source(label))
-            lines.append(f"{name} = {obj}.{sugared[label]}")
+            obj = resolve(_port_source(label, sugar.ATTR_OBJ_PORT))
+            lines.append(f"{name} = {obj}.{sugared_attrs[label]}")
+            continue
+
+        if label in sugared_items:
+            name = required_by_handle.get((label, sugar.ITEM_PORT)) or alloc.fresh(
+                _output_name_suggestion(label, sugar.ITEM_PORT, 1)
+            )
+            produced[(label, sugar.ITEM_PORT)] = name
+            obj = resolve(_port_source(label, sugar.ITEM_OBJ_PORT))
+            key = resolve(_port_source(label, sugar.KEY_PORT))
+            lines.append(f"{name} = {obj}[{key}]")
             continue
 
         call_path = node_call_path(node, label, emitter, alloc)

--- a/src/flowrep/compiler/sugar.py
+++ b/src/flowrep/compiler/sugar.py
@@ -15,10 +15,19 @@ from flowrep.prospective import (
 _GETATTR = cast(atomic_recipe.AtomicRecipe, std.get_attr.flowrep_recipe)  # type: ignore[attr-defined]
 _GETATTR_FQN = _GETATTR.reference.info.fully_qualified_name
 
-# Port names are derived from the recipe, never spelled out: editing `std.getattr_`
-# must not require editing strings anywhere else in the source.
-OBJ_PORT, NAME_PORT = _GETATTR.inputs
+# Port names are derived from the recipe, never spelled out: editing `std.get_attr` or
+# `std.getitem` must not require editing strings anywhere else in the source. The two
+# object ports differ -- `obj` for get_attr, `a` for getitem, which inherits
+# `operator.getitem(a, b)`'s signature -- so each is named for its own link kind.
+ATTR_OBJ_PORT, NAME_PORT = _GETATTR.inputs
 (ATTR_PORT,) = _GETATTR.outputs
+
+# `LabeledRecipe.recipe` is a discriminated union; the cast narrows it for mypy.
+_GETITEM = cast(atomic_recipe.AtomicRecipe, std.getitem.flowrep_recipe)  # type: ignore[attr-defined]
+_GETITEM_FQN = _GETITEM.reference.info.fully_qualified_name
+
+ITEM_OBJ_PORT, KEY_PORT = _GETITEM.inputs
+(ITEM_PORT,) = _GETITEM.outputs
 
 
 def is_std_getattr(node: union_types.RecipeDiscrimination) -> bool:
@@ -33,6 +42,21 @@ def is_std_getattr(node: union_types.RecipeDiscrimination) -> bool:
         and node.reference.info.fully_qualified_name == _GETATTR_FQN
         and node.inputs == _GETATTR.inputs
         and node.outputs == _GETATTR.outputs
+    )
+
+
+def is_std_getitem(node: union_types.RecipeDiscrimination) -> bool:
+    """True if *node* is the standard-library item-access recipe.
+
+    Matched on the referenced function's fully qualified name rather than on
+    ``VersionInfo`` equality, so a recipe serialised under a different flowrep
+    version is still recognised.
+    """
+    return (
+        isinstance(node, atomic_recipe.AtomicRecipe)
+        and node.reference.info.fully_qualified_name == _GETITEM_FQN
+        and node.inputs == _GETITEM.inputs
+        and node.outputs == _GETITEM.outputs
     )
 
 

--- a/tests/integration/parsers/test_parsing_item_access.py
+++ b/tests/integration/parsers/test_parsing_item_access.py
@@ -69,6 +69,13 @@ class TestComplexKeyFromAnotherStep(unittest.TestCase):
             makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
         )
 
+    def test_compiled_source_is_sugared(self):
+        """A symbolic key renders as a symbol, which also pins the ordering: `resolve`
+        can only name the key's node if the topological sort emitted it first."""
+        rendered = source._workflow2python(makers.reference_free(item_symbol_key))
+        self.assertRegex(rendered.source, r"\n\s*\w+ = (\w+)\[(\w+)\]\n")
+        self.assertNotIn("flowrep.std.getitem(", rendered.source)
+
 
 @workflow_parser.workflow
 def item_from_inputs(
@@ -140,6 +147,14 @@ class TestConstantKeys(unittest.TestCase):
             makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
         )
 
+    def test_compiled_source_is_sugared(self):
+        rendered = source._workflow2python(makers.reference_free(item_constant_keys))
+        # Subscript syntax, one statement per access -- never a call to the underlying
+        # std wrapper.
+        self.assertIn("['mass']", rendered.source)
+        self.assertIn("[0]", rendered.source)
+        self.assertNotIn("flowrep.std.getitem(", rendered.source)
+
 
 @workflow_parser.workflow
 def mixed_chain(holder: library.Nested):
@@ -196,6 +211,15 @@ class TestMixedChain(unittest.TestCase):
         self.assertEqual(
             makers.dump_no_refs(fn.flowrep_recipe), makers.dump_no_refs(free)
         )
+
+    def test_compiled_source_is_sugared(self):
+        """Both syntaxes in one chain: the hybrid rendering is what this replaces."""
+        rendered = source._workflow2python(makers.reference_free(mixed_chain))
+        self.assertIn(".sub", rendered.source)
+        self.assertIn("['item']", rendered.source)
+        self.assertIn("['subitem']", rendered.source)
+        self.assertIn(".val", rendered.source)
+        self.assertNotIn("flowrep.std.getitem(", rendered.source)
 
 
 class TestRejections(unittest.TestCase):

--- a/tests/unit/compiler/test_sugar.py
+++ b/tests/unit/compiler/test_sugar.py
@@ -31,6 +31,26 @@ class TestIsStdGetattr(unittest.TestCase):
         self.assertFalse(sugar.is_std_getattr(recipe))
 
 
+class TestIsStdGetitem(unittest.TestCase):
+    def test_true_for_std_getitem_recipe(self):
+        self.assertTrue(sugar.is_std_getitem(std.getitem.flowrep_recipe))
+
+    def test_false_for_other_atomic(self):
+        self.assertFalse(sugar.is_std_getitem(std.add.flowrep_recipe))
+
+    def test_false_for_std_getattr(self):
+        self.assertFalse(sugar.is_std_getitem(std.get_attr.flowrep_recipe))
+
+    def test_false_for_constant_recipe(self):
+        self.assertFalse(
+            sugar.is_std_getitem(constant_recipe.ConstantRecipe(constant=1))
+        )
+
+    def test_false_for_workflow_recipe(self):
+        recipe = makers.reference_free(_wf)
+        self.assertFalse(sugar.is_std_getitem(recipe))
+
+
 class TestIsAttributeSyntax(unittest.TestCase):
     def test_true_cases(self):
         for value in ("a", "inputs", "_x", "__class__"):
@@ -62,13 +82,13 @@ class TestAttributeName(unittest.TestCase):
         )
         # Rewire the name port to come from a non-constant node output instead of a
         # constant peer -- a shape only hand-construction produces.
-        target = edge_models.TargetHandle(node="getattr_a_0", port="name")
+        target = edge_models.TargetHandle(node="get_attr_0", port="name")
         new_edges = dict(recipe.edges)
         new_edges[target] = edge_models.SourceHandle(
             node="MyDataclass_0", port="instance"
         )
         recipe = recipe.model_copy(update={"edges": new_edges})
-        self.assertIsNone(sugar.attribute_name("getattr_a_0", recipe))
+        self.assertIsNone(sugar.attribute_name("get_attr_0", recipe))
 
     def test_none_when_constant_is_non_identifier_string(self):
         recipe = workflow_parser.parse_workflow(_wf).model_copy(
@@ -77,28 +97,39 @@ class TestAttributeName(unittest.TestCase):
         new_nodes = dict(recipe.nodes)
         new_nodes["constant_0"] = constant_recipe.ConstantRecipe(constant="not an id!")
         recipe = recipe.model_copy(update={"nodes": new_nodes})
-        self.assertIsNone(sugar.attribute_name("getattr_a_0", recipe))
+        self.assertIsNone(sugar.attribute_name("get_attr_0", recipe))
 
     def test_none_when_name_port_unwired(self):
         recipe = workflow_parser.parse_workflow(_wf).model_copy(
             update={"reference": None}
         )
-        target = edge_models.TargetHandle(node="getattr_a_0", port="name")
+        target = edge_models.TargetHandle(node="get_attr_0", port="name")
         new_edges = {k: v for k, v in recipe.edges.items() if k != target}
         recipe = recipe.model_copy(update={"edges": new_edges})
-        self.assertIsNone(sugar.attribute_name("getattr_a_0", recipe))
+        self.assertIsNone(sugar.attribute_name("get_attr_0", recipe))
 
 
 class TestPortConstantsTrackTheRecipe(unittest.TestCase):
-    """Editing std.getattr_'s ports must not require editing strings in src/."""
+    """Editing std.get_attr's or std.getitem's ports must not require editing strings
+    in src/."""
 
-    def test_input_ports_come_from_the_recipe(self):
+    def test_getattr_input_ports_come_from_the_recipe(self):
         self.assertEqual(
-            (sugar.OBJ_PORT, sugar.NAME_PORT), tuple(std.get_attr.flowrep_recipe.inputs)
+            (sugar.ATTR_OBJ_PORT, sugar.NAME_PORT),
+            tuple(std.get_attr.flowrep_recipe.inputs),
         )
 
-    def test_output_port_comes_from_the_recipe(self):
+    def test_getattr_output_port_comes_from_the_recipe(self):
         self.assertEqual((sugar.ATTR_PORT,), tuple(std.get_attr.flowrep_recipe.outputs))
+
+    def test_getitem_input_ports_come_from_the_recipe(self):
+        self.assertEqual(
+            (sugar.ITEM_OBJ_PORT, sugar.KEY_PORT),
+            tuple(std.getitem.flowrep_recipe.inputs),
+        )
+
+    def test_getitem_output_port_comes_from_the_recipe(self):
+        self.assertEqual((sugar.ITEM_PORT,), tuple(std.getitem.flowrep_recipe.outputs))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of the raw `std.getitem...`, because it's prettier this way. Recipes are identical.