### PR TITLE
Remove dataclass unpack

### DIFF
--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -301,7 +301,6 @@
     "|---|---|---|\n",
     "| `TUPLE` (default) | Unpack return as a tuple | One port per element |\n",
     "| `NONE` | Treat return as a single value | Exactly one port |\n",
-    "| `DATACLASS` | Unpack return as a dataclass | One port per field |\n",
     "\n",
     "#### `TUPLE` mode (default)\n",
     "\n",
@@ -436,86 +435,6 @@
    "id": "1c301250",
    "metadata": {},
    "source": [
-    "#### `DATACLASS` mode\n",
-    "\n",
-    "When a function returns a dataclass instance, this mode names outputs after the\n",
-    "dataclass fields. The function must have a dataclass return-type annotation and\n",
-    "must return a single value:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "0d46e437",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.016177Z",
-     "start_time": "2026-07-11T03:59:26.999641Z"
-    }
-   },
-   "source": [
-    "import dataclasses\n",
-    "\n",
-    "\n",
-    "@dataclasses.dataclass\n",
-    "class Point:\n",
-    "    x: float\n",
-    "    y: float\n",
-    "\n",
-    "\n",
-    "@fr.atomic(unpack_mode=fr.schemas.UnpackMode.DATACLASS)\n",
-    "def make_point(x, y) -> Point:\n",
-    "    return Point(x, y)\n",
-    "\n",
-    "\n",
-    "print(f\"Outputs: {make_point.flowrep_recipe.outputs}\")\n",
-    "assert(make_point.flowrep_recipe.outputs == ['x', 'y'])"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outputs: ['x', 'y']\n"
-     ]
-    }
-   ],
-   "execution_count": 9
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "This unpacking mode is an instruction for flowrep and WfMS -- it doesn't impact the decorated function. The decorated function still just returns the dataclass instance:",
-   "id": "95a09d3e500b1b87"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.066635Z",
-     "start_time": "2026-07-11T03:59:27.027778Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "make_point(1, 2)",
-   "id": "bebb33c6345c3ab9",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Point(x=1, y=2)"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 10
-  },
-  {
-   "cell_type": "markdown",
-   "id": "637a194b",
-   "metadata": {},
-   "source": [
     "### 1.4 Annotated output labels\n",
     "\n",
     "For finer control, you can name outputs via `typing.Annotated` metadata on the\n",
@@ -525,11 +444,11 @@
   },
   {
    "cell_type": "code",
-   "id": "77276c40",
+   "id": "0d46e437",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.086897Z",
-     "start_time": "2026-07-11T03:59:27.077624Z"
+     "end_time": "2026-07-11T03:59:27.016177Z",
+     "start_time": "2026-07-11T03:59:26.999641Z"
     }
    },
    "source": [
@@ -556,33 +475,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Outputs: ['magnitude', 'angle']\n"
+      "Outputs: ['x', 'y']\n"
      ]
     }
    ],
-   "execution_count": 11
+   "execution_count": 9
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "2af1f0c2",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
    "source": [
     "Annotation labels take precedence over AST-scraped variable names. Positions\n",
     "without annotations fall back to the scraped name. You can also override information\n",
     "in the function altogether and pass output label strings directly to the decorator:"
-   ]
+   ],
+   "id": "95a09d3e500b1b87"
   },
   {
-   "cell_type": "code",
-   "id": "a4019caa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.148721Z",
-     "start_time": "2026-07-11T03:59:27.098162Z"
+     "end_time": "2026-07-11T03:59:27.066635Z",
+     "start_time": "2026-07-11T03:59:27.027778Z"
     }
    },
+   "cell_type": "code",
    "source": [
     "@fr.atomic(\"my_magnitude\", \"my_angle\")\n",
     "def norm2(\n",
@@ -598,20 +514,24 @@
     "print(f\"Outputs: {norm2.flowrep_recipe.outputs}\")\n",
     "assert(norm2.flowrep_recipe.outputs == ['my_magnitude', 'my_angle'])"
    ],
+   "id": "bebb33c6345c3ab9",
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outputs: ['my_magnitude', 'my_angle']\n"
-     ]
+     "data": {
+      "text/plain": [
+       "Point(x=1, y=2)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "execution_count": 12
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",
-   "id": "db05bb2e",
+   "id": "637a194b",
    "metadata": {},
    "source": [
     "### 1.5 The `PythonReference` and provenance\n",
@@ -626,11 +546,11 @@
   },
   {
    "cell_type": "code",
-   "id": "b8f03ee2",
+   "id": "77276c40",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.220959Z",
-     "start_time": "2026-07-11T03:59:27.150738Z"
+     "end_time": "2026-07-11T03:59:27.086897Z",
+     "start_time": "2026-07-11T03:59:27.077624Z"
     }
    },
    "source": [
@@ -648,21 +568,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Module:           __main__\n",
-      "Qualname:         add\n",
-      "Version:          None\n",
-      "FQN:              __main__.add\n",
-      "Defaults:         []\n",
-      "Restricted kinds: {}\n"
+      "Outputs: ['magnitude', 'angle']\n"
      ]
     }
    ],
-   "execution_count": 13
+   "execution_count": 11
   },
   {
    "cell_type": "markdown",
-   "id": "02ccd920",
-   "metadata": {},
+   "id": "2af1f0c2",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Since `add` is defined in `__main__` (this notebook), it has no package version.\n",
     "For a function from a published package, the version would be populated\n",
@@ -671,8 +588,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66ac7ffa",
-   "metadata": {},
+   "id": "a4019caa",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.148721Z",
+     "start_time": "2026-07-11T03:59:27.098162Z"
+    }
+   },
    "source": [
     "The `fully_qualified_name` property (`module.qualname`) is the string a WfMS\n",
     "would use to `import` and call the function. Recipes are only truly reusable if\n",
@@ -686,25 +608,26 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "db05bb2e",
+   "metadata": {},
    "source": [
     "### 1.6 Class atomic recipes\n",
     "\n",
     "Most of the time an atomic recipe will center around a function, but you can also parse and decorate classes into recipes. The resulting recipe takes the creation arguments as input, and returns a single `\"instance\"` output port for an instance of that class.\n",
     "\n",
     "Similarly, methods and static methods inside classes are just functions we can decorate and assign recipes. Note that when you make a recipe out of a regular method, it really does expect an instance of the class as the first input:"
-   ],
-   "id": "bdb1f0becd5134e5"
+   ]
   },
   {
+   "cell_type": "code",
+   "id": "b8f03ee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.261236Z",
-     "start_time": "2026-07-11T03:59:27.241863Z"
+     "end_time": "2026-07-11T03:59:27.220959Z",
+     "start_time": "2026-07-11T03:59:27.150738Z"
     }
    },
-   "cell_type": "code",
    "source": [
     "import flowrep as fr\n",
     "\n",
@@ -734,6 +657,68 @@
     "        decorated.flowrep_recipe.outputs\n",
     "    )"
    ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Module:           __main__\n",
+      "Qualname:         add\n",
+      "Version:          None\n",
+      "FQN:              __main__.add\n",
+      "Defaults:         []\n",
+      "Restricted kinds: {}\n"
+     ]
+    }
+   ],
+   "execution_count": 13
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02ccd920",
+   "metadata": {},
+   "source": "This also works trivially for dataclasses --  you can stack the decorators together, or use the `flowrep.dataclass` decorator to do both at once for you. Just like the decorated objects, these stay as usual dataclasses but get their `.flowrep_recipe` attached:"
+  },
+  {
+   "cell_type": "code",
+   "id": "66ac7ffa",
+   "metadata": {},
+   "source": [
+    "import dataclasses\n",
+    "\n",
+    "@fr.dataclass\n",
+    "class MyDataclass:\n",
+    "    a: str\n",
+    "    x: int = 1\n",
+    "\n",
+    "print(\"Dataclass?\", dataclasses.is_dataclass(MyDataclass))\n",
+    "print(\"Recipe?\", type(MyDataclass.flowrep_recipe))\n",
+    "MyDataclass.flowrep_recipe.inputs, MyDataclass.flowrep_recipe.outputs"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Dataclasses also get a `.flowrep_recipe_inverse` -- a recipe going the other direction, unpacking an instance's fields into separate outputs. It's a normal callable, so calling the recipe and calling python agree exactly:",
+   "id": "bdb1f0becd5134e5"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.261236Z",
+     "start_time": "2026-07-11T03:59:27.241863Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "instance = MyDataclass(a=\"hello\", x=7)\n",
+    "\n",
+    "print(\"Inverse inputs: \", MyDataclass.flowrep_recipe_inverse.inputs)\n",
+    "print(\"Inverse outputs:\", MyDataclass.flowrep_recipe_inverse.outputs)\n",
+    "MyDataclass.flowrep_recipe_inverse(instance)"
+   ],
    "id": "915053248a94e896",
    "outputs": [
     {
@@ -751,7 +736,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "This also works trivially for dataclasses --  you can stack the decorators together, or use the `flowrep.dataclass` decorator to do both at once for you. Just like the decorated objects, these stay as usual dataclasses but get their `.flowrep_recipe` attached:",
+   "source": "If you only want a single field rather than the whole dataclass, `@fr.workflow`-decorated functions inject a `fr.std.get_attr` node for you on attribute access, so `instance.a` inside a workflow just works.",
    "id": "acb61dfa571f0a0"
   },
   {
@@ -761,47 +746,9 @@
      "start_time": "2026-07-11T03:59:27.262256Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "import dataclasses\n",
-    "\n",
-    "@fr.dataclass\n",
-    "class MyDataclass:\n",
-    "    a: str\n",
-    "    x: int = 1\n",
-    "\n",
-    "print(\"Dataclass?\", dataclasses.is_dataclass(MyDataclass))\n",
-    "print(\"Recipe?\", type(MyDataclass.flowrep_recipe))\n",
-    "MyDataclass.flowrep_recipe.inputs, MyDataclass.flowrep_recipe.outputs"
-   ],
-   "id": "e10b7383753d5d86",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataclass? True\n",
-      "Recipe? <class 'flowrep.prospective.atomic_recipe.AtomicRecipe'>\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(['a', 'x'], ['instance'])"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 15
-  },
-  {
-   "metadata": {},
    "cell_type": "markdown",
    "source": "**Limitations**: `@staticmethod` only works when the decorators are applied in the right order; `@classmethod` doesn't work at all; classes defining a custom `__new__` will fail to parse cleanly; classes defining a class-level `flowrep_recipe` field (classvar or method) will fail cleanly.",
-   "id": "ec98d006c8259b8e"
+   "id": "e10b7383753d5d86"
   },
   {
    "metadata": {},
@@ -818,15 +765,10 @@
     "a recipe that exposes only a safe subset of inputs, relying on Python defaults\n",
     "for the rest:"
    ],
-   "id": "cd048745aefa7acc"
+   "id": "ec98d006c8259b8e"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.297043Z",
-     "start_time": "2026-07-11T03:59:27.283303Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "import numpy as np\n",
@@ -844,40 +786,31 @@
     "print(f\"Inputs:  {linspace_node.inputs}\")\n",
     "print(f\"Outputs: {linspace_node.outputs}\")"
    ],
-   "id": "8b5f8794c3dcd24d",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inputs:  ['start', 'stop', 'num']\n",
-      "Outputs: ['samples']\n"
-     ]
-    }
-   ],
-   "execution_count": 16
+   "id": "cd048745aefa7acc",
+   "outputs": [],
+   "execution_count": null
   },
   {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.297043Z",
+     "start_time": "2026-07-11T03:59:27.283303Z"
+    }
+   },
    "cell_type": "markdown",
-   "id": "67cf6163",
-   "metadata": {},
    "source": [
     "**Forcing consistent argument passing.** `numpy.arange` interprets positional\n",
     "arguments differently depending on how many you pass: `arange(stop)` vs\n",
     "`arange(start, stop, step)`. A WfMS needs a single, unambiguous calling convention.\n",
     "We can use `restricted_input_kinds` to force keyword-only passing, removing all\n",
     "positional ambiguity:"
-   ]
+   ],
+   "id": "8b5f8794c3dcd24d"
   },
   {
    "cell_type": "code",
-   "id": "1037ac27",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.313779Z",
-     "start_time": "2026-07-11T03:59:27.297985Z"
-    }
-   },
+   "id": "67cf6163",
+   "metadata": {},
    "source": [
     "arange_node = fr.schemas.AtomicRecipe(\n",
     "    reference=fr.schemas.PythonReference(\n",
@@ -895,21 +828,18 @@
     ")\n",
     "print(f\"Restricted kinds: {arange_node.reference.restricted_input_kinds}\")"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Restricted kinds: {'start': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'stop': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'step': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>}\n"
-     ]
-    }
-   ],
-   "execution_count": 17
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "8064bc26",
-   "metadata": {},
+   "id": "1037ac27",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.313779Z",
+     "start_time": "2026-07-11T03:59:27.297985Z"
+    }
+   },
    "source": [
     "The recipe now tells any WfMS: \"call this function with keyword arguments only,\n",
     "and `start` and `step` have defaults.\" The WfMS can then always call\n",
@@ -921,13 +851,21 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "8064bc26",
+   "metadata": {},
    "source": [
     "Atomic nodes also implement a `__call__` method which naively imports the underlying reference and passes all args and kwargs to it.\n",
     "In the even that the recipe has been written consistently with the underlying function, this will result in a perfectly valid execution of that function:"
-   ],
-   "id": "d0b951260802626c"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "arange_node(start=1, stop=2, step=3)",
+   "id": "d0b951260802626c",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -936,70 +874,16 @@
      "start_time": "2026-07-11T03:59:27.317556Z"
     }
    },
-   "cell_type": "code",
-   "source": "arange_node(start=1, stop=2, step=3)",
-   "id": "f0bac0d25a93b5fa",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1])"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 18
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "Recall: atomic-decorated functions with `unpack_mode=\"dataclass\"`  still just returned the raw dataclass their python code suggests. When we call the _recipe_ for `\"dataclass\"`-unpacked functions, we'll get the decomposed values:",
-   "id": "396728243a8a212e"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.346151Z",
-     "start_time": "2026-07-11T03:59:27.332863Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "make_point(1, 2), make_point.flowrep_recipe(1, 2)",
-   "id": "5e2b36c02de9cb22",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Point(x=1, y=2), (1, 2))"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 19
-  },
-  {
-   "metadata": {},
    "cell_type": "markdown",
    "source": [
     "**Handling variadics.** The graph-based approach requires that IO all be explicitly labeled, which means that python's variadic signatures pose a problem. If we know something about how those variadics should behave, we can get a workaround by exposing a fixed subset of variadics.\n",
     "\n",
     "E.g., if a function author exposes `**kwargs`, but we know a particular set of kwargs that should be used we can specify a particular recipe for this function exposing those kwargs:"
    ],
-   "id": "c24743c2e8ff6ddb"
+   "id": "f0bac0d25a93b5fa"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.360882Z",
-     "start_time": "2026-07-11T03:59:27.347172Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "def my_dict_maker(**kwargs):\n",
@@ -1020,53 +904,45 @@
     ")\n",
     "print(f\"Restricted kinds: {my_particular_dict_recipe.reference.restricted_input_kinds}\")"
    ],
-   "id": "d4026a680946afca",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Restricted kinds: {'this': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'that': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'the_other': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>}\n"
-     ]
-    }
-   ],
-   "execution_count": 20
+   "id": "396728243a8a212e",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.375564Z",
-     "start_time": "2026-07-11T03:59:27.362210Z"
+     "end_time": "2026-07-11T03:59:27.346151Z",
+     "start_time": "2026-07-11T03:59:27.332863Z"
     }
    },
    "cell_type": "code",
    "source": "my_particular_dict_recipe(this=1, that=2, the_other=3)",
-   "id": "3a6051ff2f2da9e0",
+   "id": "5e2b36c02de9cb22",
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'this': 1, 'that': 2, 'the_other': 3}"
+       "(Point(x=1, y=2), (1, 2))"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 21
+   "execution_count": 19
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "We can play similar tricks to handle positional variadics, e.g.",
-   "id": "4ef16bf07dc23b4a"
+   "id": "c24743c2e8ff6ddb"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.391960Z",
-     "start_time": "2026-07-11T03:59:27.377483Z"
+     "end_time": "2026-07-11T03:59:27.360882Z",
+     "start_time": "2026-07-11T03:59:27.347172Z"
     }
    },
    "cell_type": "code",
@@ -1093,54 +969,56 @@
     ")\n",
     "print(f\"Restricted kinds: {my_offset_sum.reference.restricted_input_kinds}\")"
    ],
-   "id": "b467569b70654cb6",
+   "id": "d4026a680946afca",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Restricted kinds: {'a': <RestrictedParamKind.POSITIONAL_ONLY: 'POSITIONAL_ONLY'>, 'b': <RestrictedParamKind.POSITIONAL_ONLY: 'POSITIONAL_ONLY'>}\n"
+      "Restricted kinds: {'this': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'that': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'the_other': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>}\n"
      ]
     }
    ],
-   "execution_count": 22
+   "execution_count": 20
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.405635Z",
-     "start_time": "2026-07-11T03:59:27.393499Z"
+     "end_time": "2026-07-11T03:59:27.375564Z",
+     "start_time": "2026-07-11T03:59:27.362210Z"
     }
    },
    "cell_type": "code",
    "source": "my_offset_sum(1, 2, offset=3)",
-   "id": "ca3cb2598c788de5",
+   "id": "3a6051ff2f2da9e0",
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "6"
+       "{'this': 1, 'that': 2, 'the_other': 3}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 23
+   "execution_count": 21
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "In these cases the recipe winds up more specific than the function, but the function is still usable in a workflow recipe.",
-   "id": "d24e981330e5f22"
+   "id": "4ef16bf07dc23b4a"
   },
   {
-   "cell_type": "markdown",
-   "id": "c4ce2025",
    "metadata": {
-    "lines_to_next_cell": 2
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.391960Z",
+     "start_time": "2026-07-11T03:59:27.377483Z"
+    }
    },
+   "cell_type": "markdown",
    "source": [
     "---\n",
     "## 2. Workflows\n",
@@ -1157,17 +1035,17 @@
     "- A single `return` statement\n",
     "\n",
     "(We'll see later that control flow and imports are also supported.)"
-   ]
+   ],
+   "id": "b467569b70654cb6"
   },
   {
-   "cell_type": "code",
-   "id": "d39608c2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.428582Z",
-     "start_time": "2026-07-11T03:59:27.407171Z"
+     "end_time": "2026-07-11T03:59:27.405635Z",
+     "start_time": "2026-07-11T03:59:27.393499Z"
     }
    },
+   "cell_type": "code",
    "source": [
     "@fr.atomic\n",
     "def add(a, b):\n",
@@ -1194,6 +1072,58 @@
     "print(f\"Recipe type: {type(linear.flowrep_recipe).__name__}\")\n",
     "linear.flowrep_recipe"
    ],
+   "id": "ca3cb2598c788de5",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 23
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "The parsed workflow has:\n",
+    "- **inputs**: `[\"x\", \"slope\", \"intercept\"]` — the function parameters.\n",
+    "- **outputs**: `[\"result\"]` — from the return statement.\n",
+    "- **nodes**: `{\"multiply_0\": AtomicRecipe, \"add_0\": AtomicRecipe}` — the child nodes,\n",
+    "  labelled by function name with a disambiguating suffix.\n",
+    "- Three sets of **edges** connecting everything together.\n",
+    "\n",
+    "The function body is still valid, runnable Python. When a WfMS executes the recipe,\n",
+    "we expect it to produce the same result as calling the function directly."
+   ],
+   "id": "d24e981330e5f22"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4ce2025",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "Of course workflows can also be written directly as JSON, so unlike atomic nodes, they don't _necessarily_ have an underlying python function `reference`.\n",
+    "In the even that they do (e.g. when they're created by parsing or decorating a python function), they do and the recipes themselves are callable like atomic recipes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "d39608c2",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.428582Z",
+     "start_time": "2026-07-11T03:59:27.407171Z"
+    }
+   },
+   "source": "linear.flowrep_recipe(x=3, slope=2, intercept=1)",
    "outputs": [
     {
      "name": "stdout",
@@ -1221,55 +1151,6 @@
    "id": "ad9b6689",
    "metadata": {},
    "source": [
-    "The parsed workflow has:\n",
-    "- **inputs**: `[\"x\", \"slope\", \"intercept\"]` — the function parameters.\n",
-    "- **outputs**: `[\"result\"]` — from the return statement.\n",
-    "- **nodes**: `{\"multiply_0\": AtomicRecipe, \"add_0\": AtomicRecipe}` — the child nodes,\n",
-    "  labelled by function name with a disambiguating suffix.\n",
-    "- Three sets of **edges** connecting everything together.\n",
-    "\n",
-    "The function body is still valid, runnable Python. When a WfMS executes the recipe,\n",
-    "we expect it to produce the same result as calling the function directly."
-   ]
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
-    "Of course workflows can also be written directly as JSON, so unlike atomic nodes, they don't _necessarily_ have an underlying python function `reference`.\n",
-    "In the even that they do (e.g. when they're created by parsing or decorating a python function), they do and the recipes themselves are callable like atomic recipes:"
-   ],
-   "id": "273ce5e9a7bb8ded"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.443414Z",
-     "start_time": "2026-07-11T03:59:27.429902Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "linear.flowrep_recipe(x=3, slope=2, intercept=1)",
-   "id": "ce41773494e520c8",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "7"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 25
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ddb268be",
-   "metadata": {},
-   "source": [
     "### 2.2 How child nodes get their recipes\n",
     "\n",
     "When the `@workflow` parser encounters a function call on the right-hand side of\n",
@@ -1285,26 +1166,23 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "e90699f6",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
    "source": [
     "### 2.3 Nesting\n",
     "\n",
     "Workflows are arbitrarily nestable:"
-   ]
+   ],
+   "id": "273ce5e9a7bb8ded"
   },
   {
-   "cell_type": "code",
-   "id": "55716aa9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.458290Z",
-     "start_time": "2026-07-11T03:59:27.444627Z"
+     "end_time": "2026-07-11T03:59:27.443414Z",
+     "start_time": "2026-07-11T03:59:27.429902Z"
     }
    },
+   "cell_type": "code",
    "source": [
     "@fr.workflow\n",
     "def quadratic(x, a, b, c):\n",
@@ -1329,22 +1207,24 @@
     "print(f\"linear_0 type:   {recipe.nodes['linear_0'].type}\")\n",
     "print(f\"linear_0 children: {list(recipe.nodes['linear_0'].nodes.keys())}\")"
    ],
+   "id": "ce41773494e520c8",
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Top-level nodes: ['linear_0', 'quadratic_0']\n",
-      "linear_0 type:   workflow\n",
-      "linear_0 children: ['multiply_0', 'add_0']\n"
-     ]
+     "data": {
+      "text/plain": [
+       "7"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "execution_count": 26
+   "execution_count": 25
   },
   {
    "cell_type": "markdown",
-   "id": "55cd18bc",
+   "id": "ddb268be",
    "metadata": {},
    "source": [
     "Here, `linear_0` is itself a `WorkflowRecipe` with its own subgraph, nested inside\n",
@@ -1358,7 +1238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5954340e",
+   "id": "e90699f6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1371,11 +1251,11 @@
   },
   {
    "cell_type": "code",
-   "id": "cd45cbb2",
+   "id": "55716aa9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.474424Z",
-     "start_time": "2026-07-11T03:59:27.460856Z"
+     "end_time": "2026-07-11T03:59:27.458290Z",
+     "start_time": "2026-07-11T03:59:27.444627Z"
     }
    },
    "source": [
@@ -1395,17 +1275,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inputs:  ['a', 'b', 'tag']\n",
-      "Outputs: ['result', 'tag']\n",
-      "Output edges: {OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result'), OutputTarget(node=None, port='tag'): InputSource(node=None, port='tag')}\n"
+      "Top-level nodes: ['linear_0', 'quadratic_0']\n",
+      "linear_0 type:   workflow\n",
+      "linear_0 children: ['multiply_0', 'add_0']\n"
      ]
     }
    ],
-   "execution_count": 27
+   "execution_count": 26
   },
   {
    "cell_type": "markdown",
-   "id": "54d94866",
+   "id": "55cd18bc",
    "metadata": {},
    "source": [
     "The `tag` output is sourced from an `InputSource` rather than a `SourceHandle`,\n",
@@ -1416,24 +1296,27 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "5954340e",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "### 2.5 Power User: Recipes as workflow steps\n",
     "\n",
     "Not only will workflow definitions try to leverage the `.flowrep_recipe` recipe information when processing call steps, they will also accept recipe objects themselves.\n",
     "To demonstrate this, let's parse a workflow using some recipes we defined for \"awkward\" functions from our last power-user aside:"
-   ],
-   "id": "7e7106b145ffbdc"
+   ]
   },
   {
+   "cell_type": "code",
+   "id": "cd45cbb2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.481126Z",
-     "start_time": "2026-07-11T03:59:27.475464Z"
+     "end_time": "2026-07-11T03:59:27.474424Z",
+     "start_time": "2026-07-11T03:59:27.460856Z"
     }
    },
-   "cell_type": "code",
    "source": [
     "@fr.workflow\n",
     "def my_workflow_from_recipes(\n",
@@ -1447,17 +1330,59 @@
     "    )\n",
     "    return output_dict"
    ],
-   "id": "de18e624974cf3e2",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inputs:  ['a', 'b', 'tag']\n",
+      "Outputs: ['result', 'tag']\n",
+      "Output edges: {OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result'), OutputTarget(node=None, port='tag'): InputSource(node=None, port='tag')}\n"
+     ]
+    }
+   ],
+   "execution_count": 27
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54d94866",
+   "metadata": {},
+   "source": [
+    "Just like usual, the parsed workflow will automatically generate labels for the child nodes.\n",
+    "In this case, these recipes have underlying Python references, so the workflow names the child nodes after the function names as usual:"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "child_labels = list(my_workflow_from_recipes.flowrep_recipe.nodes.keys())\n",
+    "assert(child_labels == ['arange_0', 'my_dict_maker_0'])\n",
+    "print(child_labels)"
+   ],
+   "id": "7e7106b145ffbdc",
    "outputs": [],
-   "execution_count": 28
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.481126Z",
+     "start_time": "2026-07-11T03:59:27.475464Z"
+    }
+   },
+   "cell_type": "markdown",
+   "source": [
+    "Workflows will parse _any recipe_ used in this way, even other `WorkflowRecipe` recipes and flow control recipes.\n",
+    "However, just as workflow nodes are only callable when they have an underlying python function, when that python function calls actual recipe objects, will only execute successfully if each of those recipe objects is itself callable.\n",
+    "I.e., leveraging this feature of \"recipes as a workflow steps\" will always parse OK, but may break the call-ability of your workflow function object."
+   ],
+   "id": "de18e624974cf3e2"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": [
-    "Just like usual, the parsed workflow will automatically generate labels for the child nodes.\n",
-    "In this case, these recipes have underlying Python references, so the workflow names the child nodes after the function names as usual:"
-   ],
+   "source": "In this case, we are calling recipes wrapping python functions, which are themselves callable, and so both the workflow function and its associated recipe remain callable:",
    "id": "c24cf47407659e9"
   },
   {
@@ -1468,11 +1393,7 @@
     }
    },
    "cell_type": "code",
-   "source": [
-    "child_labels = list(my_workflow_from_recipes.flowrep_recipe.nodes.keys())\n",
-    "assert(child_labels == ['arange_0', 'my_dict_maker_0'])\n",
-    "print(child_labels)"
-   ],
+   "source": "my_workflow_from_recipes.flowrep_recipe(start=0, stop=3, step=2)",
    "id": "6a0c65a9c8b32b63",
    "outputs": [
     {
@@ -1488,47 +1409,6 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": [
-    "Workflows will parse _any recipe_ used in this way, even other `WorkflowRecipe` recipes and flow control recipes.\n",
-    "However, just as workflow nodes are only callable when they have an underlying python function, when that python function calls actual recipe objects, will only execute successfully if each of those recipe objects is itself callable.\n",
-    "I.e., leveraging this feature of \"recipes as a workflow steps\" will always parse OK, but may break the call-ability of your workflow function object."
-   ],
-   "id": "5dd03eb5e7644e01"
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "In this case, we are calling recipes wrapping python functions, which are themselves callable, and so both the workflow function and its associated recipe remain callable:",
-   "id": "ce5c5407af6ae68a"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.513972Z",
-     "start_time": "2026-07-11T03:59:27.496180Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "my_workflow_from_recipes.flowrep_recipe(start=0, stop=3, step=2)",
-   "id": "f91eb49fe62486aa",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'this': 'this default', 'that': 'that default', 'the_other': array([0, 2])}"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 30
-  },
-  {
-   "cell_type": "markdown",
-   "id": "68ac7e14",
-   "metadata": {},
    "source": [
     "---\n",
     "## 3. Edges: the connective tissue\n",
@@ -1568,55 +1448,48 @@
     "\n",
     "Using the target as the dictionary key makes this constraint automatic — you\n",
     "can't have two sources for the same target in a `dict`."
-   ]
+   ],
+   "id": "5dd03eb5e7644e01"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "> **Aside on attribute access:** `InputSource` and `OutputTarget` do still have a `node` field, but it is locked to `None`:",
-   "id": "7144a6706b877f78"
+   "id": "ce5c5407af6ae68a"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.527620Z",
-     "start_time": "2026-07-11T03:59:27.515088Z"
+     "end_time": "2026-07-11T03:59:27.513972Z",
+     "start_time": "2026-07-11T03:59:27.496180Z"
     }
    },
    "cell_type": "code",
    "source": "fr.schemas.InputSource(port=\"inp\").node, fr.schemas.OutputTarget(port=\"out\").node",
-   "id": "56384e86f385779d",
+   "id": "f91eb49fe62486aa",
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(None, None)"
+       "{'this': 'this default', 'that': 'that default', 'the_other': array([0, 2])}"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 31
+   "execution_count": 30
   },
   {
    "cell_type": "markdown",
-   "id": "13f799b9",
+   "id": "68ac7e14",
    "metadata": {},
-   "source": [
-    "### 3.3 Inspecting edges"
-   ]
+   "source": "### 3.3 Inspecting edges"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "id": "06c2b2eb",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.541321Z",
-     "start_time": "2026-07-11T03:59:27.528514Z"
-    }
-   },
    "source": [
     "recipe = linear.flowrep_recipe\n",
     "\n",
@@ -1632,142 +1505,48 @@
     "for target, source in recipe.output_edges.items():\n",
     "    print(f\"  {source.serialize()} → {target.serialize()}\")"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Input edges (parent input → child input):\n",
-      "  x → multiply_0.x\n",
-      "  slope → multiply_0.y\n",
-      "  intercept → add_0.b\n",
-      "\n",
-      "Sibling edges (child → child):\n",
-      "  multiply_0.product → add_0.a\n",
-      "\n",
-      "Output edges (child → parent output):\n",
-      "  add_0.result → result\n"
-     ]
-    }
-   ],
-   "execution_count": 32
+   "id": "7144a6706b877f78",
+   "outputs": [],
+   "execution_count": null
   },
   {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.527620Z",
+     "start_time": "2026-07-11T03:59:27.515088Z"
+    }
+   },
    "cell_type": "markdown",
-   "id": "e67cac8d",
-   "metadata": {},
    "source": [
     "### 3.4 Serialisation and the dot notation\n",
     "\n",
     "Edges serialise to compact dot-separated strings. A `SourceHandle(\"add_0\", \"c\")`\n",
     "becomes `\"add_0.c\"`, while an `InputSource(\"x\")` (which has no node) becomes\n",
     "just `\"x\"`. This keeps the JSON representation concise:"
-   ]
+   ],
+   "id": "56384e86f385779d"
   },
   {
    "cell_type": "code",
-   "id": "6d7a6e2a",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.563399Z",
-     "start_time": "2026-07-11T03:59:27.543583Z"
-    }
-   },
+   "id": "13f799b9",
+   "metadata": {},
    "source": [
     "import json\n",
     "\n",
     "print(json.dumps(json.loads(recipe.model_dump_json()), indent=2))"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"type\": \"workflow\",\n",
-      "  \"inputs\": [\n",
-      "    \"x\",\n",
-      "    \"slope\",\n",
-      "    \"intercept\"\n",
-      "  ],\n",
-      "  \"outputs\": [\n",
-      "    \"result\"\n",
-      "  ],\n",
-      "  \"description\": \"y = slope * x + intercept\",\n",
-      "  \"nodes\": {\n",
-      "    \"multiply_0\": {\n",
-      "      \"type\": \"atomic\",\n",
-      "      \"inputs\": [\n",
-      "        \"x\",\n",
-      "        \"y\"\n",
-      "      ],\n",
-      "      \"outputs\": [\n",
-      "        \"product\"\n",
-      "      ],\n",
-      "      \"description\": null,\n",
-      "      \"reference\": {\n",
-      "        \"info\": {\n",
-      "          \"module\": \"__main__\",\n",
-      "          \"qualname\": \"multiply\",\n",
-      "          \"version\": null\n",
-      "        },\n",
-      "        \"inputs_with_defaults\": [],\n",
-      "        \"restricted_input_kinds\": {}\n",
-      "      },\n",
-      "      \"unpack_mode\": \"tuple\"\n",
-      "    },\n",
-      "    \"add_0\": {\n",
-      "      \"type\": \"atomic\",\n",
-      "      \"inputs\": [\n",
-      "        \"a\",\n",
-      "        \"b\"\n",
-      "      ],\n",
-      "      \"outputs\": [\n",
-      "        \"result\"\n",
-      "      ],\n",
-      "      \"description\": null,\n",
-      "      \"reference\": {\n",
-      "        \"info\": {\n",
-      "          \"module\": \"__main__\",\n",
-      "          \"qualname\": \"add\",\n",
-      "          \"version\": null\n",
-      "        },\n",
-      "        \"inputs_with_defaults\": [],\n",
-      "        \"restricted_input_kinds\": {}\n",
-      "      },\n",
-      "      \"unpack_mode\": \"tuple\"\n",
-      "    }\n",
-      "  },\n",
-      "  \"input_edges\": {\n",
-      "    \"multiply_0.x\": \"x\",\n",
-      "    \"multiply_0.y\": \"slope\",\n",
-      "    \"add_0.b\": \"intercept\"\n",
-      "  },\n",
-      "  \"edges\": {\n",
-      "    \"add_0.a\": \"multiply_0.product\"\n",
-      "  },\n",
-      "  \"output_edges\": {\n",
-      "    \"result\": \"add_0.result\"\n",
-      "  },\n",
-      "  \"reference\": {\n",
-      "    \"info\": {\n",
-      "      \"module\": \"__main__\",\n",
-      "      \"qualname\": \"linear\",\n",
-      "      \"version\": null\n",
-      "    },\n",
-      "    \"inputs_with_defaults\": [],\n",
-      "    \"restricted_input_kinds\": {}\n",
-      "  }\n",
-      "}\n"
-     ]
-    }
-   ],
-   "execution_count": 33
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "edecef8c",
-   "metadata": {},
+   "id": "06c2b2eb",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.541321Z",
+     "start_time": "2026-07-11T03:59:27.528514Z"
+    }
+   },
    "source": [
     "The `model_dump_json()` / `model_validate_json()` round-trip is the primary way\n",
     "recipes are shared. The JSON is fully self-describing — any consumer that\n",
@@ -1776,13 +1555,8 @@
   },
   {
    "cell_type": "code",
-   "id": "53e8f09d",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.579609Z",
-     "start_time": "2026-07-11T03:59:27.564310Z"
-    }
-   },
+   "id": "e67cac8d",
+   "metadata": {},
    "source": [
     "# Round-trip demo\n",
     "json_str = recipe.model_dump_json()\n",
@@ -1790,22 +1564,17 @@
     "assert reconstructed == recipe\n",
     "print(\"Round-trip successful!\")"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Round-trip successful!\n"
-     ]
-    }
-   ],
-   "execution_count": 34
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "d2723813",
+   "id": "6d7a6e2a",
    "metadata": {
-    "lines_to_next_cell": 2
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.563399Z",
+     "start_time": "2026-07-11T03:59:27.543583Z"
+    }
    },
    "source": [
     "---\n",
@@ -1830,13 +1599,9 @@
    ]
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.595280Z",
-     "start_time": "2026-07-11T03:59:27.580498Z"
-    }
-   },
    "cell_type": "code",
+   "id": "edecef8c",
+   "metadata": {},
    "source": [
     "# A preview — we'll dissect each type below\n",
     "def less_than(a, b):\n",
@@ -1872,24 +1637,18 @@
     "print(f\"abs_value(5)  = {abs_value(5)}\")\n",
     "print(f\"Recipe nodes:  {list(abs_value.flowrep_recipe.nodes.keys())}\")"
    ],
-   "id": "371165167183fdce",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "abs_value(-3) = 3\n",
-      "abs_value(5)  = 5\n",
-      "Recipe nodes:  ['if_0']\n"
-     ]
-    }
-   ],
-   "execution_count": 35
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "b7c44a28",
-   "metadata": {},
+   "id": "53e8f09d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.579609Z",
+     "start_time": "2026-07-11T03:59:27.564310Z"
+    }
+   },
    "source": [
     "> **Developer note:** Each control flow type has its own parser module\n",
     "> (e.g. `flowrep.models.parsers.for_parser`) invoked internally by the workflow\n",
@@ -1899,8 +1658,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53546398",
-   "metadata": {},
+   "id": "d2723813",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Before diving into each control flow type, we need to understand how the parser\n",
     "tracks variable scope — because scope rules are what make control flow parsing\n",
@@ -1969,7 +1730,12 @@
    ]
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.595280Z",
+     "start_time": "2026-07-11T03:59:27.580498Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "---\n",
@@ -1994,16 +1760,12 @@
     "\n",
     "#### Parsed example"
    ],
-   "id": "e0b3f4ba0331ef9c"
+   "id": "371165167183fdce"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.612857Z",
-     "start_time": "2026-07-11T03:59:27.596524Z"
-    }
-   },
    "cell_type": "code",
+   "id": "b7c44a28",
+   "metadata": {},
    "source": [
     "@fr.atomic\n",
     "def double(x):\n",
@@ -2034,29 +1796,12 @@
     "    f\"Body node:     {for_node.body_node.label} -> {type(for_node.body_node.recipe).__name__}\"\n",
     ")"
    ],
-   "id": "b3caee22e3c3befc",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "double_all([1,2,3]) = [2, 4, 6]\n",
-      "\n",
-      "ForEach-node type: for_each\n",
-      "Inputs:        ['items']\n",
-      "Outputs:       ['results']\n",
-      "Nested ports:  ['item']\n",
-      "Zipped ports:  []\n",
-      "Input edges:   {TargetHandle(node='body', port='item'): InputSource(node=None, port='items')}\n",
-      "Body node:     body -> WorkflowRecipe\n"
-     ]
-    }
-   ],
-   "execution_count": 36
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "332fcb1c",
+   "id": "53546398",
    "metadata": {},
    "source": [
     "Note the structure: the for-node's input is `items` (the collection to iterate\n",
@@ -2066,11 +1811,8 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "4fec6034",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
    "source": [
     "#### Broadcasting and scattering\n",
     "\n",
@@ -2078,13 +1820,14 @@
     "execute its recipes. For for-nodes, that means inputs that aren't iterated over are\n",
     "*broadcast* (sent to every body instance), while inputs that are iterated over are\n",
     "*scattered* (each body instance gets one element):"
-   ]
+   ],
+   "id": "e0b3f4ba0331ef9c"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.682206Z",
-     "start_time": "2026-07-11T03:59:27.615166Z"
+     "end_time": "2026-07-11T03:59:27.612857Z",
+     "start_time": "2026-07-11T03:59:27.596524Z"
     }
    },
    "cell_type": "code",
@@ -2111,6 +1854,68 @@
     "for target, source in for_node.input_edges.items():\n",
     "    print(f\"  {source.serialize()} → {target.serialize()}\")"
    ],
+   "id": "b3caee22e3c3befc",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "double_all([1,2,3]) = [2, 4, 6]\n",
+      "\n",
+      "ForEach-node type: for_each\n",
+      "Inputs:        ['items']\n",
+      "Outputs:       ['results']\n",
+      "Nested ports:  ['item']\n",
+      "Zipped ports:  []\n",
+      "Input edges:   {TargetHandle(node='body', port='item'): InputSource(node=None, port='items')}\n",
+      "Body node:     body -> WorkflowRecipe\n"
+     ]
+    }
+   ],
+   "execution_count": 36
+  },
+  {
+   "cell_type": "markdown",
+   "id": "332fcb1c",
+   "metadata": {},
+   "source": [
+    "`factor` is to be broadcast (same value to every body instance), while `item` is\n",
+    "to be scattered (one element per instance), just as they are in the underlying python\n",
+    "function which produced this recipe when parsed.\n",
+    "\n",
+    "I.e., we see how the for-loop passes input down to the body via the `input_edges`, and know whether this is to be scattered or broadcast by whether or not that body target appears in one of the looped ports fields."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fec6034",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": "#### Zipped iteration"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.682206Z",
+     "start_time": "2026-07-11T03:59:27.615166Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "@fr.workflow\n",
+    "def add_pairwise(xs, ys):\n",
+    "    results = []\n",
+    "    for x, y in zip(xs, ys):\n",
+    "        s = add(x, y)\n",
+    "        results.append(s)\n",
+    "    return results\n",
+    "\n",
+    "\n",
+    "for_node = add_pairwise.flowrep_recipe.nodes[\"for_each_0\"]\n",
+    "print(f\"Zipped ports: {for_node.zipped_ports}\")\n",
+    "print(f\"Nested ports: {for_node.nested_ports}\")"
+   ],
    "id": "7007ffc505c010c5",
    "outputs": [
     {
@@ -2132,77 +1937,18 @@
    "id": "45401977",
    "metadata": {},
    "source": [
-    "`factor` is to be broadcast (same value to every body instance), while `item` is\n",
-    "to be scattered (one element per instance), just as they are in the underlying python\n",
-    "function which produced this recipe when parsed.\n",
-    "\n",
-    "I.e., we see how the for-loop passes input down to the body via the `input_edges`, and know whether this is to be scattered or broadcast by whether or not that body target appears in one of the looped ports fields."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0eef1327",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "source": [
-    "#### Zipped iteration"
-   ]
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.704571Z",
-     "start_time": "2026-07-11T03:59:27.688279Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "@fr.workflow\n",
-    "def add_pairwise(xs, ys):\n",
-    "    results = []\n",
-    "    for x, y in zip(xs, ys):\n",
-    "        s = add(x, y)\n",
-    "        results.append(s)\n",
-    "    return results\n",
-    "\n",
-    "\n",
-    "for_node = add_pairwise.flowrep_recipe.nodes[\"for_each_0\"]\n",
-    "print(f\"Zipped ports: {for_node.zipped_ports}\")\n",
-    "print(f\"Nested ports: {for_node.nested_ports}\")"
-   ],
-   "id": "69d06b59a0b7bc26",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Zipped ports: ['x', 'y']\n",
-      "Nested ports: []\n"
-     ]
-    }
-   ],
-   "execution_count": 38
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
     "#### Transferred outputs\n",
     "\n",
     "ForEach-nodes also support forwarding iterated input data directly to an output,\n",
     "so that output lists can be correlated with their generating inputs:"
-   ],
-   "id": "78354acb95e458e6"
+   ]
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.718556Z",
-     "start_time": "2026-07-11T03:59:27.705531Z"
-    }
-   },
    "cell_type": "code",
+   "id": "0eef1327",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "@fr.workflow\n",
     "def process_and_track(items):\n",
@@ -2221,24 +1967,17 @@
     "for target, source in for_node.transferred_outputs.items():\n",
     "    print(f\"  {target.serialize()} sourced from input '{source.port}'\")"
    ],
-   "id": "9147790cd9a1c79a",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outputs: ['results', 'sources']\n",
-      "Transferred (input-forwarded) outputs:\n",
-      "  sources sourced from input 'items'\n"
-     ]
-    }
-   ],
-   "execution_count": 39
+   "outputs": [],
+   "execution_count": null
   },
   {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.704571Z",
+     "start_time": "2026-07-11T03:59:27.688279Z"
+    }
+   },
    "cell_type": "markdown",
-   "id": "95d03fb4",
-   "metadata": {},
    "source": [
     "#### What's not supported\n",
     "\n",
@@ -2255,14 +1994,12 @@
     "- **Iteration sources must be symbols**, not inline expressions.\n",
     "- **Non-iterated pass-through outputs are forbidden.** Output edges from\n",
     "  `InputSource` are only valid when the input is being iterated on."
-   ]
+   ],
+   "id": "69d06b59a0b7bc26"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "86b272de",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
    "source": [
     "---\n",
     "### 4.3 If-nodes\n",
@@ -2282,17 +2019,17 @@
     "This last point introduces **prospective output edges**: a mapping from each output\n",
     "port to a *list* of possible sources — one per branch that can produce it. At\n",
     "runtime, exactly one of these sources will be actualized."
-   ]
+   ],
+   "id": "78354acb95e458e6"
   },
   {
-   "cell_type": "code",
-   "id": "0a285891",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.733103Z",
-     "start_time": "2026-07-11T03:59:27.719591Z"
+     "end_time": "2026-07-11T03:59:27.718556Z",
+     "start_time": "2026-07-11T03:59:27.705531Z"
     }
    },
+   "cell_type": "code",
    "source": [
     "@fr.workflow\n",
     "def sign(x):\n",
@@ -2316,29 +2053,23 @@
     "    for s in sources:\n",
     "        print(f\"    - {s.serialize()}\")"
    ],
+   "id": "9147790cd9a1c79a",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Type: if\n",
-      "Inputs: ['x']\n",
-      "Outputs: ['result']\n",
-      "Number of cases: 1\n",
-      "Has else: True\n",
-      "\n",
-      "Prospective output edges:\n",
-      "  result can come from:\n",
-      "    - body_0.result\n",
-      "    - else_body.result\n"
+      "Outputs: ['results', 'sources']\n",
+      "Transferred (input-forwarded) outputs:\n",
+      "  sources sourced from input 'items'\n"
      ]
     }
    ],
-   "execution_count": 40
+   "execution_count": 39
   },
   {
    "cell_type": "markdown",
-   "id": "9e438df5",
+   "id": "95d03fb4",
    "metadata": {},
    "source": [
     "The `prospective_output_edges` dictionary is what makes if-nodes different from\n",
@@ -2357,8 +2088,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "887f023a",
-   "metadata": {},
+   "id": "86b272de",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "#### What's not supported\n",
     "\n",
@@ -2366,30 +2099,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0a285891",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-03-10T14:31:28.272756Z",
-     "start_time": "2026-03-10T14:31:28.227295Z"
+     "end_time": "2026-07-11T03:59:27.733103Z",
+     "start_time": "2026-07-11T03:59:27.719591Z"
     }
    },
-   "cell_type": "markdown",
    "source": [
     "> **Aside for WfMS designers:** If no case matches and no else is provided, there will be no source data with which to populate the output.\n",
     "> We don't proscribe here exactly how you ought to handle this (raise an exception? Silently halt?) but it is a condition under which\n",
     "> downstream input targets will be unable to secure their requested input data from the upstream source.\n",
     "> The WfMS must be prepared for the possibility of this.\n",
     "> When executing such a situation as pure python, the python interpreter raises an `UnboundLocalError` for us:"
-   ],
-   "id": "f170e946bc3d3e53"
+   ]
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.757249Z",
-     "start_time": "2026-07-11T03:59:27.739975Z"
-    }
-   },
    "cell_type": "code",
+   "id": "9e438df5",
+   "metadata": {},
    "source": [
     "# Aside example\n",
     "import traceback\n",
@@ -2410,38 +2139,13 @@
     "except Exception:\n",
     "    traceback.print_exc()"
    ],
-   "id": "e88ea8e75fb8b197",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['result']\n",
-      "{OutputTarget(node=None, port='result'): [SourceHandle(node='body_0', port='result')]}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_59191/3477409776.py\", line 16, in <module>\n",
-      "    conditional_availability(-1)\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_59191/3477409776.py\", line 9, in conditional_availability\n",
-      "    downstream = identity(result)\n",
-      "                          ^^^^^^\n",
-      "UnboundLocalError: cannot access local variable 'result' where it is not associated with a value\n"
-     ]
-    }
-   ],
-   "execution_count": 41
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "460686cf",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
+   "id": "887f023a",
+   "metadata": {},
    "source": [
     ">---\n",
     "### 4.4 While-nodes\n",
@@ -2462,15 +2166,13 @@
    ]
   },
   {
-   "cell_type": "code",
-   "id": "515eae1c",
    "metadata": {
-    "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.763575Z",
-     "start_time": "2026-07-11T03:59:27.758276Z"
+     "end_time": "2026-03-10T14:31:28.272756Z",
+     "start_time": "2026-03-10T14:31:28.227295Z"
     }
    },
+   "cell_type": "code",
    "source": [
     "@fr.atomic\n",
     "def is_below_threshold(value, threshold):\n",
@@ -2483,15 +2185,18 @@
     "    result = x + 1\n",
     "    return result"
    ],
+   "id": "f170e946bc3d3e53",
    "outputs": [],
-   "execution_count": 42
+   "execution_count": null
   },
   {
-   "cell_type": "markdown",
-   "id": "77c86c9f",
    "metadata": {
-    "lines_to_next_cell": 2
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.757249Z",
+     "start_time": "2026-07-11T03:59:27.739975Z"
+    }
    },
+   "cell_type": "markdown",
    "source": [
     "A natural first attempt might be:\n",
     "\n",
@@ -2507,16 +2212,14 @@
     "But `value = start` is a bare name-to-name assignment, which the workflow parser\n",
     "doesn't support (right-hand sides must be function calls or empty lists). Instead,\n",
     "we work directly with the function parameter, or use an identity function:"
-   ]
+   ],
+   "id": "e88ea8e75fb8b197"
   },
   {
    "cell_type": "code",
-   "id": "52ab25e4",
+   "id": "460686cf",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.777055Z",
-     "start_time": "2026-07-11T03:59:27.764090Z"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "@fr.workflow\n",
@@ -2537,30 +2240,17 @@
     "#\n",
     "# The while-node also exposes inferred iteration edges:"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "count_up(0, 5) = 5\n",
-      "\n",
-      "Type: while\n",
-      "Inputs:  ['start', 'threshold']\n",
-      "Outputs: ['start']\n",
-      "Condition: condition\n",
-      "Body:      body\n"
-     ]
-    }
-   ],
-   "execution_count": 43
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "id": "79c1d339",
+   "id": "515eae1c",
    "metadata": {
+    "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.791355Z",
-     "start_time": "2026-07-11T03:59:27.777702Z"
+     "end_time": "2026-07-11T03:59:27.763575Z",
+     "start_time": "2026-07-11T03:59:27.758276Z"
     }
    },
    "source": [
@@ -2572,25 +2262,15 @@
     "for target, source in while_node.body_condition_edges.items():\n",
     "    print(f\"  {source.serialize()} → {target.serialize()}\")"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Body → body (next iteration) edges:\n",
-      "  body.start → body.start\n",
-      "\n",
-      "Body → condition (next check) edges:\n",
-      "  body.start → condition.value\n"
-     ]
-    }
-   ],
-   "execution_count": 44
+   "outputs": [],
+   "execution_count": 42
   },
   {
    "cell_type": "markdown",
-   "id": "a1b2b270",
-   "metadata": {},
+   "id": "77c86c9f",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "#### What's not supported\n",
     "\n",
@@ -2600,9 +2280,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de93d7c8",
+   "id": "52ab25e4",
    "metadata": {
-    "lines_to_next_cell": 2
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.777055Z",
+     "start_time": "2026-07-11T03:59:27.764090Z"
+    }
    },
    "source": [
     "---\n",
@@ -2630,11 +2313,11 @@
   },
   {
    "cell_type": "code",
-   "id": "d76836d6",
+   "id": "79c1d339",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.808443Z",
-     "start_time": "2026-07-11T03:59:27.793731Z"
+     "end_time": "2026-07-11T03:59:27.791355Z",
+     "start_time": "2026-07-11T03:59:27.777702Z"
     }
    },
    "source": [
@@ -2677,6 +2360,64 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Body → body (next iteration) edges:\n",
+      "  body.start → body.start\n",
+      "\n",
+      "Body → condition (next check) edges:\n",
+      "  body.start → condition.value\n"
+     ]
+    }
+   ],
+   "execution_count": 44
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2b270",
+   "metadata": {},
+   "source": [
+    "#### What's not supported\n",
+    "\n",
+    "- An `else`-clause in the `try` block is not supported.\n",
+    "- Terminating with a `finally`-clause is not yet supported.\n",
+    "- Bare `except:` (without specifying types) is not supported.\n",
+    "- Named handlers (`except ValueError as e:`) are not yet supported."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de93d7c8",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### 4.6 Aside on parsed subgraphs\n",
+    "\n",
+    "When parsing subgraphs for flow controls or their cases, the parser _always_ wraps the body in a workflow node.\n",
+    "In principle, this is not necessary when the body clause consists of a single call, and recipes where such a body is, e.g., a simple atomic node are perfectly validated.\n",
+    "The wrapping occurs in recipes produced by parsing raw python only to simplify parsing and maintenance.\n",
+    "\n",
+    "So do not be alarmed if you occasionally find an \"unnecessary\" intermediate workflow node in your graph.\n",
+    "For instance, if we revist our very simple incrementing while node from above, we find that the body case is a workflow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "d76836d6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.808443Z",
+     "start_time": "2026-07-11T03:59:27.793731Z"
+    }
+   },
+   "source": [
+    "intermediate = count_up.flowrep_recipe.nodes[\"while_0\"].case.body\n",
+    "print(f\"The intermediate node {intermediate.label!r} is of type {str(intermediate.recipe.type)!r}\")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "careful_divide(10, 2) = 5.0\n",
       "careful_divide(10, 0) = 0\n",
       "\n",
@@ -2695,29 +2436,18 @@
    "cell_type": "markdown",
    "id": "ef63fe36",
    "metadata": {},
-   "source": [
-    "#### What's not supported\n",
-    "\n",
-    "- An `else`-clause in the `try` block is not supported.\n",
-    "- Terminating with a `finally`-clause is not yet supported.\n",
-    "- Bare `except:` (without specifying types) is not supported.\n",
-    "- Named handlers (`except ValueError as e:`) are not yet supported."
-   ]
+   "source": "But, strictly speaking, this intermediate workflow is not necessary since it anyhow has a single child -- the atomic incrementer:"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
+   "cell_type": "code",
    "source": [
-    "### 4.6 Aside on parsed subgraphs\n",
-    "\n",
-    "When parsing subgraphs for flow controls or their cases, the parser _always_ wraps the body in a workflow node.\n",
-    "In principle, this is not necessary when the body clause consists of a single call, and recipes where such a body is, e.g., a simple atomic node are perfectly validated.\n",
-    "The wrapping occurs in recipes produced by parsing raw python only to simplify parsing and maintenance.\n",
-    "\n",
-    "So do not be alarmed if you occasionally find an \"unnecessary\" intermediate workflow node in your graph.\n",
-    "For instance, if we revist our very simple incrementing while node from above, we find that the body case is a workflow:"
+    "child_label, child_recipe = next(iter(intermediate.recipe.nodes.items()))\n",
+    "print(f\"This workflow has a single-node body: {child_label!r} of type {str(child_recipe.type)!r}\")"
    ],
-   "id": "880a7caa20cb48ec"
+   "id": "880a7caa20cb48ec",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -2726,57 +2456,7 @@
      "start_time": "2026-07-11T03:59:27.810632Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "intermediate = count_up.flowrep_recipe.nodes[\"while_0\"].case.body\n",
-    "print(f\"The intermediate node {intermediate.label!r} is of type {str(intermediate.recipe.type)!r}\")"
-   ],
-   "id": "d9bf38390b916b62",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The intermediate node 'body' is of type 'workflow'\n"
-     ]
-    }
-   ],
-   "execution_count": 46
-  },
-  {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "But, strictly speaking, this intermediate workflow is not necessary since it anyhow has a single child -- the atomic incrementer:",
-   "id": "257fa2cc1c78265d"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.836844Z",
-     "start_time": "2026-07-11T03:59:27.824048Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "child_label, child_recipe = next(iter(intermediate.recipe.nodes.items()))\n",
-    "print(f\"This workflow has a single-node body: {child_label!r} of type {str(child_recipe.type)!r}\")"
-   ],
-   "id": "1b2d2b33f6e90e59",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This workflow has a single-node body: 'increment_0' of type 'atomic'\n"
-     ]
-    }
-   ],
-   "execution_count": 47
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8b925db5",
-   "metadata": {},
    "source": [
     "---\n",
     "## 5. Aside on Version Provenance\n",
@@ -2794,6 +2474,59 @@
     "- `forbid_locals=True`: Reject functions defined inside other functions\n",
     "  (whose qualname contains `<locals>`).\n",
     "- `require_version=True`: Reject functions whose package has no version."
+   ],
+   "id": "d9bf38390b916b62"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# This will fail because we're in __main__:\n",
+    "try:\n",
+    "\n",
+    "    @fr.atomic(forbid_main=True)\n",
+    "    def my_func(x):\n",
+    "        y = x\n",
+    "        return y\n",
+    "\n",
+    "except Exception:\n",
+    "    traceback.print_exc()"
+   ],
+   "id": "257fa2cc1c78265d",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.836844Z",
+     "start_time": "2026-07-11T03:59:27.824048Z"
+    }
+   },
+   "cell_type": "markdown",
+   "source": [
+    "These constraints **propagate through the entire parse tree**. When `@workflow`\n",
+    "parses a function body and encounters child function calls, the same\n",
+    "`forbid_main`, `forbid_locals`, and `require_version` constraints are applied\n",
+    "to every child — recursively, to arbitrary depth. In a notebook (where everything\n",
+    "is in `__main__`), this means `@workflow(forbid_main=True)` will reject any\n",
+    "locally-defined child function as well.\n",
+    "\n",
+    "In a real package context, this ensures that a recipe built with\n",
+    "`require_version=True` will fail at parse time if *any* function in the entire\n",
+    "call graph comes from an unversioned package."
+   ],
+   "id": "1b2d2b33f6e90e59"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b925db5",
+   "metadata": {},
+   "source": [
+    "### 5.2 Custom version scraping\n",
+    "\n",
+    "Some packages don't expose `__version__`. The `version_scraping` argument provides\n",
+    "a mapping from module names to callables that return the version string:"
    ]
   },
   {
@@ -2806,16 +2539,12 @@
     }
    },
    "source": [
-    "# This will fail because we're in __main__:\n",
-    "try:\n",
+    "# Hypothetical example for a package with non-standard versioning:\n",
+    "@fr.atomic(version_scraping={\"__main__\": lambda _: \"1.2.3\"})\n",
+    "def my_func(x):\n",
+    "    return x\n",
     "\n",
-    "    @fr.atomic(forbid_main=True)\n",
-    "    def my_func(x):\n",
-    "        y = x\n",
-    "        return y\n",
-    "\n",
-    "except Exception:\n",
-    "    traceback.print_exc()"
+    "print(my_func.flowrep_recipe.reference.info.version)"
    ],
    "outputs": [
     {
@@ -2850,78 +2579,18 @@
    "id": "17f66954",
    "metadata": {},
    "source": [
-    "These constraints **propagate through the entire parse tree**. When `@workflow`\n",
-    "parses a function body and encounters child function calls, the same\n",
-    "`forbid_main`, `forbid_locals`, and `require_version` constraints are applied\n",
-    "to every child — recursively, to arbitrary depth. In a notebook (where everything\n",
-    "is in `__main__`), this means `@workflow(forbid_main=True)` will reject any\n",
-    "locally-defined child function as well.\n",
-    "\n",
-    "In a real package context, this ensures that a recipe built with\n",
-    "`require_version=True` will fail at parse time if *any* function in the entire\n",
-    "call graph comes from an unversioned package."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b9a1b49d",
-   "metadata": {},
-   "source": [
-    "### 5.2 Custom version scraping\n",
-    "\n",
-    "Some packages don't expose `__version__`. The `version_scraping` argument provides\n",
-    "a mapping from module names to callables that return the version string:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "82468383",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.866707Z",
-     "start_time": "2026-07-11T03:59:27.853871Z"
-    }
-   },
-   "source": [
-    "# Hypothetical example for a package with non-standard versioning:\n",
-    "@fr.atomic(version_scraping={\"__main__\": lambda _: \"1.2.3\"})\n",
-    "def my_func(x):\n",
-    "    return x\n",
-    "\n",
-    "print(my_func.flowrep_recipe.reference.info.version)"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.2.3\n"
-     ]
-    }
-   ],
-   "execution_count": 49
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
     "---\n",
     "## 6. Compiling recipes back to python functions\n",
     "\n",
     "The expected user path is to write some python code and generate a `flowrep` recipe by decorating this with `@workflow` or `@atomic`, but there is nothing stopping you from opening your favourite text editor and writing a recipe from scratch as a JSON file. For this (or any other) reason, you may find yourself with a recipe without any underlying python function. In such a situation, you can compile (almost) any `WorkflowRecipe` _into_ python!\n",
     "\n",
     "For python functions that already have an underlying python reference, you'll get a complaint -- don't both re-compiling, just use the existing reference!"
-   ],
-   "id": "e0ac6cf3086d983a"
+   ]
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.881332Z",
-     "start_time": "2026-07-11T03:59:27.867580Z"
-    }
-   },
    "cell_type": "code",
+   "id": "b9a1b49d",
+   "metadata": {},
    "source": [
     "@fr.workflow\n",
     "def my_recipe(x: int, y: int = 4):\n",
@@ -2933,27 +2602,53 @@
     "except ValueError as e:\n",
     "    print(e)"
    ],
-   "id": "31639b9ce08f4f94",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This recipe already has an underlying Python reference: info=VersionInfo(module='__main__', qualname='my_recipe', version=None) inputs_with_defaults=['y'] restricted_input_kinds={}\n"
-     ]
-    }
-   ],
-   "execution_count": 50
+   "outputs": [],
+   "execution_count": null
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "82468383",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.866707Z",
+     "start_time": "2026-07-11T03:59:27.853871Z"
+    }
+   },
    "source": [
     "### 6.1 basic compile\n",
     "\n",
     "For our purposes here, let's strip the reference off and try again. This gives us a \"rendered\" object."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "unreferenced_recipe = my_recipe.flowrep_recipe.model_copy(update={\"reference\": None})\n",
+    "rendered = fr.tools.flowrep2python(unreferenced_recipe)"
    ],
-   "id": "f906e1e3d41e5b3b"
+   "id": "e0ac6cf3086d983a",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.881332Z",
+     "start_time": "2026-07-11T03:59:27.867580Z"
+    }
+   },
+   "cell_type": "markdown",
+   "source": "We can look at the python source code generated from with this recipe, and if we wanted we could `.dump(filepath)` it to a `.py` file",
+   "id": "31639b9ce08f4f94"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "print(rendered.source)",
+   "id": "f906e1e3d41e5b3b",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -2962,20 +2657,20 @@
      "start_time": "2026-07-11T03:59:27.882757Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "unreferenced_recipe = my_recipe.flowrep_recipe.model_copy(update={\"reference\": None})\n",
-    "rendered = fr.tools.flowrep2python(unreferenced_recipe)"
-   ],
-   "id": "664078176aceb6e0",
-   "outputs": [],
-   "execution_count": 51
+   "cell_type": "markdown",
+   "source": "We can also generate an actual living python function object",
+   "id": "664078176aceb6e0"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": "We can look at the python source code generated from with this recipe, and if we wanted we could `.dump(filepath)` it to a `.py` file",
-   "id": "612788a582d4680"
+   "cell_type": "code",
+   "source": [
+    "rebuilt = rendered.build()\n",
+    "rebuilt(1, 2)"
+   ],
+   "id": "612788a582d4680",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -2984,81 +2679,16 @@
      "start_time": "2026-07-11T03:59:27.887114Z"
     }
    },
-   "cell_type": "code",
-   "source": "print(rendered.source)",
-   "id": "b05174603f66abe0",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "from __future__ import annotations\n",
-      "\n",
-      "import __main__\n",
-      "import flowrep\n",
-      "import typing\n",
-      "\n",
-      "@flowrep.workflow(\"total\")\n",
-      "def compiled_from_workflow_recipe(x, y):\n",
-      "    add = __main__.add(a=x, b=y)\n",
-      "    return add\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "execution_count": 52
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "We can also generate an actual living python function object",
-   "id": "54362e50de84e98d"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.914939Z",
-     "start_time": "2026-07-11T03:59:27.900898Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "rebuilt = rendered.build()\n",
-    "rebuilt(1, 2)"
-   ],
-   "id": "6c66d3483935a69e",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 53
-  },
-  {
-   "metadata": {},
    "cell_type": "markdown",
    "source": [
     "### 6.2 Simple signatures\n",
     "\n",
     "Flowrep recipes don't know about annotations or defaults, so you'll notice that our compiled source is missing these. You are free to specify them at call-time as a signature object"
    ],
-   "id": "281ef568be306e93"
+   "id": "b05174603f66abe0"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.936649Z",
-     "start_time": "2026-07-11T03:59:27.922782Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "import inspect\n",
@@ -3075,46 +2705,27 @@
     ")\n",
     "print(rendered_with_annotations.source)"
    ],
-   "id": "966d2a06e2842a37",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "from __future__ import annotations\n",
-      "\n",
-      "import __main__\n",
-      "import flowrep\n",
-      "import typing\n",
-      "\n",
-      "@flowrep.workflow(\"total\")\n",
-      "def my_function_with_annotations(x: int, y: int = 4):\n",
-      "    add = __main__.add(a=x, b=y)\n",
-      "    return add\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "execution_count": 54
+   "id": "54362e50de84e98d",
+   "outputs": [],
+   "execution_count": null
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.914939Z",
+     "start_time": "2026-07-11T03:59:27.900898Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "### 6.3 Complex signatures\n",
     "\n",
     "Where the annotations and defaults have reprs that play nicely with `ast.literal_eval`, these signature items inline nicely into the source code. Where they are more complex, we use placeholders"
    ],
-   "id": "730469f5b44b6dd8"
+   "id": "6c66d3483935a69e"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.953687Z",
-     "start_time": "2026-07-11T03:59:27.937643Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "class MyCustomThing(int): ...\n",
@@ -3140,38 +2751,54 @@
     ")\n",
     "print(complex_rendered.source)"
    ],
-   "id": "938b1fe74c549980",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "from __future__ import annotations\n",
-      "\n",
-      "import __main__\n",
-      "import flowrep\n",
-      "import typing\n",
-      "\n",
-      "@flowrep.workflow(\"total\")\n",
-      "def wont_dump(x: _ann_x, y: _ann_y = _default_y):\n",
-      "    add = __main__.add(a=x, b=y)\n",
-      "    return add\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "execution_count": 55
+   "id": "281ef568be306e93",
+   "outputs": [],
+   "execution_count": null
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.936649Z",
+     "start_time": "2026-07-11T03:59:27.922782Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "Such code won't dump without forcing the issue with a boolean flag.\n",
     "\n",
     "These placeholder symbols are stored in a namespace"
    ],
-   "id": "578b4f2ccc1ee02e"
+   "id": "966d2a06e2842a37"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "complex_rendered.namespace",
+   "id": "730469f5b44b6dd8",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.953687Z",
+     "start_time": "2026-07-11T03:59:27.937643Z"
+    }
+   },
+   "cell_type": "markdown",
+   "source": "This allows us to build the function just fine, so only dumping the source code is negatively impacted by complex signature values",
+   "id": "938b1fe74c549980"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "rebuilt_complex = complex_rendered.build()\n",
+    "rebuilt(MyCustomThing(1), MyCustomThing(2))"
+   ],
+   "id": "578b4f2ccc1ee02e",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -3180,72 +2807,17 @@
      "start_time": "2026-07-11T03:59:27.954651Z"
     }
    },
-   "cell_type": "code",
-   "source": "complex_rendered.namespace",
-   "id": "385466cdcaf0ec6e",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'_ann_x': __main__.MyCustomThing,\n",
-       " '_ann_y': __main__.MyCustomThing,\n",
-       " '_default_y': 4}"
-      ]
-     },
-     "execution_count": 56,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 56
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "This allows us to build the function just fine, so only dumping the source code is negatively impacted by complex signature values",
-   "id": "6da55d857f12b75e"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.982017Z",
-     "start_time": "2026-07-11T03:59:27.968628Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "rebuilt_complex = complex_rendered.build()\n",
-    "rebuilt(MyCustomThing(1), MyCustomThing(2))"
-   ],
-   "id": "e05fec796a1c063b",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 57
-  },
-  {
-   "metadata": {},
    "cell_type": "markdown",
    "source": [
     "The compiler also works on `DagData` retrospective objects, where the port fields are leveraged to build signature information.\n",
     "\n",
     "While most recipes will compile this way, there are a few places where the underlying `flowrep` recipe structure is more flexible than our python parser -- e.g., the parser demands that the conditions of an `if` clause be representable as a callable, but in the recipe format we would be free to put a `WhileRecipe` as the condition. The parser is designed to fail cleanly in these edge cases."
    ],
-   "id": "c0dfca6f272c635d"
+   "id": "385466cdcaf0ec6e"
   },
   {
-   "cell_type": "markdown",
-   "id": "5ccd8c05",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "---\n",
     "## 7. Converting to Other Formats\n",
@@ -3263,17 +2835,17 @@
     "  carry concrete values).\n",
     "\n",
     "### 7.1 flowrep → PWD"
-   ]
+   ],
+   "id": "6da55d857f12b75e"
   },
   {
-   "cell_type": "code",
-   "id": "cabe9313",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.996803Z",
-     "start_time": "2026-07-11T03:59:27.983158Z"
+     "end_time": "2026-07-11T03:59:27.982017Z",
+     "start_time": "2026-07-11T03:59:27.968628Z"
     }
    },
+   "cell_type": "code",
    "source": [
     "try:\n",
     "\n",
@@ -3296,39 +2868,31 @@
     "    print(\"python-workflow-definition is not installed — skipping this section.\")\n",
     "    print(\"Install with: pip install python-workflow-definition\")"
    ],
+   "id": "e05fec796a1c063b",
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PWD version: 0.0.1\n",
-      "Nodes: 6\n",
-      "  id=0, type=input, name=x\n",
-      "  id=1, type=input, name=slope\n",
-      "  id=2, type=input, name=intercept\n",
-      "  id=3, type=output, name=result\n",
-      "  id=4, type=function, value=__main__.multiply\n",
-      "  id=5, type=function, value=__main__.add\n",
-      "Edges: 5\n"
-     ]
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "execution_count": 58
+   "execution_count": 57
   },
   {
-   "cell_type": "markdown",
-   "id": "4046960d",
    "metadata": {},
-   "source": "### 7.2 PWD → flowrep"
+   "cell_type": "markdown",
+   "source": "### 7.2 PWD → flowrep",
+   "id": "c0dfca6f272c635d"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.011631Z",
-     "start_time": "2026-07-11T03:59:27.997786Z"
-    }
-   },
    "cell_type": "code",
+   "id": "5ccd8c05",
+   "metadata": {},
    "source": [
     "try:\n",
     "    # Round-trip: flowrep → PWD → flowrep\n",
@@ -3346,25 +2910,18 @@
     "except ImportError:\n",
     "    print(\"python-workflow-definition is not installed — skipping.\")"
    ],
-   "id": "b4d773a54b386eba",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Round-tripped inputs:  ['x', 'slope', 'intercept']\n",
-      "Round-tripped outputs: ['result']\n",
-      "Round-tripped nodes:   ['multiply_0', 'add_0']\n",
-      "Defaults: {'x': 0.0, 'slope': 1.0, 'intercept': 0.0}\n"
-     ]
-    }
-   ],
-   "execution_count": 59
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "2370bd6b",
-   "metadata": {},
+   "id": "cabe9313",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:27.996803Z",
+     "start_time": "2026-07-11T03:59:27.983158Z"
+    }
+   },
    "source": [
     "Note that PWD carries less information than flowrep (no version info on individual\n",
     "nodes, no nested subgraphs), so the round-trip is lossy in the flowrep → PWD\n",
@@ -3372,8 +2929,9 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "4046960d",
+   "metadata": {},
    "source": [
     "---\n",
     "## 8. Retrospective, \"Instance View\" Data\n",
@@ -3388,26 +2946,26 @@
     "They cannot be dumped directly to JSON.\n",
     "\n",
     "Recipes can be easily converted into this data \"instance view\" through the API tool `recipe2data`, ready to have data fields populated by a WfMS."
-   ],
-   "id": "833e6b0ceb72e917"
+   ]
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.011631Z",
+     "start_time": "2026-07-11T03:59:27.997786Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "To explore this, let's revisit our earlier example of scaling values in a for-loop.\n",
     "Here, we'll add default values (tracked only by a boolean \"are they available\" flag in the recipe) and annotations (not tracked at all in the recipe):"
    ],
-   "id": "d8537a11cde237e4"
+   "id": "b4d773a54b386eba"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.018411Z",
-     "start_time": "2026-07-11T03:59:28.013354Z"
-    }
-   },
    "cell_type": "code",
+   "id": "2370bd6b",
+   "metadata": {},
    "source": [
     "@fr.atomic\n",
     "def rescale(value: int | float, factor: float = 1.0) -> float:\n",
@@ -3435,49 +2993,32 @@
     "    scaled = rescale_all(to_scale, scale)\n",
     "    return scaled"
    ],
-   "id": "7ca53a662f660901",
    "outputs": [],
-   "execution_count": 60
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.021921Z",
-     "start_time": "2026-07-11T03:59:28.018859Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "node_data = fr.tools.recipe2data(scaled_range.flowrep_recipe)",
-   "id": "f044f5954e57507c",
-   "outputs": [],
-   "execution_count": 61
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.034478Z",
-     "start_time": "2026-07-11T03:59:28.022277Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "type(node_data.recipe)",
-   "id": "a1bd687271aa5721",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "flowrep.prospective.workflow_recipe.WorkflowRecipe"
-      ]
-     },
-     "execution_count": 62,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 62
+   "execution_count": null
   },
   {
    "metadata": {},
+   "cell_type": "code",
+   "source": "node_data = fr.tools.recipe2data(scaled_range.flowrep_recipe)",
+   "id": "833e6b0ceb72e917",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "type(node_data.recipe)",
+   "id": "d8537a11cde237e4",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.018411Z",
+     "start_time": "2026-07-11T03:59:28.013354Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "### 8.1 Recursive construction\n",
@@ -3485,13 +3026,13 @@
     "The first thing to note is that the conversion is recursive.\n",
     "When converting a workflow to its data instance, the conversion happens to recipes the whole way through the graph and to all subgraphs."
    ],
-   "id": "1ec4a0ac252961ef"
+   "id": "7ca53a662f660901"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.053203Z",
-     "start_time": "2026-07-11T03:59:28.035405Z"
+     "end_time": "2026-07-11T03:59:28.021921Z",
+     "start_time": "2026-07-11T03:59:28.018859Z"
     }
    },
    "cell_type": "code",
@@ -3506,6 +3047,39 @@
     "\n",
     "recursively_look_at_data_nodes(node_data)"
    ],
+   "id": "f044f5954e57507c",
+   "outputs": [],
+   "execution_count": 61
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.034478Z",
+     "start_time": "2026-07-11T03:59:28.022277Z"
+    }
+   },
+   "cell_type": "markdown",
+   "source": "### 8.2 IO ports",
+   "id": "a1bd687271aa5721"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "For each data node, we can look at its input and outputs.\n",
+    "To start with, since they represent an un-run recipe all their actual values will be a special \"not data\" object:"
+   ],
+   "id": "1ec4a0ac252961ef"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.053203Z",
+     "start_time": "2026-07-11T03:59:28.035405Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "node_data.input_ports[\"n\"].value",
    "id": "aec301f79141f523",
    "outputs": [
     {
@@ -3523,17 +3097,16 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "### 8.2 IO ports",
+   "source": "But default values are parsed for input ports (where available), and hold their actual python values:",
    "id": "dfe8a73f0f059be7"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": [
-    "For each data node, we can look at its input and outputs.\n",
-    "To start with, since they represent an un-run recipe all their actual values will be a special \"not data\" object:"
-   ],
-   "id": "c9e8560bc82a6038"
+   "cell_type": "code",
+   "source": "node_data.input_ports[\"scale\"].default",
+   "id": "c9e8560bc82a6038",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -3542,28 +3115,22 @@
      "start_time": "2026-07-11T03:59:28.054289Z"
     }
    },
-   "cell_type": "code",
-   "source": "node_data.input_ports[\"n\"].value",
-   "id": "c6545f09fe38cc1b",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "NOT_DATA"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 64
+   "cell_type": "markdown",
+   "source": "The same is true of IO annotations:",
+   "id": "c6545f09fe38cc1b"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": "But default values are parsed for input ports (where available), and hold their actual python values:",
-   "id": "6d43e80546840ed0"
+   "cell_type": "code",
+   "source": [
+    "(\n",
+    "    node_data.input_ports[\"scale\"].annotation,\n",
+    "    node_data.output_ports[\"scaled\"].annotation\n",
+    ")"
+   ],
+   "id": "6d43e80546840ed0",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -3572,28 +3139,25 @@
      "start_time": "2026-07-11T03:59:28.070939Z"
     }
    },
-   "cell_type": "code",
-   "source": "node_data.input_ports[\"scale\"].default",
-   "id": "d9dd1ddaf30c4f90",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.0"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 65
+   "cell_type": "markdown",
+   "source": "And of course these are available recusively on the \"live\" children",
+   "id": "d9dd1ddaf30c4f90"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": "The same is true of IO annotations:",
-   "id": "c0c1dc9c6ca8e156"
+   "cell_type": "code",
+   "source": [
+    "(\n",
+    "    node_data.nodes[\"int_list_0\"].input_ports[\"n\"].value,\n",
+    "    node_data.nodes[\"int_list_0\"].input_ports[\"n\"].default,\n",
+    "    node_data.nodes[\"int_list_0\"].input_ports[\"n\"].annotation,\n",
+    "    node_data.nodes[\"int_list_0\"].output_ports[\"output_0\"].value,\n",
+    "    node_data.nodes[\"int_list_0\"].output_ports[\"output_0\"].annotation,\n",
+    ")"
+   ],
+   "id": "c0c1dc9c6ca8e156",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -3602,33 +3166,25 @@
      "start_time": "2026-07-11T03:59:28.084866Z"
     }
    },
-   "cell_type": "code",
+   "cell_type": "markdown",
    "source": [
-    "(\n",
-    "    node_data.input_ports[\"scale\"].annotation,\n",
-    "    node_data.output_ports[\"scaled\"].annotation\n",
-    ")"
+    "### 8.3 Edges\n",
+    "\n",
+    "Just as the recipes subgraphs are recursively instantiated into data nodes, we also provide copies of the edges to represent instance-view edges between our instance-view nodes.\n",
+    "Since the edge data format is already quite simple, we don't need any new data types here and can use our pydantic edge models directly, including their nice succinct printing format:"
    ],
-   "id": "c1ade97f5e96b4ba",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(float, list[float])"
-      ]
-     },
-     "execution_count": 66,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 66
+   "id": "c1ade97f5e96b4ba"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": "And of course these are available recusively on the \"live\" children",
-   "id": "29bb5cf64f1b2ea2"
+   "cell_type": "code",
+   "source": [
+    "for target, source in node_data.input_edges.items():\n",
+    "    print(f\"{source.serialize()} → {target.serialize()}\")"
+   ],
+   "id": "29bb5cf64f1b2ea2",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -3639,13 +3195,8 @@
    },
    "cell_type": "code",
    "source": [
-    "(\n",
-    "    node_data.nodes[\"int_list_0\"].input_ports[\"n\"].value,\n",
-    "    node_data.nodes[\"int_list_0\"].input_ports[\"n\"].default,\n",
-    "    node_data.nodes[\"int_list_0\"].input_ports[\"n\"].annotation,\n",
-    "    node_data.nodes[\"int_list_0\"].output_ports[\"output_0\"].value,\n",
-    "    node_data.nodes[\"int_list_0\"].output_ports[\"output_0\"].annotation,\n",
-    ")"
+    "for target, source in node_data.edges.items():\n",
+    "    print(f\"{source.serialize()} → {target.serialize()}\")"
    ],
    "id": "1468f7bd033bb028",
    "outputs": [
@@ -3664,14 +3215,14 @@
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
+   "cell_type": "code",
    "source": [
-    "### 8.3 Edges\n",
-    "\n",
-    "Just as the recipes subgraphs are recursively instantiated into data nodes, we also provide copies of the edges to represent instance-view edges between our instance-view nodes.\n",
-    "Since the edge data format is already quite simple, we don't need any new data types here and can use our pydantic edge models directly, including their nice succinct printing format:"
+    "for target, source in node_data.output_edges.items():\n",
+    "    print(f\"{source.serialize()} → {target.serialize()}\")"
    ],
-   "id": "df3500015b3a2f5a"
+   "id": "df3500015b3a2f5a",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -3680,23 +3231,18 @@
      "start_time": "2026-07-11T03:59:28.116392Z"
     }
    },
-   "cell_type": "code",
+   "cell_type": "markdown",
    "source": [
-    "for target, source in node_data.input_edges.items():\n",
-    "    print(f\"{source.serialize()} → {target.serialize()}\")"
+    "### 8.4 Flow controls\n",
+    "\n",
+    "Flow control recipes are significantly more complex than static workflows, because prospectively we don't know what their body subgraphs will look like.\n",
+    "_Retrospectively_, we do know this -- and it's always a simple DAG!\n",
+    "Thus, while all the flow control data nodes have their own output class to retain a 1:1 relationship between the retrospective data format and the underlying recipe, their behaviour at this stage is identical: they all initializes as an empty DAG.\n",
+    "The main difference between workflow data and a flow control data node is that the workflow can initialize to a non-empty graph, while for all the flow controls it is the responsibility of the WfMS to follow the recipe and populate the DAG at runtime.\n",
+    "\n",
+    "In our example, we can see that the deeply-nested for-loop node has no subgraph info of its own yet:"
    ],
-   "id": "8016d71ec8195853",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "n → int_list_0.n\n",
-      "scale → rescale_all_0.factor\n"
-     ]
-    }
-   ],
-   "execution_count": 68
+   "id": "8016d71ec8195853"
   },
   {
    "metadata": {
@@ -3707,8 +3253,15 @@
    },
    "cell_type": "code",
    "source": [
-    "for target, source in node_data.edges.items():\n",
-    "    print(f\"{source.serialize()} → {target.serialize()}\")"
+    "for_data = node_data.nodes[\"rescale_all_0\"].nodes[\"for_each_0\"]\n",
+    "\n",
+    "(\n",
+    "    for_data.recipe.type,\n",
+    "    for_data.nodes,\n",
+    "    for_data.input_edges,\n",
+    "    for_data.edges,\n",
+    "    for_data.output_edges,\n",
+    ")"
    ],
    "id": "8003b380315257cd",
    "outputs": [
@@ -3729,74 +3282,6 @@
      "start_time": "2026-07-11T03:59:28.220696Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "for target, source in node_data.output_edges.items():\n",
-    "    print(f\"{source.serialize()} → {target.serialize()}\")"
-   ],
-   "id": "56f385796c984111",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "rescale_all_0.results → scaled\n"
-     ]
-    }
-   ],
-   "execution_count": 70
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
-    "### 8.4 Flow controls\n",
-    "\n",
-    "Flow control recipes are significantly more complex than static workflows, because prospectively we don't know what their body subgraphs will look like.\n",
-    "_Retrospectively_, we do know this -- and it's always a simple DAG!\n",
-    "Thus, while all the flow control data nodes have their own output class to retain a 1:1 relationship between the retrospective data format and the underlying recipe, their behaviour at this stage is identical: they all initializes as an empty DAG.\n",
-    "The main difference between workflow data and a flow control data node is that the workflow can initialize to a non-empty graph, while for all the flow controls it is the responsibility of the WfMS to follow the recipe and populate the DAG at runtime.\n",
-    "\n",
-    "In our example, we can see that the deeply-nested for-loop node has no subgraph info of its own yet:"
-   ],
-   "id": "cc1e5c958dd87720"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.248350Z",
-     "start_time": "2026-07-11T03:59:28.235562Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "for_data = node_data.nodes[\"rescale_all_0\"].nodes[\"for_each_0\"]\n",
-    "\n",
-    "(\n",
-    "    for_data.recipe.type,\n",
-    "    for_data.nodes,\n",
-    "    for_data.input_edges,\n",
-    "    for_data.edges,\n",
-    "    for_data.output_edges,\n",
-    ")"
-   ],
-   "id": "80942d3b934ef105",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(<RecipeElementType.FOR_EACH: 'for_each'>, {}, {}, {}, {})"
-      ]
-     },
-     "execution_count": 71,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 71
-  },
-  {
-   "metadata": {},
    "cell_type": "markdown",
    "source": [
     "### 8.5 Aside on annotations\n",
@@ -3805,15 +3290,10 @@
     "\n",
     "It's customary in python to sometimes hide annotations behind a fake import, which never actually executes at runtime:"
    ],
-   "id": "5dd2fc6e39e728b4"
+   "id": "56f385796c984111"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.256186Z",
-     "start_time": "2026-07-11T03:59:28.249195Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "from __future__ import annotations\n",
@@ -3827,23 +3307,23 @@
     "def get_blue(colors: SeabornColors) -> str:\n",
     "    return colors.blue"
    ],
-   "id": "ca0292eb59cf963a",
+   "id": "cc1e5c958dd87720",
    "outputs": [],
-   "execution_count": 72
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "This is completely fine at a recipe level, but if we try to convert the recipe into data we won't be able to find `SeabornColors` to populate the hint field!",
-   "id": "36045479099ade66"
+   "execution_count": null
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.270600Z",
-     "start_time": "2026-07-11T03:59:28.256991Z"
+     "end_time": "2026-07-11T03:59:28.248350Z",
+     "start_time": "2026-07-11T03:59:28.235562Z"
     }
    },
+   "cell_type": "markdown",
+   "source": "This is completely fine at a recipe level, but if we try to convert the recipe into data we won't be able to find `SeabornColors` to populate the hint field!",
+   "id": "80942d3b934ef105"
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "try:\n",
@@ -3851,31 +3331,23 @@
     "except NameError as e:\n",
     "    print(e)"
    ],
-   "id": "44fa91cf59e164c7",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "While parsing '__main__.get_blue' for recipe inputs ['colors'] and outputs ['output_0'], could not find the symbol for at least one annotation. This is likely due to forward referenced annotations. Please cross reference the underlying name error (\"name 'SeabornColors' is not defined\") and the function being parsed, and locally make the necessary imports before re-parsing.\n"
-     ]
-    }
-   ],
-   "execution_count": 73
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "To solve this, prior to data-fying your recipes, you need to locally import the relevant types. We try to make the error message above as helpful as possible, but you may need to go read the source scope where the underlying function was defined and decorated to learn exactly what import to use.",
-   "id": "8fc856912a06a735"
+   "id": "5dd2fc6e39e728b4",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.285169Z",
-     "start_time": "2026-07-11T03:59:28.271440Z"
+     "end_time": "2026-07-11T03:59:28.256186Z",
+     "start_time": "2026-07-11T03:59:28.249195Z"
     }
    },
+   "cell_type": "markdown",
+   "source": "To solve this, prior to data-fying your recipes, you need to locally import the relevant types. We try to make the error message above as helpful as possible, but you may need to go read the source scope where the underlying function was defined and decorated to learn exactly what import to use.",
+   "id": "ca0292eb59cf963a"
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "from pyiron_snippets.colors import SeabornColors\n",
@@ -3884,23 +3356,17 @@
     "\n",
     "data.input_ports[\"colors\"].annotation"
    ],
-   "id": "1fc5221b5f62a0da",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "pyiron_snippets.colors.SeabornColors"
-      ]
-     },
-     "execution_count": 74,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 74
+   "id": "36045479099ade66",
+   "outputs": [],
+   "execution_count": null
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.270600Z",
+     "start_time": "2026-07-11T03:59:28.256991Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "### 8.6 A Toy WfMS\n",
@@ -3911,7 +3377,37 @@
     "Since all our recipe ports must be named, the engine is accessed by a simple runner function that demands all input data be provided with keyword arguments.\n",
     "Default values are exploited where available, as demonstrated by the fact we will omit a `scale=...` argument to our call:"
    ],
-   "id": "47a7f46ae249d2f6"
+   "id": "44fa91cf59e164c7"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "ran_node = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=3)",
+   "id": "8fc856912a06a735",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.285169Z",
+     "start_time": "2026-07-11T03:59:28.271440Z"
+    }
+   },
+   "cell_type": "markdown",
+   "source": [
+    "Post-facto, the values of each IO port are fully populated.\n",
+    "We can look at the results of the workflow:"
+   ],
+   "id": "1fc5221b5f62a0da"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "ran_node.output_ports[\"scaled\"].value",
+   "id": "47a7f46ae249d2f6",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -3920,58 +3416,12 @@
      "start_time": "2026-07-11T03:59:28.286066Z"
     }
    },
-   "cell_type": "code",
-   "source": "ran_node = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=3)",
-   "id": "54c1c113638190b8",
-   "outputs": [],
-   "execution_count": 75
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
-    "Post-facto, the values of each IO port are fully populated.\n",
-    "We can look at the results of the workflow:"
-   ],
-   "id": "72982d6646db5e03"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.305512Z",
-     "start_time": "2026-07-11T03:59:28.291868Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "ran_node.output_ports[\"scaled\"].value",
-   "id": "65a9e2c8660174e",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[0.0, 1.0, 2.0]"
-      ]
-     },
-     "execution_count": 76,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 76
-  },
-  {
-   "metadata": {},
    "cell_type": "markdown",
    "source": "And/or use the graph-structure of the workflow to investigate the data provenance of each step, even deep inside a subgraph:",
-   "id": "1264d43293ffbd43"
+   "id": "54c1c113638190b8"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.318869Z",
-     "start_time": "2026-07-11T03:59:28.306752Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "ran_for = ran_node.nodes[\"rescale_all_0\"].nodes[\"for_each_0\"]\n",
@@ -3983,22 +3433,17 @@
     "        f\"→ {body_node.output_ports['scaled'].value}\"\n",
     "    )"
    ],
-   "id": "df5a0ed5a28fd5cf",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "For-loop child body_0 transformed 0*1.0 → 0.0\n",
-      "For-loop child body_1 transformed 1*1.0 → 1.0\n",
-      "For-loop child body_2 transformed 2*1.0 → 2.0\n"
-     ]
-    }
-   ],
-   "execution_count": 77
+   "id": "72982d6646db5e03",
+   "outputs": [],
+   "execution_count": null
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.305512Z",
+     "start_time": "2026-07-11T03:59:28.291868Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "### 8.7 Convenient storage and retrieval\n",
@@ -4008,15 +3453,10 @@
     "\n",
     "Let's start by running a simple for-loop -- something easy to understand, but with non-trivial structure:"
    ],
-   "id": "8d092cdcf9c0e517"
+   "id": "65a9e2c8660174e"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.334711Z",
-     "start_time": "2026-07-11T03:59:28.319711Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "@fr.atomic\n",
@@ -4048,46 +3488,40 @@
     "executed = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=5)\n",
     "executed.output_ports"
    ],
-   "id": "f94e046ee2730c68",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'scaled': OutputDataPort(value=[0.0, 1.0, 2.0, 3.0, 4.0], annotation=list[float])}"
-      ]
-     },
-     "execution_count": 78,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 78
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "Saving with `bagofholding` is straightforward:",
-   "id": "caeb3c190f954f71"
+   "id": "1264d43293ffbd43",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.698253Z",
-     "start_time": "2026-07-11T03:59:28.335655Z"
+     "end_time": "2026-07-11T03:59:28.318869Z",
+     "start_time": "2026-07-11T03:59:28.306752Z"
     }
    },
+   "cell_type": "markdown",
+   "source": "Saving with `bagofholding` is straightforward:",
+   "id": "df5a0ed5a28fd5cf"
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "import bagofholding as boh\n",
     "\n",
     "boh.H5Bag.save(executed, \"executed.h5\", overwrite_existing=True)"
    ],
-   "id": "c4fe9644c6e43a16",
+   "id": "8d092cdcf9c0e517",
    "outputs": [],
-   "execution_count": 79
+   "execution_count": null
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.334711Z",
+     "start_time": "2026-07-11T03:59:28.319711Z"
+    }
+   },
    "cell_type": "markdown",
    "source": [
     "One of the benefits of `bagofholding`'s structure is that results are browseable and partially-loadable -- i.e. we don't need to reload the _entire_ python object from disk, rather we can reload just a subset, like a particular subgraph or particular output value.\n",
@@ -4097,7 +3531,40 @@
     "\n",
     "For instance, we can browse the entire lexical structure of our stored workflow like this:"
    ],
-   "id": "412ddc4424bcefd3"
+   "id": "f94e046ee2730c68"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "browser = fr.tools.LexicalBagBrowser(\"executed.h5\")\n",
+    "browser.list_paths()"
+   ],
+   "id": "caeb3c190f954f71",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-11T03:59:28.698253Z",
+     "start_time": "2026-07-11T03:59:28.335655Z"
+    }
+   },
+   "cell_type": "markdown",
+   "source": "We can then re-instantiate from file only a particular node",
+   "id": "c4fe9644c6e43a16"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "reloaded_node = browser.load(\"rescale_all_0\")\n",
+    "isinstance(reloaded_node, fr.schemas.DagData), reloaded_node.nodes.keys()"
+   ],
+   "id": "412ddc4424bcefd3",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -4106,84 +3573,20 @@
      "start_time": "2026-07-11T03:59:28.703632Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "browser = fr.tools.LexicalBagBrowser(\"executed.h5\")\n",
-    "browser.list_paths()"
-   ],
-   "id": "4433e29b74f02efe",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['inputs.n',\n",
-       " 'inputs.scale',\n",
-       " 'outputs.scaled',\n",
-       " 'int_list_0',\n",
-       " 'int_list_0.inputs.n',\n",
-       " 'int_list_0.outputs.output_0',\n",
-       " 'rescale_all_0',\n",
-       " 'rescale_all_0.inputs.factor',\n",
-       " 'rescale_all_0.inputs.items',\n",
-       " 'rescale_all_0.outputs.results',\n",
-       " 'rescale_all_0.for_each_0',\n",
-       " 'rescale_all_0.for_each_0.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.inputs.items',\n",
-       " 'rescale_all_0.for_each_0.outputs.results',\n",
-       " 'rescale_all_0.for_each_0.body_0',\n",
-       " 'rescale_all_0.for_each_0.body_0.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_0.inputs.item',\n",
-       " 'rescale_all_0.for_each_0.body_0.outputs.scaled',\n",
-       " 'rescale_all_0.for_each_0.body_0.rescale_0',\n",
-       " 'rescale_all_0.for_each_0.body_0.rescale_0.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_0.rescale_0.inputs.value',\n",
-       " 'rescale_all_0.for_each_0.body_0.rescale_0.outputs.result',\n",
-       " 'rescale_all_0.for_each_0.body_1',\n",
-       " 'rescale_all_0.for_each_0.body_1.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_1.inputs.item',\n",
-       " 'rescale_all_0.for_each_0.body_1.outputs.scaled',\n",
-       " 'rescale_all_0.for_each_0.body_1.rescale_0',\n",
-       " 'rescale_all_0.for_each_0.body_1.rescale_0.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_1.rescale_0.inputs.value',\n",
-       " 'rescale_all_0.for_each_0.body_1.rescale_0.outputs.result',\n",
-       " 'rescale_all_0.for_each_0.body_2',\n",
-       " 'rescale_all_0.for_each_0.body_2.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_2.inputs.item',\n",
-       " 'rescale_all_0.for_each_0.body_2.outputs.scaled',\n",
-       " 'rescale_all_0.for_each_0.body_2.rescale_0',\n",
-       " 'rescale_all_0.for_each_0.body_2.rescale_0.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_2.rescale_0.inputs.value',\n",
-       " 'rescale_all_0.for_each_0.body_2.rescale_0.outputs.result',\n",
-       " 'rescale_all_0.for_each_0.body_3',\n",
-       " 'rescale_all_0.for_each_0.body_3.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_3.inputs.item',\n",
-       " 'rescale_all_0.for_each_0.body_3.outputs.scaled',\n",
-       " 'rescale_all_0.for_each_0.body_3.rescale_0',\n",
-       " 'rescale_all_0.for_each_0.body_3.rescale_0.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_3.rescale_0.inputs.value',\n",
-       " 'rescale_all_0.for_each_0.body_3.rescale_0.outputs.result',\n",
-       " 'rescale_all_0.for_each_0.body_4',\n",
-       " 'rescale_all_0.for_each_0.body_4.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_4.inputs.item',\n",
-       " 'rescale_all_0.for_each_0.body_4.outputs.scaled',\n",
-       " 'rescale_all_0.for_each_0.body_4.rescale_0',\n",
-       " 'rescale_all_0.for_each_0.body_4.rescale_0.inputs.factor',\n",
-       " 'rescale_all_0.for_each_0.body_4.rescale_0.inputs.value',\n",
-       " 'rescale_all_0.for_each_0.body_4.rescale_0.outputs.result']"
-      ]
-     },
-     "execution_count": 80,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 80
+   "cell_type": "markdown",
+   "source": "Or a particular port",
+   "id": "4433e29b74f02efe"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": "We can then re-instantiate from file only a particular node",
-   "id": "d948155042459cb"
+   "cell_type": "code",
+   "source": [
+    "reloaded_port = browser.load(\"rescale_all_0.for_each_0.body_1.inputs.item\")\n",
+    "isinstance(reloaded_port, fr.schemas.InputDataPort), reloaded_port.value"
+   ],
+   "id": "d948155042459cb",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -4192,31 +3595,25 @@
      "start_time": "2026-07-11T03:59:28.727957Z"
     }
    },
-   "cell_type": "code",
+   "cell_type": "markdown",
    "source": [
-    "reloaded_node = browser.load(\"rescale_all_0\")\n",
-    "isinstance(reloaded_node, fr.schemas.DagData), reloaded_node.nodes.keys()"
+    "The input and output port collections are stopping points in a plausible lexical path, but for the sake of return-type simplicity, the browser will _only_ load ports and nodes.\n",
+    "If you try to reload one of the IO collections, you get a clean error:"
    ],
-   "id": "c3622954ff23bc6f",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(True, dict_keys(['for_each_0']))"
-      ]
-     },
-     "execution_count": 81,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 81
+   "id": "c3622954ff23bc6f"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": "Or a particular port",
-   "id": "e0e550efad910586"
+   "cell_type": "code",
+   "source": [
+    "try:\n",
+    "    browser.load(\"rescale_all_0.inputs\")\n",
+    "except ValueError as e:\n",
+    "    print(e)"
+   ],
+   "id": "e0e550efad910586",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -4225,34 +3622,20 @@
      "start_time": "2026-07-11T03:59:29.075064Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "reloaded_port = browser.load(\"rescale_all_0.for_each_0.body_1.inputs.item\")\n",
-    "isinstance(reloaded_port, fr.schemas.InputDataPort), reloaded_port.value"
-   ],
-   "id": "51463f7d0fa254be",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(True, 1)"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 82
+   "cell_type": "markdown",
+   "source": "In a jupyter environment like this, there is also a browser widget to view the tree structure of the graph:",
+   "id": "51463f7d0fa254be"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
+   "cell_type": "code",
    "source": [
-    "The input and output port collections are stopping points in a plausible lexical path, but for the sake of return-type simplicity, the browser will _only_ load ports and nodes.\n",
-    "If you try to reload one of the IO collections, you get a clean error:"
+    "widget = browser.browse()\n",
+    "widget"
    ],
-   "id": "1b10ad697f945ac5"
+   "id": "1b10ad697f945ac5",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {
@@ -4261,29 +3644,14 @@
      "start_time": "2026-07-11T03:59:29.096217Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "try:\n",
-    "    browser.load(\"rescale_all_0.inputs\")\n",
-    "except ValueError as e:\n",
-    "    print(e)"
-   ],
-   "id": "3fab94fab657aebd",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Path terminated in 'inputs'. Please select an individual port to load from among ('factor', 'items')\n"
-     ]
-    }
-   ],
-   "execution_count": 83
+   "cell_type": "markdown",
+   "source": "In an interactive session, you can select an item and then `widget.load_selected()` to re-instantiate it.",
+   "id": "3fab94fab657aebd"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "In a jupyter environment like this, there is also a browser widget to view the tree structure of the graph:",
+   "source": "There is no deep magic in this tool, it is just a convenient shortcut for mapping the \"Lexical path\" of a `fr.schemas.LiveWorkflow` to the underlying `bagofholding.H5Bag` file structure.",
    "id": "a5d1637cb2072044"
   },
   {
@@ -4293,42 +3661,41 @@
      "start_time": "2026-07-11T03:59:29.122996Z"
     }
    },
-   "cell_type": "code",
+   "cell_type": "markdown",
    "source": [
-    "widget = browser.browse()\n",
-    "widget"
+    "---\n",
+    "## Summary\n",
+    "\n",
+    "| Concept             | Key point                                                          |\n",
+    "|---------------------|--------------------------------------------------------------------|\n",
+    "| Atomic nodes        | Wrap a single function call; ephemeral internals                   |\n",
+    "| Workflows           | Static DAG of child nodes; fully known at definition time          |\n",
+    "| Edges               | `target: source` dicts; three levels (input, sibling, output)      |\n",
+    "| ForEach-nodes       | Iterate + accumulate; broadcast vs scatter                         |\n",
+    "| If-nodes            | Branching with prospective output edges                            |\n",
+    "| While-nodes         | Loop with output ⊆ input constraint                                |\n",
+    "| Try-nodes           | Exception dispatch with prospective outputs                        |\n",
+    "| Provenance          | `PythonReference` + version scraping + constraints                 |\n",
+    "| Compiling           | Build recipes into python functions and dump as source code to .py |\n",
+    "| Converters          | Interop with PWD (flat DAG workflows only)                         |\n",
+    "| retrospective nodes | Instance-views for data-ful workflows                              |\n",
+    "| WfMS                | Convert recipes into retrospective instance views                  |\n",
+    "\n",
+    "All recipes are **prospective** (no data), **JSON-serialisable**, and designed\n",
+    "so that executing them produces the same result as running the original Python\n",
+    "functions. Accompanying retrospective instance-view dataclasses provide a format for associating\n",
+    "recipes and data, and a toy WfMS demonstrates the conversion between\n",
+    "prospective recipes and data."
    ],
-   "id": "50bfd15d81eabf32",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "LexicalBagTree(multiple_selection=False, nodes=(Node(close_icon_style='danger', name='Workflow', nodes=(Node(c…"
-      ],
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "2a6153ff8d92439682550b236f758e0a"
-      }
-     },
-     "execution_count": 84,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 84
+   "id": "50bfd15d81eabf32"
   },
   {
    "metadata": {},
-   "cell_type": "markdown",
-   "source": "In an interactive session, you can select an item and then `widget.load_selected()` to re-instantiate it.",
-   "id": "947adb096007fe7e"
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "There is no deep magic in this tool, it is just a convenient shortcut for mapping the \"Lexical path\" of a `fr.schemas.LiveWorkflow` to the underlying `bagofholding.H5Bag` file structure.",
-   "id": "f1fcb3577dd088f8"
+   "cell_type": "code",
+   "source": "",
+   "id": "947adb096007fe7e",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -4359,19 +3726,6 @@
     "prospective recipes and data."
    ],
    "id": "6bce09a118e4be2c"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:29.226332Z",
-     "start_time": "2026-07-11T03:59:29.215800Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "",
-   "id": "f9bf1a0cd6d6913c",
-   "outputs": [],
-   "execution_count": 84
   }
  ],
  "metadata": {

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -37,8 +37,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.763353Z",
-     "start_time": "2026-07-11T03:59:26.493392Z"
+     "end_time": "2026-07-17T16:35:51.887622Z",
+     "start_time": "2026-07-17T16:35:51.588565Z"
     }
    },
    "cell_type": "code",
@@ -103,8 +103,8 @@
    "id": "8590ac6e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.799300Z",
-     "start_time": "2026-07-11T03:59:26.767530Z"
+     "end_time": "2026-07-17T16:35:51.921231Z",
+     "start_time": "2026-07-17T16:35:51.899253Z"
     }
    },
    "source": [
@@ -163,8 +163,8 @@
    "id": "fbb2ac82",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.820218Z",
-     "start_time": "2026-07-11T03:59:26.810921Z"
+     "end_time": "2026-07-17T16:35:51.955088Z",
+     "start_time": "2026-07-17T16:35:51.923936Z"
     }
    },
    "source": [
@@ -204,8 +204,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.851682Z",
-     "start_time": "2026-07-11T03:59:26.835165Z"
+     "end_time": "2026-07-17T16:35:52.003204Z",
+     "start_time": "2026-07-17T16:35:51.978757Z"
     }
    },
    "cell_type": "code",
@@ -240,8 +240,8 @@
    "id": "4ce6917d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.882655Z",
-     "start_time": "2026-07-11T03:59:26.865800Z"
+     "end_time": "2026-07-17T16:35:52.052606Z",
+     "start_time": "2026-07-17T16:35:52.005916Z"
     }
    },
    "source": [
@@ -312,8 +312,8 @@
    "id": "cac0a1bd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.923576Z",
-     "start_time": "2026-07-11T03:59:26.894563Z"
+     "end_time": "2026-07-17T16:35:52.078388Z",
+     "start_time": "2026-07-17T16:35:52.055325Z"
     }
    },
    "source": [
@@ -353,8 +353,8 @@
    "id": "9f659bd7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.973444Z",
-     "start_time": "2026-07-11T03:59:26.925617Z"
+     "end_time": "2026-07-17T16:35:52.109321Z",
+     "start_time": "2026-07-17T16:35:52.081121Z"
     }
    },
    "source": [
@@ -393,8 +393,8 @@
    "id": "467bd6b8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:26.989432Z",
-     "start_time": "2026-07-11T03:59:26.975366Z"
+     "end_time": "2026-07-17T16:35:52.186280Z",
+     "start_time": "2026-07-17T16:35:52.111956Z"
     }
    },
    "source": [
@@ -447,8 +447,8 @@
    "id": "0d46e437",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.016177Z",
-     "start_time": "2026-07-11T03:59:26.999641Z"
+     "end_time": "2026-07-17T16:35:52.219335Z",
+     "start_time": "2026-07-17T16:35:52.189359Z"
     }
    },
    "source": [
@@ -475,7 +475,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Outputs: ['x', 'y']\n"
+      "Outputs: ['magnitude', 'angle']\n"
      ]
     }
    ],
@@ -494,8 +494,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.066635Z",
-     "start_time": "2026-07-11T03:59:27.027778Z"
+     "end_time": "2026-07-17T16:35:52.258737Z",
+     "start_time": "2026-07-17T16:35:52.231116Z"
     }
    },
    "cell_type": "code",
@@ -517,14 +517,11 @@
    "id": "bebb33c6345c3ab9",
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Point(x=1, y=2)"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outputs: ['my_magnitude', 'my_angle']\n"
+     ]
     }
    ],
    "execution_count": 10
@@ -549,8 +546,8 @@
    "id": "77276c40",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.086897Z",
-     "start_time": "2026-07-11T03:59:27.077624Z"
+     "end_time": "2026-07-17T16:35:52.288274Z",
+     "start_time": "2026-07-17T16:35:52.261282Z"
     }
    },
    "source": [
@@ -568,7 +565,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Outputs: ['magnitude', 'angle']\n"
+      "Module:           __main__\n",
+      "Qualname:         add\n",
+      "Version:          None\n",
+      "FQN:              __main__.add\n",
+      "Defaults:         []\n",
+      "Restricted kinds: {}\n"
      ]
     }
    ],
@@ -624,8 +626,8 @@
    "id": "b8f03ee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.220959Z",
-     "start_time": "2026-07-11T03:59:27.150738Z"
+     "end_time": "2026-07-17T16:35:52.317262Z",
+     "start_time": "2026-07-17T16:35:52.291185Z"
     }
    },
    "source": [
@@ -662,16 +664,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Module:           __main__\n",
-      "Qualname:         add\n",
-      "Version:          None\n",
-      "FQN:              __main__.add\n",
-      "Defaults:         []\n",
-      "Restricted kinds: {}\n"
+      "__main__.MyClass ['x'] ['instance']\n",
+      "__main__.MyClass.some_method ['self', 'y'] ['output_0']\n",
+      "__main__.MyClass.some_static ['a'] ['triple', 'single']\n"
      ]
     }
    ],
-   "execution_count": 13
+   "execution_count": 12
   },
   {
    "cell_type": "markdown",
@@ -682,7 +681,12 @@
   {
    "cell_type": "code",
    "id": "66ac7ffa",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:52.362774Z",
+     "start_time": "2026-07-17T16:35:52.320013Z"
+    }
+   },
    "source": [
     "import dataclasses\n",
     "\n",
@@ -695,8 +699,27 @@
     "print(\"Recipe?\", type(MyDataclass.flowrep_recipe))\n",
     "MyDataclass.flowrep_recipe.inputs, MyDataclass.flowrep_recipe.outputs"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataclass? True\n",
+      "Recipe? <class 'flowrep.prospective.atomic_recipe.AtomicRecipe'>\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(['a', 'x'], ['instance'])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 13
   },
   {
    "metadata": {},
@@ -707,8 +730,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.261236Z",
-     "start_time": "2026-07-11T03:59:27.241863Z"
+     "end_time": "2026-07-17T16:35:52.454109Z",
+     "start_time": "2026-07-17T16:35:52.365291Z"
     }
    },
    "cell_type": "code",
@@ -725,10 +748,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "__main__.MyClass ['x'] ['instance']\n",
-      "__main__.MyClass.some_method ['self', 'y'] ['output_0']\n",
-      "__main__.MyClass.some_static ['a'] ['triple', 'single']\n"
+      "Inverse inputs:  ['dataclass']\n",
+      "Inverse outputs: ['a', 'x']\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "('hello', 7)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "execution_count": 14
@@ -768,7 +800,12 @@
    "id": "ec98d006c8259b8e"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:52.517554Z",
+     "start_time": "2026-07-17T16:35:52.494809Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "import numpy as np\n",
@@ -787,8 +824,17 @@
     "print(f\"Outputs: {linspace_node.outputs}\")"
    ],
    "id": "cd048745aefa7acc",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inputs:  ['start', 'stop', 'num']\n",
+      "Outputs: ['samples']\n"
+     ]
+    }
+   ],
+   "execution_count": 15
   },
   {
    "metadata": {
@@ -810,7 +856,12 @@
   {
    "cell_type": "code",
    "id": "67cf6163",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:52.575236Z",
+     "start_time": "2026-07-17T16:35:52.541996Z"
+    }
+   },
    "source": [
     "arange_node = fr.schemas.AtomicRecipe(\n",
     "    reference=fr.schemas.PythonReference(\n",
@@ -828,8 +879,16 @@
     ")\n",
     "print(f\"Restricted kinds: {arange_node.reference.restricted_input_kinds}\")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Restricted kinds: {'start': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'stop': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'step': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>}\n"
+     ]
+    }
+   ],
+   "execution_count": 16
   },
   {
    "cell_type": "markdown",
@@ -860,12 +919,28 @@
    ]
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:52.617511Z",
+     "start_time": "2026-07-17T16:35:52.588423Z"
+    }
+   },
    "cell_type": "code",
    "source": "arange_node(start=1, stop=2, step=3)",
    "id": "d0b951260802626c",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 17
   },
   {
    "metadata": {
@@ -883,7 +958,12 @@
    "id": "f0bac0d25a93b5fa"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:52.650483Z",
+     "start_time": "2026-07-17T16:35:52.630568Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "def my_dict_maker(**kwargs):\n",
@@ -905,14 +985,22 @@
     "print(f\"Restricted kinds: {my_particular_dict_recipe.reference.restricted_input_kinds}\")"
    ],
    "id": "396728243a8a212e",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Restricted kinds: {'this': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'that': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'the_other': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>}\n"
+     ]
+    }
+   ],
+   "execution_count": 18
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.346151Z",
-     "start_time": "2026-07-11T03:59:27.332863Z"
+     "end_time": "2026-07-17T16:35:52.693117Z",
+     "start_time": "2026-07-17T16:35:52.662339Z"
     }
    },
    "cell_type": "code",
@@ -922,7 +1010,7 @@
     {
      "data": {
       "text/plain": [
-       "(Point(x=1, y=2), (1, 2))"
+       "{'this': 1, 'that': 2, 'the_other': 3}"
       ]
      },
      "execution_count": 19,
@@ -941,8 +1029,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.360882Z",
-     "start_time": "2026-07-11T03:59:27.347172Z"
+     "end_time": "2026-07-17T16:35:52.726707Z",
+     "start_time": "2026-07-17T16:35:52.695773Z"
     }
    },
    "cell_type": "code",
@@ -975,7 +1063,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Restricted kinds: {'this': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'that': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>, 'the_other': <RestrictedParamKind.KEYWORD_ONLY: 'KEYWORD_ONLY'>}\n"
+      "Restricted kinds: {'a': <RestrictedParamKind.POSITIONAL_ONLY: 'POSITIONAL_ONLY'>, 'b': <RestrictedParamKind.POSITIONAL_ONLY: 'POSITIONAL_ONLY'>}\n"
      ]
     }
    ],
@@ -984,8 +1072,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.375564Z",
-     "start_time": "2026-07-11T03:59:27.362210Z"
+     "end_time": "2026-07-17T16:35:52.763571Z",
+     "start_time": "2026-07-17T16:35:52.730516Z"
     }
    },
    "cell_type": "code",
@@ -995,7 +1083,7 @@
     {
      "data": {
       "text/plain": [
-       "{'this': 1, 'that': 2, 'the_other': 3}"
+       "6"
       ]
      },
      "execution_count": 21,
@@ -1041,8 +1129,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.405635Z",
-     "start_time": "2026-07-11T03:59:27.393499Z"
+     "end_time": "2026-07-17T16:35:52.801121Z",
+     "start_time": "2026-07-17T16:35:52.777734Z"
     }
    },
    "cell_type": "code",
@@ -1075,17 +1163,25 @@
    "id": "ca3cb2598c788de5",
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "linear(3, 2, 1) = 7\n",
+      "Recipe type: WorkflowRecipe\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "6"
+       "WorkflowRecipe(type=<RecipeElementType.WORKFLOW: 'workflow'>, inputs=['x', 'slope', 'intercept'], outputs=['result'], description='y = slope * x + intercept', nodes={'multiply_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>), 'add_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>)}, input_edges={TargetHandle(node='multiply_0', port='x'): InputSource(node=None, port='x'), TargetHandle(node='multiply_0', port='y'): InputSource(node=None, port='slope'), TargetHandle(node='add_0', port='b'): InputSource(node=None, port='intercept')}, edges={TargetHandle(node='add_0', port='a'): SourceHandle(node='multiply_0', port='product')}, output_edges={OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result')}, reference=PythonReference(info=VersionInfo(module='__main__', qualname='linear', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 23
+   "execution_count": 22
   },
   {
    "metadata": {},
@@ -1119,32 +1215,24 @@
    "id": "d39608c2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.428582Z",
-     "start_time": "2026-07-11T03:59:27.407171Z"
+     "end_time": "2026-07-17T16:35:52.841857Z",
+     "start_time": "2026-07-17T16:35:52.817655Z"
     }
    },
    "source": "linear.flowrep_recipe(x=3, slope=2, intercept=1)",
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "linear(3, 2, 1) = 7\n",
-      "Recipe type: WorkflowRecipe\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "WorkflowRecipe(type=<RecipeElementType.WORKFLOW: 'workflow'>, inputs=['x', 'slope', 'intercept'], outputs=['result'], description='y = slope * x + intercept', nodes={'multiply_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>), 'add_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>)}, input_edges={TargetHandle(node='multiply_0', port='x'): InputSource(node=None, port='x'), TargetHandle(node='multiply_0', port='y'): InputSource(node=None, port='slope'), TargetHandle(node='add_0', port='b'): InputSource(node=None, port='intercept')}, edges={TargetHandle(node='add_0', port='a'): SourceHandle(node='multiply_0', port='product')}, output_edges={OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result')}, reference=PythonReference(info=VersionInfo(module='__main__', qualname='linear', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
+       "7"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 24
+   "execution_count": 23
   },
   {
    "cell_type": "markdown",
@@ -1178,8 +1266,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.443414Z",
-     "start_time": "2026-07-11T03:59:27.429902Z"
+     "end_time": "2026-07-17T16:35:52.873297Z",
+     "start_time": "2026-07-17T16:35:52.844362Z"
     }
    },
    "cell_type": "code",
@@ -1210,17 +1298,16 @@
    "id": "ce41773494e520c8",
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "7"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top-level nodes: ['linear_0', 'quadratic_0']\n",
+      "linear_0 type:   workflow\n",
+      "linear_0 children: ['multiply_0', 'add_0']\n"
+     ]
     }
    ],
-   "execution_count": 25
+   "execution_count": 24
   },
   {
    "cell_type": "markdown",
@@ -1254,8 +1341,8 @@
    "id": "55716aa9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.458290Z",
-     "start_time": "2026-07-11T03:59:27.444627Z"
+     "end_time": "2026-07-17T16:35:52.904678Z",
+     "start_time": "2026-07-17T16:35:52.875681Z"
     }
    },
    "source": [
@@ -1275,13 +1362,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Top-level nodes: ['linear_0', 'quadratic_0']\n",
-      "linear_0 type:   workflow\n",
-      "linear_0 children: ['multiply_0', 'add_0']\n"
+      "Inputs:  ['a', 'b', 'tag']\n",
+      "Outputs: ['result', 'tag']\n",
+      "Output edges: {OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result'), OutputTarget(node=None, port='tag'): InputSource(node=None, port='tag')}\n"
      ]
     }
    ],
-   "execution_count": 26
+   "execution_count": 25
   },
   {
    "cell_type": "markdown",
@@ -1313,8 +1400,8 @@
    "id": "cd45cbb2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.474424Z",
-     "start_time": "2026-07-11T03:59:27.460856Z"
+     "end_time": "2026-07-17T16:35:52.941271Z",
+     "start_time": "2026-07-17T16:35:52.907377Z"
     }
    },
    "source": [
@@ -1330,18 +1417,8 @@
     "    )\n",
     "    return output_dict"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inputs:  ['a', 'b', 'tag']\n",
-      "Outputs: ['result', 'tag']\n",
-      "Output edges: {OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result'), OutputTarget(node=None, port='tag'): InputSource(node=None, port='tag')}\n"
-     ]
-    }
-   ],
-   "execution_count": 27
+   "outputs": [],
+   "execution_count": 26
   },
   {
    "cell_type": "markdown",
@@ -1353,7 +1430,12 @@
    ]
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.017762Z",
+     "start_time": "2026-07-17T16:35:52.942214Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "child_labels = list(my_workflow_from_recipes.flowrep_recipe.nodes.keys())\n",
@@ -1361,8 +1443,16 @@
     "print(child_labels)"
    ],
    "id": "7e7106b145ffbdc",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arange_0', 'my_dict_maker_0']\n"
+     ]
+    }
+   ],
+   "execution_count": 27
   },
   {
    "metadata": {
@@ -1388,8 +1478,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.494793Z",
-     "start_time": "2026-07-11T03:59:27.481683Z"
+     "end_time": "2026-07-17T16:35:53.041543Z",
+     "start_time": "2026-07-17T16:35:53.020006Z"
     }
    },
    "cell_type": "code",
@@ -1397,14 +1487,17 @@
    "id": "6a0c65a9c8b32b63",
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['arange_0', 'my_dict_maker_0']\n"
-     ]
+     "data": {
+      "text/plain": [
+       "{'this': 'this default', 'that': 'that default', 'the_other': array([0, 2])}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "execution_count": 29
+   "execution_count": 28
   },
   {
    "metadata": {},
@@ -1460,8 +1553,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.513972Z",
-     "start_time": "2026-07-11T03:59:27.496180Z"
+     "end_time": "2026-07-17T16:35:53.067331Z",
+     "start_time": "2026-07-17T16:35:53.043909Z"
     }
    },
    "cell_type": "code",
@@ -1471,15 +1564,15 @@
     {
      "data": {
       "text/plain": [
-       "{'this': 'this default', 'that': 'that default', 'the_other': array([0, 2])}"
+       "(None, None)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 30
+   "execution_count": 29
   },
   {
    "cell_type": "markdown",
@@ -1488,7 +1581,12 @@
    "source": "### 3.3 Inspecting edges"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.092964Z",
+     "start_time": "2026-07-17T16:35:53.069807Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "recipe = linear.flowrep_recipe\n",
@@ -1506,8 +1604,25 @@
     "    print(f\"  {source.serialize()} → {target.serialize()}\")"
    ],
    "id": "7144a6706b877f78",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input edges (parent input → child input):\n",
+      "  x → multiply_0.x\n",
+      "  slope → multiply_0.y\n",
+      "  intercept → add_0.b\n",
+      "\n",
+      "Sibling edges (child → child):\n",
+      "  multiply_0.product → add_0.a\n",
+      "\n",
+      "Output edges (child → parent output):\n",
+      "  add_0.result → result\n"
+     ]
+    }
+   ],
+   "execution_count": 30
   },
   {
    "metadata": {
@@ -1529,14 +1644,102 @@
   {
    "cell_type": "code",
    "id": "13f799b9",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.132504Z",
+     "start_time": "2026-07-17T16:35:53.106047Z"
+    }
+   },
    "source": [
     "import json\n",
     "\n",
     "print(json.dumps(json.loads(recipe.model_dump_json()), indent=2))"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"type\": \"workflow\",\n",
+      "  \"inputs\": [\n",
+      "    \"x\",\n",
+      "    \"slope\",\n",
+      "    \"intercept\"\n",
+      "  ],\n",
+      "  \"outputs\": [\n",
+      "    \"result\"\n",
+      "  ],\n",
+      "  \"description\": \"y = slope * x + intercept\",\n",
+      "  \"nodes\": {\n",
+      "    \"multiply_0\": {\n",
+      "      \"type\": \"atomic\",\n",
+      "      \"inputs\": [\n",
+      "        \"x\",\n",
+      "        \"y\"\n",
+      "      ],\n",
+      "      \"outputs\": [\n",
+      "        \"product\"\n",
+      "      ],\n",
+      "      \"description\": null,\n",
+      "      \"reference\": {\n",
+      "        \"info\": {\n",
+      "          \"module\": \"__main__\",\n",
+      "          \"qualname\": \"multiply\",\n",
+      "          \"version\": null\n",
+      "        },\n",
+      "        \"inputs_with_defaults\": [],\n",
+      "        \"restricted_input_kinds\": {}\n",
+      "      },\n",
+      "      \"unpack_mode\": \"tuple\"\n",
+      "    },\n",
+      "    \"add_0\": {\n",
+      "      \"type\": \"atomic\",\n",
+      "      \"inputs\": [\n",
+      "        \"a\",\n",
+      "        \"b\"\n",
+      "      ],\n",
+      "      \"outputs\": [\n",
+      "        \"result\"\n",
+      "      ],\n",
+      "      \"description\": null,\n",
+      "      \"reference\": {\n",
+      "        \"info\": {\n",
+      "          \"module\": \"__main__\",\n",
+      "          \"qualname\": \"add\",\n",
+      "          \"version\": null\n",
+      "        },\n",
+      "        \"inputs_with_defaults\": [],\n",
+      "        \"restricted_input_kinds\": {}\n",
+      "      },\n",
+      "      \"unpack_mode\": \"tuple\"\n",
+      "    }\n",
+      "  },\n",
+      "  \"input_edges\": {\n",
+      "    \"multiply_0.x\": \"x\",\n",
+      "    \"multiply_0.y\": \"slope\",\n",
+      "    \"add_0.b\": \"intercept\"\n",
+      "  },\n",
+      "  \"edges\": {\n",
+      "    \"add_0.a\": \"multiply_0.product\"\n",
+      "  },\n",
+      "  \"output_edges\": {\n",
+      "    \"result\": \"add_0.result\"\n",
+      "  },\n",
+      "  \"reference\": {\n",
+      "    \"info\": {\n",
+      "      \"module\": \"__main__\",\n",
+      "      \"qualname\": \"linear\",\n",
+      "      \"version\": null\n",
+      "    },\n",
+      "    \"inputs_with_defaults\": [],\n",
+      "    \"restricted_input_kinds\": {}\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "execution_count": 31
   },
   {
    "cell_type": "markdown",
@@ -1556,7 +1759,12 @@
   {
    "cell_type": "code",
    "id": "e67cac8d",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.159638Z",
+     "start_time": "2026-07-17T16:35:53.134821Z"
+    }
+   },
    "source": [
     "# Round-trip demo\n",
     "json_str = recipe.model_dump_json()\n",
@@ -1564,8 +1772,16 @@
     "assert reconstructed == recipe\n",
     "print(\"Round-trip successful!\")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Round-trip successful!\n"
+     ]
+    }
+   ],
+   "execution_count": 32
   },
   {
    "cell_type": "markdown",
@@ -1601,7 +1817,12 @@
   {
    "cell_type": "code",
    "id": "edecef8c",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.199942Z",
+     "start_time": "2026-07-17T16:35:53.170600Z"
+    }
+   },
    "source": [
     "# A preview — we'll dissect each type below\n",
     "def less_than(a, b):\n",
@@ -1637,8 +1858,18 @@
     "print(f\"abs_value(5)  = {abs_value(5)}\")\n",
     "print(f\"Recipe nodes:  {list(abs_value.flowrep_recipe.nodes.keys())}\")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "abs_value(-3) = 3\n",
+      "abs_value(5)  = 5\n",
+      "Recipe nodes:  ['if_0']\n"
+     ]
+    }
+   ],
+   "execution_count": 33
   },
   {
    "cell_type": "markdown",
@@ -1765,7 +1996,12 @@
   {
    "cell_type": "code",
    "id": "b7c44a28",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.228519Z",
+     "start_time": "2026-07-17T16:35:53.202343Z"
+    }
+   },
    "source": [
     "@fr.atomic\n",
     "def double(x):\n",
@@ -1796,8 +2032,24 @@
     "    f\"Body node:     {for_node.body_node.label} -> {type(for_node.body_node.recipe).__name__}\"\n",
     ")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "double_all([1,2,3]) = [2, 4, 6]\n",
+      "\n",
+      "ForEach-node type: for_each\n",
+      "Inputs:        ['items']\n",
+      "Outputs:       ['results']\n",
+      "Nested ports:  ['item']\n",
+      "Zipped ports:  []\n",
+      "Input edges:   {TargetHandle(node='body', port='item'): InputSource(node=None, port='items')}\n",
+      "Body node:     body -> WorkflowRecipe\n"
+     ]
+    }
+   ],
+   "execution_count": 34
   },
   {
    "cell_type": "markdown",
@@ -1826,8 +2078,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.612857Z",
-     "start_time": "2026-07-11T03:59:27.596524Z"
+     "end_time": "2026-07-17T16:35:53.257154Z",
+     "start_time": "2026-07-17T16:35:53.230832Z"
     }
    },
    "cell_type": "code",
@@ -1860,19 +2112,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "double_all([1,2,3]) = [2, 4, 6]\n",
-      "\n",
-      "ForEach-node type: for_each\n",
-      "Inputs:        ['items']\n",
-      "Outputs:       ['results']\n",
-      "Nested ports:  ['item']\n",
-      "Zipped ports:  []\n",
-      "Input edges:   {TargetHandle(node='body', port='item'): InputSource(node=None, port='items')}\n",
-      "Body node:     body -> WorkflowRecipe\n"
+      "Inputs: ['factor', 'items']\n",
+      "Nested ports (scattered): ['item']\n",
+      "Input edges:\n",
+      "  factor → body.factor\n",
+      "  items → body.item\n"
      ]
     }
    ],
-   "execution_count": 36
+   "execution_count": 35
   },
   {
    "cell_type": "markdown",
@@ -1897,8 +2145,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.682206Z",
-     "start_time": "2026-07-11T03:59:27.615166Z"
+     "end_time": "2026-07-17T16:35:53.283557Z",
+     "start_time": "2026-07-17T16:35:53.259400Z"
     }
    },
    "cell_type": "code",
@@ -1922,15 +2170,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inputs: ['factor', 'items']\n",
-      "Nested ports (scattered): ['item']\n",
-      "Input edges:\n",
-      "  factor → body.factor\n",
-      "  items → body.item\n"
+      "Zipped ports: ['x', 'y']\n",
+      "Nested ports: []\n"
      ]
     }
    ],
-   "execution_count": 37
+   "execution_count": 36
   },
   {
    "cell_type": "markdown",
@@ -1947,7 +2192,11 @@
    "cell_type": "code",
    "id": "0eef1327",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.316010Z",
+     "start_time": "2026-07-17T16:35:53.286Z"
+    }
    },
    "source": [
     "@fr.workflow\n",
@@ -1967,8 +2216,18 @@
     "for target, source in for_node.transferred_outputs.items():\n",
     "    print(f\"  {target.serialize()} sourced from input '{source.port}'\")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outputs: ['results', 'sources']\n",
+      "Transferred (input-forwarded) outputs:\n",
+      "  sources sourced from input 'items'\n"
+     ]
+    }
+   ],
+   "execution_count": 37
   },
   {
    "metadata": {
@@ -2025,8 +2284,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.718556Z",
-     "start_time": "2026-07-11T03:59:27.705531Z"
+     "end_time": "2026-07-17T16:35:53.344656Z",
+     "start_time": "2026-07-17T16:35:53.318423Z"
     }
    },
    "cell_type": "code",
@@ -2059,13 +2318,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Outputs: ['results', 'sources']\n",
-      "Transferred (input-forwarded) outputs:\n",
-      "  sources sourced from input 'items'\n"
+      "Type: if\n",
+      "Inputs: ['x']\n",
+      "Outputs: ['result']\n",
+      "Number of cases: 1\n",
+      "Has else: True\n",
+      "\n",
+      "Prospective output edges:\n",
+      "  result can come from:\n",
+      "    - body_0.result\n",
+      "    - else_body.result\n"
      ]
     }
    ],
-   "execution_count": 39
+   "execution_count": 38
   },
   {
    "cell_type": "markdown",
@@ -2118,7 +2384,12 @@
   {
    "cell_type": "code",
    "id": "9e438df5",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.373847Z",
+     "start_time": "2026-07-17T16:35:53.346940Z"
+    }
+   },
    "source": [
     "# Aside example\n",
     "import traceback\n",
@@ -2139,8 +2410,30 @@
     "except Exception:\n",
     "    traceback.print_exc()"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['result']\n",
+      "{OutputTarget(node=None, port='result'): [SourceHandle(node='body_0', port='result')]}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_98038/3477409776.py\", line 16, in <module>\n",
+      "    conditional_availability(-1)\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_98038/3477409776.py\", line 9, in conditional_availability\n",
+      "    downstream = identity(result)\n",
+      "                          ^^^^^^\n",
+      "UnboundLocalError: cannot access local variable 'result' where it is not associated with a value\n"
+     ]
+    }
+   ],
+   "execution_count": 39
   },
   {
    "cell_type": "markdown",
@@ -2168,8 +2461,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-03-10T14:31:28.272756Z",
-     "start_time": "2026-03-10T14:31:28.227295Z"
+     "end_time": "2026-07-17T16:35:53.395659Z",
+     "start_time": "2026-07-17T16:35:53.383855Z"
     }
    },
    "cell_type": "code",
@@ -2187,7 +2480,7 @@
    ],
    "id": "f170e946bc3d3e53",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 40
   },
   {
    "metadata": {
@@ -2219,7 +2512,11 @@
    "cell_type": "code",
    "id": "460686cf",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.433159Z",
+     "start_time": "2026-07-17T16:35:53.406320Z"
+    }
    },
    "source": [
     "@fr.workflow\n",
@@ -2240,8 +2537,22 @@
     "#\n",
     "# The while-node also exposes inferred iteration edges:"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "count_up(0, 5) = 5\n",
+      "\n",
+      "Type: while\n",
+      "Inputs:  ['start', 'threshold']\n",
+      "Outputs: ['start']\n",
+      "Condition: condition\n",
+      "Body:      body\n"
+     ]
+    }
+   ],
+   "execution_count": 41
   },
   {
    "cell_type": "code",
@@ -2249,8 +2560,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.763575Z",
-     "start_time": "2026-07-11T03:59:27.758276Z"
+     "end_time": "2026-07-17T16:35:53.534457Z",
+     "start_time": "2026-07-17T16:35:53.436546Z"
     }
    },
    "source": [
@@ -2262,7 +2573,19 @@
     "for target, source in while_node.body_condition_edges.items():\n",
     "    print(f\"  {source.serialize()} → {target.serialize()}\")"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Body → body (next iteration) edges:\n",
+      "  body.start → body.start\n",
+      "\n",
+      "Body → condition (next check) edges:\n",
+      "  body.start → condition.value\n"
+     ]
+    }
+   ],
    "execution_count": 42
   },
   {
@@ -2316,8 +2639,8 @@
    "id": "79c1d339",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.791355Z",
-     "start_time": "2026-07-11T03:59:27.777702Z"
+     "end_time": "2026-07-17T16:35:53.574785Z",
+     "start_time": "2026-07-17T16:35:53.546676Z"
     }
    },
    "source": [
@@ -2360,15 +2683,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Body → body (next iteration) edges:\n",
-      "  body.start → body.start\n",
+      "careful_divide(10, 2) = 5.0\n",
+      "careful_divide(10, 0) = 0\n",
       "\n",
-      "Body → condition (next check) edges:\n",
-      "  body.start → condition.value\n"
+      "Type: try\n",
+      "Inputs:  ['a', 'b']\n",
+      "Outputs: ['result']\n",
+      "Try body: try_body\n",
+      "Exception cases: 1\n",
+      "  [0] catches ['builtins.ZeroDivisionError'] → body 'except_body_0'\n"
      ]
     }
    ],
-   "execution_count": 44
+   "execution_count": 43
   },
   {
    "cell_type": "markdown",
@@ -2405,8 +2732,8 @@
    "id": "d76836d6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.808443Z",
-     "start_time": "2026-07-11T03:59:27.793731Z"
+     "end_time": "2026-07-17T16:35:53.600305Z",
+     "start_time": "2026-07-17T16:35:53.577019Z"
     }
    },
    "source": [
@@ -2418,19 +2745,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "careful_divide(10, 2) = 5.0\n",
-      "careful_divide(10, 0) = 0\n",
-      "\n",
-      "Type: try\n",
-      "Inputs:  ['a', 'b']\n",
-      "Outputs: ['result']\n",
-      "Try body: try_body\n",
-      "Exception cases: 1\n",
-      "  [0] catches ['builtins.ZeroDivisionError'] → body 'except_body_0'\n"
+      "The intermediate node 'body' is of type 'workflow'\n"
      ]
     }
    ],
-   "execution_count": 45
+   "execution_count": 44
   },
   {
    "cell_type": "markdown",
@@ -2439,15 +2758,28 @@
    "source": "But, strictly speaking, this intermediate workflow is not necessary since it anyhow has a single child -- the atomic incrementer:"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.634971Z",
+     "start_time": "2026-07-17T16:35:53.609393Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "child_label, child_recipe = next(iter(intermediate.recipe.nodes.items()))\n",
     "print(f\"This workflow has a single-node body: {child_label!r} of type {str(child_recipe.type)!r}\")"
    ],
    "id": "880a7caa20cb48ec",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This workflow has a single-node body: 'increment_0' of type 'atomic'\n"
+     ]
+    }
+   ],
+   "execution_count": 45
   },
   {
    "metadata": {
@@ -2478,7 +2810,12 @@
    "id": "d9bf38390b916b62"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.660623Z",
+     "start_time": "2026-07-17T16:35:53.637447Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "# This will fail because we're in __main__:\n",
@@ -2493,8 +2830,33 @@
     "    traceback.print_exc()"
    ],
    "id": "257fa2cc1c78265d",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_98038/3041652459.py\", line 4, in <module>\n",
+      "    @fr.atomic(forbid_main=True)\n",
+      "     ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/parser_helpers.py\", line 64, in deferred\n",
+      "    return wrap(f, labels)\n",
+      "           ^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 73, in wrap\n",
+      "    f.flowrep_recipe = parse_atomic(f, *labels, **kwargs)\n",
+      "                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 149, in parse_atomic\n",
+      "    function_info = versions.VersionInfo.of(\n",
+      "                    ^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 125, in of\n",
+      "    info.validate_constraints(\n",
+      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 143, in validate_constraints\n",
+      "    raise ValueError(f\"Found forbidden module '__main__' in module for {self}\")\n",
+      "ValueError: Found forbidden module '__main__' in module for VersionInfo(module='__main__', qualname='my_func', version=None)\n"
+     ]
+    }
+   ],
+   "execution_count": 46
   },
   {
    "metadata": {
@@ -2534,8 +2896,8 @@
    "id": "3efa3180",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.852851Z",
-     "start_time": "2026-07-11T03:59:27.838047Z"
+     "end_time": "2026-07-17T16:35:53.687219Z",
+     "start_time": "2026-07-17T16:35:53.662821Z"
     }
    },
    "source": [
@@ -2548,31 +2910,14 @@
    ],
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_59191/3041652459.py\", line 4, in <module>\n",
-      "    @fr.atomic(forbid_main=True)\n",
-      "     ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/parser_helpers.py\", line 45, in deferred\n",
-      "    return wrap(f, labels)\n",
-      "           ^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 76, in wrap\n",
-      "    f.flowrep_recipe = parse_atomic(f, *labels, **kwargs)\n",
-      "                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 152, in parse_atomic\n",
-      "    function_info = versions.VersionInfo.of(\n",
-      "                    ^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 125, in of\n",
-      "    info.validate_constraints(\n",
-      "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 143, in validate_constraints\n",
-      "    raise ValueError(f\"Found forbidden module '__main__' in module for {self}\")\n",
-      "ValueError: Found forbidden module '__main__' in module for VersionInfo(module='__main__', qualname='my_func', version=None)\n"
+      "1.2.3\n"
      ]
     }
    ],
-   "execution_count": 48
+   "execution_count": 47
   },
   {
    "cell_type": "markdown",
@@ -2590,7 +2935,12 @@
   {
    "cell_type": "code",
    "id": "b9a1b49d",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.711995Z",
+     "start_time": "2026-07-17T16:35:53.689439Z"
+    }
+   },
    "source": [
     "@fr.workflow\n",
     "def my_recipe(x: int, y: int = 4):\n",
@@ -2602,8 +2952,16 @@
     "except ValueError as e:\n",
     "    print(e)"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This recipe already has an underlying Python reference: info=VersionInfo(module='__main__', qualname='my_recipe', version=None) inputs_with_defaults=['y'] restricted_input_kinds={}\n"
+     ]
+    }
+   ],
+   "execution_count": 48
   },
   {
    "cell_type": "markdown",
@@ -2621,7 +2979,12 @@
    ]
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.728693Z",
+     "start_time": "2026-07-17T16:35:53.714356Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "unreferenced_recipe = my_recipe.flowrep_recipe.model_copy(update={\"reference\": None})\n",
@@ -2629,7 +2992,7 @@
    ],
    "id": "e0ac6cf3086d983a",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 49
   },
   {
    "metadata": {
@@ -2643,12 +3006,36 @@
    "id": "31639b9ce08f4f94"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.761081Z",
+     "start_time": "2026-07-17T16:35:53.738478Z"
+    }
+   },
    "cell_type": "code",
    "source": "print(rendered.source)",
    "id": "f906e1e3d41e5b3b",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from __future__ import annotations\n",
+      "\n",
+      "import __main__\n",
+      "import flowrep\n",
+      "import typing\n",
+      "\n",
+      "@flowrep.workflow(\"total\")\n",
+      "def compiled_from_workflow_recipe(x, y):\n",
+      "    add = __main__.add(a=x, b=y)\n",
+      "    return add\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 50
   },
   {
    "metadata": {
@@ -2662,15 +3049,31 @@
    "id": "664078176aceb6e0"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.805261Z",
+     "start_time": "2026-07-17T16:35:53.763441Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "rebuilt = rendered.build()\n",
     "rebuilt(1, 2)"
    ],
    "id": "612788a582d4680",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 51
   },
   {
    "metadata": {
@@ -2688,7 +3091,12 @@
    "id": "b05174603f66abe0"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.832279Z",
+     "start_time": "2026-07-17T16:35:53.810822Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "import inspect\n",
@@ -2706,8 +3114,27 @@
     "print(rendered_with_annotations.source)"
    ],
    "id": "54362e50de84e98d",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from __future__ import annotations\n",
+      "\n",
+      "import __main__\n",
+      "import flowrep\n",
+      "import typing\n",
+      "\n",
+      "@flowrep.workflow(\"total\")\n",
+      "def my_function_with_annotations(x: int, y: int = 4):\n",
+      "    add = __main__.add(a=x, b=y)\n",
+      "    return add\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 52
   },
   {
    "metadata": {
@@ -2725,7 +3152,12 @@
    "id": "6c66d3483935a69e"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.855178Z",
+     "start_time": "2026-07-17T16:35:53.834477Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "class MyCustomThing(int): ...\n",
@@ -2752,8 +3184,27 @@
     "print(complex_rendered.source)"
    ],
    "id": "281ef568be306e93",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from __future__ import annotations\n",
+      "\n",
+      "import __main__\n",
+      "import flowrep\n",
+      "import typing\n",
+      "\n",
+      "@flowrep.workflow(\"total\")\n",
+      "def wont_dump(x: _ann_x, y: _ann_y = _default_y):\n",
+      "    add = __main__.add(a=x, b=y)\n",
+      "    return add\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 53
   },
   {
    "metadata": {
@@ -2771,12 +3222,30 @@
    "id": "966d2a06e2842a37"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.886027Z",
+     "start_time": "2026-07-17T16:35:53.858400Z"
+    }
+   },
    "cell_type": "code",
    "source": "complex_rendered.namespace",
    "id": "730469f5b44b6dd8",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_ann_x': __main__.MyCustomThing,\n",
+       " '_ann_y': __main__.MyCustomThing,\n",
+       " '_default_y': 4}"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 54
   },
   {
    "metadata": {
@@ -2790,15 +3259,31 @@
    "id": "938b1fe74c549980"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:53.911297Z",
+     "start_time": "2026-07-17T16:35:53.888643Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "rebuilt_complex = complex_rendered.build()\n",
     "rebuilt(MyCustomThing(1), MyCustomThing(2))"
    ],
    "id": "578b4f2ccc1ee02e",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 55
   },
   {
    "metadata": {
@@ -2841,8 +3326,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:27.982017Z",
-     "start_time": "2026-07-11T03:59:27.968628Z"
+     "end_time": "2026-07-17T16:35:53.960540Z",
+     "start_time": "2026-07-17T16:35:53.913677Z"
     }
    },
    "cell_type": "code",
@@ -2871,17 +3356,22 @@
    "id": "e05fec796a1c063b",
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PWD version: 0.0.1\n",
+      "Nodes: 6\n",
+      "  id=0, type=input, name=x\n",
+      "  id=1, type=input, name=slope\n",
+      "  id=2, type=input, name=intercept\n",
+      "  id=3, type=output, name=result\n",
+      "  id=4, type=function, value=__main__.multiply\n",
+      "  id=5, type=function, value=__main__.add\n",
+      "Edges: 5\n"
+     ]
     }
    ],
-   "execution_count": 57
+   "execution_count": 56
   },
   {
    "metadata": {},
@@ -2892,7 +3382,12 @@
   {
    "cell_type": "code",
    "id": "5ccd8c05",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.042281Z",
+     "start_time": "2026-07-17T16:35:53.962735Z"
+    }
+   },
    "source": [
     "try:\n",
     "    # Round-trip: flowrep → PWD → flowrep\n",
@@ -2910,8 +3405,19 @@
     "except ImportError:\n",
     "    print(\"python-workflow-definition is not installed — skipping.\")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Round-tripped inputs:  ['x', 'slope', 'intercept']\n",
+      "Round-tripped outputs: ['result']\n",
+      "Round-tripped nodes:   ['multiply_0', 'add_0']\n",
+      "Defaults: {'x': 0.0, 'slope': 1.0, 'intercept': 0.0}\n"
+     ]
+    }
+   ],
+   "execution_count": 57
   },
   {
    "cell_type": "markdown",
@@ -2965,7 +3471,12 @@
   {
    "cell_type": "code",
    "id": "2370bd6b",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.085453Z",
+     "start_time": "2026-07-17T16:35:54.058854Z"
+    }
+   },
    "source": [
     "@fr.atomic\n",
     "def rescale(value: int | float, factor: float = 1.0) -> float:\n",
@@ -2994,23 +3505,44 @@
     "    return scaled"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": 58
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.098244Z",
+     "start_time": "2026-07-17T16:35:54.087555Z"
+    }
+   },
    "cell_type": "code",
    "source": "node_data = fr.tools.recipe2data(scaled_range.flowrep_recipe)",
    "id": "833e6b0ceb72e917",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 59
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.135488Z",
+     "start_time": "2026-07-17T16:35:54.108661Z"
+    }
+   },
    "cell_type": "code",
    "source": "type(node_data.recipe)",
    "id": "d8537a11cde237e4",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "flowrep.prospective.workflow_recipe.WorkflowRecipe"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 60
   },
   {
    "metadata": {
@@ -3031,8 +3563,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.021921Z",
-     "start_time": "2026-07-11T03:59:28.018859Z"
+     "end_time": "2026-07-17T16:35:54.162834Z",
+     "start_time": "2026-07-17T16:35:54.138244Z"
     }
    },
    "cell_type": "code",
@@ -3048,7 +3580,17 @@
     "recursively_look_at_data_nodes(node_data)"
    ],
    "id": "f044f5954e57507c",
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "int_list_0\n",
+      "rescale_all_0\n",
+      "\tfor_each_0\n"
+     ]
+    }
+   ],
    "execution_count": 61
   },
   {
@@ -3074,8 +3616,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.053203Z",
-     "start_time": "2026-07-11T03:59:28.035405Z"
+     "end_time": "2026-07-17T16:35:54.188226Z",
+     "start_time": "2026-07-17T16:35:54.164987Z"
     }
    },
    "cell_type": "code",
@@ -3083,16 +3625,17 @@
    "id": "aec301f79141f523",
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "int_list_0\n",
-      "rescale_all_0\n",
-      "\tfor_each_0\n"
-     ]
+     "data": {
+      "text/plain": [
+       "NOT_DATA"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "execution_count": 63
+   "execution_count": 62
   },
   {
    "metadata": {},
@@ -3101,12 +3644,28 @@
    "id": "dfe8a73f0f059be7"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.217800Z",
+     "start_time": "2026-07-17T16:35:54.191861Z"
+    }
+   },
    "cell_type": "code",
    "source": "node_data.input_ports[\"scale\"].default",
    "id": "c9e8560bc82a6038",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.0"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 63
   },
   {
    "metadata": {
@@ -3120,7 +3679,12 @@
    "id": "c6545f09fe38cc1b"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.249281Z",
+     "start_time": "2026-07-17T16:35:54.220328Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "(\n",
@@ -3129,8 +3693,19 @@
     ")"
    ],
    "id": "6d43e80546840ed0",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(float, list[float])"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 64
   },
   {
    "metadata": {
@@ -3144,7 +3719,12 @@
    "id": "d9dd1ddaf30c4f90"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.274513Z",
+     "start_time": "2026-07-17T16:35:54.251520Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "(\n",
@@ -3156,8 +3736,19 @@
     ")"
    ],
    "id": "c0c1dc9c6ca8e156",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(NOT_DATA, NOT_DATA, int, NOT_DATA, list[int])"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 65
   },
   {
    "metadata": {
@@ -3176,21 +3767,35 @@
    "id": "c1ade97f5e96b4ba"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.303563Z",
+     "start_time": "2026-07-17T16:35:54.276889Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "for target, source in node_data.input_edges.items():\n",
     "    print(f\"{source.serialize()} → {target.serialize()}\")"
    ],
    "id": "29bb5cf64f1b2ea2",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n → int_list_0.n\n",
+      "scale → rescale_all_0.factor\n"
+     ]
+    }
+   ],
+   "execution_count": 66
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.113139Z",
-     "start_time": "2026-07-11T03:59:28.099705Z"
+     "end_time": "2026-07-17T16:35:54.366969Z",
+     "start_time": "2026-07-17T16:35:54.335402Z"
     }
    },
    "cell_type": "code",
@@ -3201,28 +3806,38 @@
    "id": "1468f7bd033bb028",
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "(NOT_DATA, NOT_DATA, int, NOT_DATA, list[int])"
-      ]
-     },
-     "execution_count": 67,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "int_list_0.output_0 → rescale_all_0.items\n"
+     ]
     }
    ],
    "execution_count": 67
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.388884Z",
+     "start_time": "2026-07-17T16:35:54.369586Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "for target, source in node_data.output_edges.items():\n",
     "    print(f\"{source.serialize()} → {target.serialize()}\")"
    ],
    "id": "df3500015b3a2f5a",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rescale_all_0.results → scaled\n"
+     ]
+    }
+   ],
+   "execution_count": 68
   },
   {
    "metadata": {
@@ -3247,8 +3862,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-11T03:59:28.219938Z",
-     "start_time": "2026-07-11T03:59:28.198309Z"
+     "end_time": "2026-07-17T16:35:54.417237Z",
+     "start_time": "2026-07-17T16:35:54.391540Z"
     }
    },
    "cell_type": "code",
@@ -3266,11 +3881,14 @@
    "id": "8003b380315257cd",
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "int_list_0.output_0 → rescale_all_0.items\n"
-     ]
+     "data": {
+      "text/plain": [
+       "(<RecipeElementType.FOR_EACH: 'for_each'>, {}, {}, {}, {})"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "execution_count": 69
@@ -3293,7 +3911,12 @@
    "id": "56f385796c984111"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.429896Z",
+     "start_time": "2026-07-17T16:35:54.419274Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "from __future__ import annotations\n",
@@ -3309,7 +3932,7 @@
    ],
    "id": "cc1e5c958dd87720",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 70
   },
   {
    "metadata": {
@@ -3323,7 +3946,12 @@
    "id": "80942d3b934ef105"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.461014Z",
+     "start_time": "2026-07-17T16:35:54.440186Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "try:\n",
@@ -3332,8 +3960,16 @@
     "    print(e)"
    ],
    "id": "5dd2fc6e39e728b4",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "While parsing '__main__.get_blue' for recipe inputs ['colors'] and outputs ['output_0'], could not find the symbol for at least one annotation. This is likely due to forward referenced annotations. Please cross reference the underlying name error (\"name 'SeabornColors' is not defined\") and the function being parsed, and locally make the necessary imports before re-parsing.\n"
+     ]
+    }
+   ],
+   "execution_count": 71
   },
   {
    "metadata": {
@@ -3347,7 +3983,12 @@
    "id": "ca0292eb59cf963a"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.563450Z",
+     "start_time": "2026-07-17T16:35:54.507955Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "from pyiron_snippets.colors import SeabornColors\n",
@@ -3357,8 +3998,19 @@
     "data.input_ports[\"colors\"].annotation"
    ],
    "id": "36045479099ade66",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pyiron_snippets.colors.SeabornColors"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 72
   },
   {
    "metadata": {
@@ -3380,12 +4032,17 @@
    "id": "44fa91cf59e164c7"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.591318Z",
+     "start_time": "2026-07-17T16:35:54.578706Z"
+    }
+   },
    "cell_type": "code",
    "source": "ran_node = fr.tools.run_recipe(scaled_range.flowrep_recipe, n=3)",
    "id": "8fc856912a06a735",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 73
   },
   {
    "metadata": {
@@ -3402,12 +4059,28 @@
    "id": "1fc5221b5f62a0da"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.621768Z",
+     "start_time": "2026-07-17T16:35:54.600606Z"
+    }
+   },
    "cell_type": "code",
    "source": "ran_node.output_ports[\"scaled\"].value",
    "id": "47a7f46ae249d2f6",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0.0, 1.0, 2.0]"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 74
   },
   {
    "metadata": {
@@ -3421,7 +4094,12 @@
    "id": "54c1c113638190b8"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.662807Z",
+     "start_time": "2026-07-17T16:35:54.637161Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "ran_for = ran_node.nodes[\"rescale_all_0\"].nodes[\"for_each_0\"]\n",
@@ -3434,8 +4112,18 @@
     "    )"
    ],
    "id": "72982d6646db5e03",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "For-loop child body_0 transformed 0*1.0 → 0.0\n",
+      "For-loop child body_1 transformed 1*1.0 → 1.0\n",
+      "For-loop child body_2 transformed 2*1.0 → 2.0\n"
+     ]
+    }
+   ],
+   "execution_count": 75
   },
   {
    "metadata": {
@@ -3456,7 +4144,12 @@
    "id": "65a9e2c8660174e"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:54.685757Z",
+     "start_time": "2026-07-17T16:35:54.664921Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "@fr.atomic\n",
@@ -3489,8 +4182,19 @@
     "executed.output_ports"
    ],
    "id": "1264d43293ffbd43",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'scaled': OutputDataPort(value=[0.0, 1.0, 2.0, 3.0, 4.0], annotation=list[float])}"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 76
   },
   {
    "metadata": {
@@ -3504,7 +4208,12 @@
    "id": "df5a0ed5a28fd5cf"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:55.075859Z",
+     "start_time": "2026-07-17T16:35:54.687846Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "import bagofholding as boh\n",
@@ -3513,7 +4222,7 @@
    ],
    "id": "8d092cdcf9c0e517",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 77
   },
   {
    "metadata": {
@@ -3534,15 +4243,84 @@
    "id": "f94e046ee2730c68"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:55.112578Z",
+     "start_time": "2026-07-17T16:35:55.079890Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "browser = fr.tools.LexicalBagBrowser(\"executed.h5\")\n",
     "browser.list_paths()"
    ],
    "id": "caeb3c190f954f71",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['inputs.n',\n",
+       " 'inputs.scale',\n",
+       " 'outputs.scaled',\n",
+       " 'int_list_0',\n",
+       " 'int_list_0.inputs.n',\n",
+       " 'int_list_0.outputs.output_0',\n",
+       " 'rescale_all_0',\n",
+       " 'rescale_all_0.inputs.factor',\n",
+       " 'rescale_all_0.inputs.items',\n",
+       " 'rescale_all_0.outputs.results',\n",
+       " 'rescale_all_0.for_each_0',\n",
+       " 'rescale_all_0.for_each_0.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.inputs.items',\n",
+       " 'rescale_all_0.for_each_0.outputs.results',\n",
+       " 'rescale_all_0.for_each_0.body_0',\n",
+       " 'rescale_all_0.for_each_0.body_0.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_0.inputs.item',\n",
+       " 'rescale_all_0.for_each_0.body_0.outputs.scaled',\n",
+       " 'rescale_all_0.for_each_0.body_0.rescale_0',\n",
+       " 'rescale_all_0.for_each_0.body_0.rescale_0.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_0.rescale_0.inputs.value',\n",
+       " 'rescale_all_0.for_each_0.body_0.rescale_0.outputs.result',\n",
+       " 'rescale_all_0.for_each_0.body_1',\n",
+       " 'rescale_all_0.for_each_0.body_1.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_1.inputs.item',\n",
+       " 'rescale_all_0.for_each_0.body_1.outputs.scaled',\n",
+       " 'rescale_all_0.for_each_0.body_1.rescale_0',\n",
+       " 'rescale_all_0.for_each_0.body_1.rescale_0.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_1.rescale_0.inputs.value',\n",
+       " 'rescale_all_0.for_each_0.body_1.rescale_0.outputs.result',\n",
+       " 'rescale_all_0.for_each_0.body_2',\n",
+       " 'rescale_all_0.for_each_0.body_2.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_2.inputs.item',\n",
+       " 'rescale_all_0.for_each_0.body_2.outputs.scaled',\n",
+       " 'rescale_all_0.for_each_0.body_2.rescale_0',\n",
+       " 'rescale_all_0.for_each_0.body_2.rescale_0.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_2.rescale_0.inputs.value',\n",
+       " 'rescale_all_0.for_each_0.body_2.rescale_0.outputs.result',\n",
+       " 'rescale_all_0.for_each_0.body_3',\n",
+       " 'rescale_all_0.for_each_0.body_3.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_3.inputs.item',\n",
+       " 'rescale_all_0.for_each_0.body_3.outputs.scaled',\n",
+       " 'rescale_all_0.for_each_0.body_3.rescale_0',\n",
+       " 'rescale_all_0.for_each_0.body_3.rescale_0.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_3.rescale_0.inputs.value',\n",
+       " 'rescale_all_0.for_each_0.body_3.rescale_0.outputs.result',\n",
+       " 'rescale_all_0.for_each_0.body_4',\n",
+       " 'rescale_all_0.for_each_0.body_4.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_4.inputs.item',\n",
+       " 'rescale_all_0.for_each_0.body_4.outputs.scaled',\n",
+       " 'rescale_all_0.for_each_0.body_4.rescale_0',\n",
+       " 'rescale_all_0.for_each_0.body_4.rescale_0.inputs.factor',\n",
+       " 'rescale_all_0.for_each_0.body_4.rescale_0.inputs.value',\n",
+       " 'rescale_all_0.for_each_0.body_4.rescale_0.outputs.result']"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 78
   },
   {
    "metadata": {
@@ -3556,15 +4334,31 @@
    "id": "c4fe9644c6e43a16"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:55.427450Z",
+     "start_time": "2026-07-17T16:35:55.114752Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "reloaded_node = browser.load(\"rescale_all_0\")\n",
     "isinstance(reloaded_node, fr.schemas.DagData), reloaded_node.nodes.keys()"
    ],
    "id": "412ddc4424bcefd3",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, dict_keys(['for_each_0']))"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 79
   },
   {
    "metadata": {
@@ -3578,15 +4372,31 @@
    "id": "4433e29b74f02efe"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:55.457025Z",
+     "start_time": "2026-07-17T16:35:55.431817Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "reloaded_port = browser.load(\"rescale_all_0.for_each_0.body_1.inputs.item\")\n",
     "isinstance(reloaded_port, fr.schemas.InputDataPort), reloaded_port.value"
    ],
    "id": "d948155042459cb",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, 1)"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 80
   },
   {
    "metadata": {
@@ -3603,7 +4413,12 @@
    "id": "c3622954ff23bc6f"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:55.535044Z",
+     "start_time": "2026-07-17T16:35:55.459405Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "try:\n",
@@ -3612,8 +4427,16 @@
     "    print(e)"
    ],
    "id": "e0e550efad910586",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Path terminated in 'inputs'. Please select an individual port to load from among ('factor', 'items')\n"
+     ]
+    }
+   ],
+   "execution_count": 81
   },
   {
    "metadata": {
@@ -3627,15 +4450,36 @@
    "id": "51463f7d0fa254be"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:55.594726Z",
+     "start_time": "2026-07-17T16:35:55.569283Z"
+    }
+   },
    "cell_type": "code",
    "source": [
     "widget = browser.browse()\n",
     "widget"
    ],
    "id": "1b10ad697f945ac5",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "LexicalBagTree(multiple_selection=False, nodes=(Node(close_icon_style='danger', name='Workflow', nodes=(Node(c…"
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "73dcbbcb9380465eae7b754f2da9370c"
+      }
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 82
   },
   {
    "metadata": {
@@ -3690,12 +4534,17 @@
    "id": "50bfd15d81eabf32"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-17T16:35:55.616542Z",
+     "start_time": "2026-07-17T16:35:55.606570Z"
+    }
+   },
    "cell_type": "code",
    "source": "",
    "id": "947adb096007fe7e",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 82
   },
   {
    "metadata": {},

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -1,15 +1,11 @@
 import ast
-import dataclasses
 import inspect
 import types
 from collections.abc import Callable, Iterable
 from typing import (
-    Annotated,
     Any,
     TypeVar,
     cast,
-    get_args,
-    get_origin,
     get_type_hints,
     overload,
 )
@@ -195,8 +191,6 @@ def _get_output_labels(
         return _parse_return_label_without_unpacking(func)
     elif unpack_mode == atomic_recipe.UnpackMode.TUPLE:
         return _parse_tuple_return_labels(func)
-    elif unpack_mode == atomic_recipe.UnpackMode.DATACLASS:
-        return _parse_dataclass_return_labels(func)
     raise TypeError(
         f"Invalid unpack mode: {unpack_mode}. Possible values are "
         f"{', '.join(atomic_recipe.UnpackMode.__members__.values())}"
@@ -277,37 +271,6 @@ def _extract_return_labels(ret: ast.Return) -> tuple[str, ...]:
             if isinstance(ret.value, ast.Name)
             else (default_output_label(0),)
         )
-
-
-def _parse_dataclass_return_labels(func: types.FunctionType) -> list[str]:
-    source_code_return = _parse_tuple_return_labels(func)
-    if len(source_code_return) != 1:
-        raise ValueError(
-            f"Dataclass unpack mode requires function code to returns to consist of "
-            f"exactly one value, i.e. the dataclass instance, but got "
-            f"{source_code_return}"
-        )
-
-    try:
-        hints = get_type_hints(func, include_extras=True)
-    except NameError as e:
-        raise NameError(
-            "Dataclass unpack mode requires the return annotation to be importable at "
-            "runtime. Evaluating the return annotation for "
-            f"{func.__module__}.{func.__qualname__} failed with: {e}"
-        ) from e
-    ann = hints.get("return")
-
-    origin = get_origin(ann)
-    return_hint = get_args(ann)[0] if origin is Annotated else ann
-
-    if dataclasses.is_dataclass(return_hint):
-        return [f.name for f in dataclasses.fields(return_hint)]
-
-    raise ValueError(
-        f"Dataclass unpack mode requires a return type annotation that is a "
-        f"(perhaps Annotated) dataclass, but got {return_hint}"
-    )
 
 
 def get_labeled_recipe(

--- a/src/flowrep/prospective/atomic_recipe.py
+++ b/src/flowrep/prospective/atomic_recipe.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 from enum import StrEnum
 from typing import Literal
 
@@ -16,12 +15,10 @@ class UnpackMode(StrEnum):
 
     - NONE: Return the output as a single value
     - TUPLE: Split return into one port per tuple element
-    - DATACLASS: Split return into one port per dataclass field
     """
 
     NONE = "none"
     TUPLE = "tuple"
-    DATACLASS = "dataclass"
 
 
 class AtomicRecipe(base_models.NodeRecipe):
@@ -77,8 +74,4 @@ class AtomicRecipe(base_models.NodeRecipe):
 
     def __call__(self, *args, **kwargs):
         func = retrieve.import_from_string(self.reference.info.fully_qualified_name)
-        if self.unpack_mode == UnpackMode.DATACLASS:
-            dc = func(*args, **kwargs)
-            return tuple(getattr(dc, f.name) for f in dataclasses.fields(dc))
-        else:
-            return func(*args, **kwargs)
+        return func(*args, **kwargs)

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -318,10 +318,8 @@ def _parse_function(
     return_annotation = hints.get("return", None)
     if unpack_mode == atomic_recipe.UnpackMode.NONE:
         output_ports = _parse_return_without_unpacking(return_annotation, outputs)
-    elif unpack_mode == atomic_recipe.UnpackMode.TUPLE:
+    else:
         output_ports = _parse_return_tuple(return_annotation, outputs)
-    elif unpack_mode == atomic_recipe.UnpackMode.DATACLASS:
-        output_ports = _parse_return_dataclass(return_annotation, outputs)
 
     if isinstance(function, type):
         output_ports[next(iter(output_ports))].annotation = function
@@ -393,42 +391,3 @@ def _parse_return_tuple(
     else:
         output_ports = {outputs[0]: OutputDataPort(annotation=return_annotation)}
     return output_ports
-
-
-def _parse_return_dataclass(
-    return_annotation, outputs: list[str]
-) -> dict[str, OutputDataPort]:
-    if not (
-        isinstance(return_annotation, type)
-        and dataclasses.is_dataclass(return_annotation)
-    ):  # pragma: no cover
-        raise TypeError(
-            f"Return annotation {return_annotation!r} is not a dataclass. This should "
-            f"have been caught by the underlying recipe validation. Please raise a "
-            f"GitHub issue reporting how you got here!"
-        )
-
-    # de-stringify dataclass annotations, if they were forward-references
-    try:
-        hints = get_type_hints(return_annotation, include_extras=True)
-    except NameError as e:
-        fqdn = f"{return_annotation.__module__}.{return_annotation.__qualname__}"
-        raise NameError(
-            f"While parsing return dataclass annotation {fqdn!r}, could not resolve "
-            f"at least one field annotation ({e}). Ensure the missing symbols are "
-            f"importable at runtime in the dataclass' defining module."
-        ) from e
-
-    fields = dataclasses.fields(return_annotation)
-    if len(outputs) != len(fields):  # pragma: no cover
-        raise ValueError(
-            f"Return dataclass {return_annotation!r} has {len(fields)} fields, "
-            f"{[f.name for f in fields]}, but {len(outputs)} outputs, {outputs} were "
-            f"requested. This should have been caught by the underlying recipe "
-            f"validation. Please raise a GitHub issue reporting how you got here!"
-        )
-
-    return {
-        label: OutputDataPort(annotation=hints.get(field.name, None))
-        for label, field in zip(outputs, fields, strict=True)
-    }

--- a/src/flowrep/wfms.py
+++ b/src/flowrep/wfms.py
@@ -8,7 +8,6 @@ fully-fledged WfMS can refer.
 
 from __future__ import annotations
 
-import dataclasses
 import itertools
 from collections.abc import Collection
 from typing import Any, cast
@@ -120,17 +119,12 @@ def _store_atomic_outputs(node: datastructures.AtomicData, result: Any) -> None:
     if recipe.unpack_mode == atomic_recipe.UnpackMode.NONE:
         node.output_ports[output_names[0]].value = result
 
-    elif recipe.unpack_mode == atomic_recipe.UnpackMode.TUPLE:
+    else:
         if len(output_names) == 1:
             node.output_ports[output_names[0]].value = result
         else:
             for name, val in zip(output_names, result, strict=True):
                 node.output_ports[name].value = val
-
-    elif recipe.unpack_mode == atomic_recipe.UnpackMode.DATACLASS:
-        fields = dataclasses.fields(result)
-        for label, field in zip(node.recipe.outputs, fields, strict=True):
-            node.output_ports[label].value = getattr(result, field.name)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import dataclasses
 import inspect
 import textwrap
 import unittest
@@ -11,22 +10,6 @@ from typing import Annotated, NamedTuple
 from flowrep import base_models
 from flowrep.parsers import atomic_parser, label_helpers, parser_helpers
 from flowrep.prospective import atomic_recipe
-
-
-@dataclasses.dataclass
-class _Result:
-    x: int
-    y: int
-
-
-@dataclasses.dataclass
-class _TypingProblem:
-    x: YouCantFindThis  # noqa: F821
-
-
-@atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.DATACLASS)
-def my_result(result: _Result) -> _Result:
-    return result
 
 
 def _make_func_in_module(module: str, qualname: str) -> FunctionType:
@@ -397,29 +380,6 @@ class TestParseAtomicWithOutputLabels(unittest.TestCase):
         node = atomic_parser.parse_atomic(func)
         self.assertEqual(node.outputs, ["result"])
 
-    def test_explicit_labels_with_dataclass(self):
-
-        def func() -> _Result:
-            return _Result(1, 2)
-
-        # Should use dataclass fields, not explicit labels
-        node = atomic_parser.parse_atomic(
-            func, unpack_mode=atomic_recipe.UnpackMode.DATACLASS
-        )
-        self.assertEqual(node.outputs, ["x", "y"])
-
-    def test_explicit_labels_with_dataclass_wrong_count_raises(self):
-
-        def func() -> _Result:
-            return _Result(1, 2)
-
-        with self.assertRaises(ValueError) as ctx:
-            atomic_parser.parse_atomic(
-                func, "only_one", unpack_mode=atomic_recipe.UnpackMode.DATACLASS
-            )
-
-        self.assertIn("expected 2 labels", str(ctx.exception))
-
 
 class TestAtomicEdgeCases(unittest.TestCase):
     def test_atomic_preserves_function_with_labels(self):
@@ -694,121 +654,6 @@ class TestExtractCombinedReturnLabels(unittest.TestCase):
         self.assertEqual(labels, [("a", "b")])
 
 
-class TestParseDataclassReturnLabels(unittest.TestCase):
-    def test_valid_dataclass_return(self):
-
-        def func() -> _Result:
-            return _Result(1, 2)
-
-        labels = atomic_parser._parse_dataclass_return_labels(func)
-        self.assertEqual(labels, ["x", "y"])
-
-    def test_missing_return_annotation_raises_error(self):
-        def func():
-            return dataclasses.make_dataclass("Result", [("x", int)])()
-
-        with self.assertRaises(ValueError) as ctx:
-            atomic_parser._parse_dataclass_return_labels(func)
-        self.assertIn("return type annotation", str(ctx.exception))
-
-    def test_non_dataclass_annotation_raises_error(self):
-        def func() -> int:
-            return 42
-
-        with self.assertRaises(ValueError) as ctx:
-            atomic_parser._parse_dataclass_return_labels(func)
-        self.assertIn("dataclass", str(ctx.exception))
-
-    def test_multiple_return_statements(self):
-
-        def func(flag) -> _Result:
-            if flag:
-                return _Result(1, 2)
-            return _Result(2, 3)
-
-        labels = atomic_parser._parse_dataclass_return_labels(func)
-        self.assertEqual(labels, ["x", "y"])
-
-    def test_dangerous_returns(self):
-
-        def func(flag) -> _Result:
-            if flag:
-                return 42
-            return _Result(2, 3)
-
-        labels = atomic_parser._parse_dataclass_return_labels(func)
-        self.assertEqual(
-            labels,
-            ["x", "y"],
-            msg="THIS IS THE DEVELOPER'S PROBLEM. We can't stop them from lying in "
-            "their return statements.",
-        )
-
-    def test_multiple_returns_raises_error(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
-
-        def func() -> tuple[Result, Result]:
-            return Result(0), Result(1)
-
-        with self.assertRaises(ValueError) as ctx:
-            atomic_parser._parse_dataclass_return_labels(func)
-        self.assertIn("exactly one value", str(ctx.exception).lower())
-
-    def test_inconsistent_returns_raises_error(self):
-        @dataclasses.dataclass
-        class Result:
-            x: int
-
-        def func(flag) -> Result:
-            if flag:
-                return Result(1), Result(2)
-            return Result(3)
-
-        with self.assertRaises(ValueError) as ctx:
-            atomic_parser._parse_dataclass_return_labels(func)
-        self.assertIn("same number of elements", str(ctx.exception).lower())
-
-    def test_unimportable_annotation_raises(self):
-        """
-        This should probably never be hittable in practice, because it requires the
-        user to ask for dataclass unpacking, and hinting something unimported, but
-        usually the hint and the returned object will be the same in this case (and
-        thus safely imported!)
-        """
-
-        def func() -> NotImportable:  # noqa: F821
-            return _TypingProblem(42)
-
-        with self.assertRaisesRegex(
-            NameError, "requires the return annotation to be importable"
-        ):
-            atomic_parser._parse_dataclass_return_labels(func)
-
-
-class TestParseDataclassCallDifferences(unittest.TestCase):
-    def test_call_differences(self):
-        input = _Result(1, 2)
-        with self.subTest("Direct call"):
-            self.assertIs(
-                input,
-                my_result(input),
-                msg="Unpacking mode should not impack the decorated function -- the "
-                "function should just do what it looks like it does",
-            )
-
-        with self.subTest("Recipe call"):
-            x, y = my_result.flowrep_recipe(input)
-            self.assertEqual(
-                input.x,
-                x,
-                msg="The recipe claims it unpacks things, and it should when used as a "
-                "callable",
-            )
-            self.assertEqual(input.y, y)
-
-
 class TestParseTupleReturnLabelsWithAnnotations(unittest.TestCase):
     def test_annotation_overrides_scraped(self):
         def func() -> Annotated[int, {"label": "custom"}]:
@@ -1022,28 +867,6 @@ class TestAtomicWithAnnotations(unittest.TestCase):
             return x, "somewhere"
 
         self.assertEqual(func.flowrep_recipe.outputs, ["dist", "city"])
-
-
-class TestAnnotationWithDataclass(unittest.TestCase):
-    def test_dataclass_mode_ignores_annotated_wrapper(self):
-
-        def func() -> Annotated[_Result, {"label": "ignored"}]:
-            return _Result(1, 2)
-
-        node = atomic_parser.parse_atomic(
-            func, unpack_mode=atomic_recipe.UnpackMode.DATACLASS
-        )
-        self.assertEqual(node.outputs, ["x", "y"])
-
-    def test_dataclass_mode_ignores_output_meta_wrapper(self):
-
-        def func() -> Annotated[_Result, label_helpers.OutputMeta(label="ignored")]:
-            return _Result(1, 2)
-
-        node = atomic_parser.parse_atomic(
-            func, unpack_mode=atomic_recipe.UnpackMode.DATACLASS
-        )
-        self.assertEqual(node.outputs, ["x", "y"])
 
 
 class TestParseAtomicVersionParams(unittest.TestCase):

--- a/tests/unit/parsers/test_dataclass_parser.py
+++ b/tests/unit/parsers/test_dataclass_parser.py
@@ -3,7 +3,7 @@ import inspect
 import typing
 import unittest
 
-from flowrep import base_models
+from flowrep import base_models, wfms
 from flowrep.parsers import atomic_parser, dataclass_parser
 from flowrep.prospective import atomic_recipe
 from flowrep.retrospective import datastructures
@@ -207,6 +207,37 @@ class TestInverseRecipeFailures(unittest.TestCase):
             class Collide:
                 foo: int
                 flowrep_recipe_inverse: int = 0
+
+
+class TestRecipeMatchesPython(unittest.TestCase):
+    """
+    The inverse recipe is callable, so WfMS execution and raw python must agree.
+    """
+
+    def test_multi_field_inverse_recipe_call_matches_wfms_run(self):
+        instance = library.Pair(1, "a")
+        recipe = library.Pair.flowrep_recipe_inverse
+
+        raw = recipe(instance)
+        node = wfms.run_recipe(recipe, dataclass=instance)
+        via_wfms = tuple(node.output_ports[label].value for label in recipe.outputs)
+
+        self.assertEqual(raw, (1, "a"), msg="Raw call unpacks the fields")
+        self.assertEqual(
+            raw,
+            via_wfms,
+            msg="Running the recipe through a WfMS must agree with calling it directly",
+        )
+
+    def test_single_field_inverse_recipe_call_matches_wfms_run(self):
+        instance = library.Single(5)
+        recipe = library.Single.flowrep_recipe_inverse
+
+        raw = recipe(instance)
+        node = wfms.run_recipe(recipe, dataclass=instance)
+
+        self.assertEqual(raw, 5, msg="A single field unpacks bare, not as a 1-tuple")
+        self.assertEqual(raw, node.output_ports["only"].value)
 
 
 if __name__ == "__main__":

--- a/tests/unit/prospective/test_atomic_recipe.py
+++ b/tests/unit/prospective/test_atomic_recipe.py
@@ -96,16 +96,6 @@ class TestAtomicRecipeUnpackMode(unittest.TestCase):
         )
         self.assertEqual(len(node.outputs), 0)
 
-    def test_dataclass_mode_multiple_outputs(self):
-        node = atomic_recipe.AtomicRecipe(
-            reference=makers.make_reference(),
-            inputs=[],
-            outputs=["a", "b", "c"],
-            unpack_mode=atomic_recipe.UnpackMode.DATACLASS,
-        )
-        self.assertEqual(len(node.outputs), 3)
-        self.assertEqual(node.unpack_mode, atomic_recipe.UnpackMode.DATACLASS)
-
     def test_none_mode_single_output(self):
         node = atomic_recipe.AtomicRecipe(
             reference=makers.make_reference(),
@@ -136,7 +126,7 @@ class TestAtomicRecipeUnpackMode(unittest.TestCase):
         self.assertIn(atomic_recipe.UnpackMode.NONE.value, str(ctx.exception))
 
     def test_all_unpack_modes_accepted_as_string(self):
-        for mode in ["none", "tuple", "dataclass"]:
+        for mode in ["none", "tuple"]:
             with self.subTest(mode=mode):
                 node = atomic_recipe.AtomicRecipe(
                     reference=makers.make_reference(),
@@ -151,7 +141,7 @@ class TestUnpackModeEnum(unittest.TestCase):
     """Tests for UnpackMode enum."""
 
     def test_all_expected_values_exist(self):
-        expected = {"none", "tuple", "dataclass"}
+        expected = {"none", "tuple"}
         actual = {e.value for e in atomic_recipe.UnpackMode}
         self.assertEqual(expected, actual)
 

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -40,15 +40,6 @@ def get_blue(colors: SeabornColors) -> str:
     return colors.blue
 
 
-@dataclasses.dataclass
-class InaccessibleFieldAnnotation:
-    x: SeabornColors
-
-
-def return_problematic_dataclass(x) -> InaccessibleFieldAnnotation:
-    return InaccessibleFieldAnnotation(x)
-
-
 class _RetroPoint(NamedTuple):
     x: int
     y: int
@@ -585,23 +576,6 @@ class TestAtomicFromRecipe(unittest.TestCase):
         origin = get_origin(node.output_ports["result"].annotation)
         self.assertIs(origin, tuple)
 
-    def test_unpacking_dataclass(self):
-        recipe = atomic_parser.parse_atomic(
-            takes_positional_only,
-            unpack_mode=atomic_recipe.UnpackMode.DATACLASS,
-        )
-        node = datastructures.AtomicData.from_recipe(recipe)
-        self.assertIs(node.output_ports["x"].annotation, int)
-        self.assertIs(node.output_ports["y"].annotation, int)
-
-    def test_unpacking_dataclass_with_inaccessible_field_raises(self):
-        recipe = atomic_parser.parse_atomic(
-            return_problematic_dataclass,
-            unpack_mode=atomic_recipe.UnpackMode.DATACLASS,
-        )
-        with self.assertRaisesRegex(NameError, "name 'SeabornColors' is not defined"):
-            datastructures.AtomicData.from_recipe(recipe)
-
     def test_unpacking_dataclass_as_none(self):
         recipe = atomic_parser.parse_atomic(
             takes_positional_only,
@@ -916,17 +890,6 @@ class TestRunAtomic(unittest.TestCase):
         )
         node = wfms.run_recipe(recipe, a=1, b=2)
         self.assertEqual(node.output_ports["result"].value, (0, 1))
-
-    def test_unpacking_dataclass(self):
-        recipe = atomic_parser.parse_atomic(
-            takes_positional_only,
-            "dc_x_field",
-            "dc_y_field",
-            unpack_mode=atomic_recipe.UnpackMode.DATACLASS,
-        )
-        node = wfms.run_recipe(recipe, x=1, y=2)
-        self.assertEqual(node.output_ports["dc_x_field"].value, 1)
-        self.assertEqual(node.output_ports["dc_y_field"].value, 2)
 
     def test_unrecognized_input_raises(self):
         with self.assertRaises(ValueError) as ctx:


### PR DESCRIPTION
The same capability is more gracefully accessed by the `.flowrep_recipe_inverse` added to `@flowrep.dataclass`-decorated dataclasses, or by using `.` attribute access when parsing a `@workflow` to inject a `get_attr` node to pull off just the fields you want. Of course, users are still completely free to write an atomic node that unpacks any or all of some dataclass's fields themselves, no utility is lost here. 