### PR TITLE
Jsonable

### DIFF
--- a/src/flowrep/api/schemas.py
+++ b/src/flowrep/api/schemas.py
@@ -23,7 +23,7 @@ from flowrep.edge_models import SourceHandle as SourceHandle
 from flowrep.edge_models import TargetHandle as TargetHandle
 from flowrep.prospective.atomic_recipe import AtomicRecipe as AtomicRecipe
 from flowrep.prospective.atomic_recipe import UnpackMode as UnpackMode
-from flowrep.prospective.constant_recipe import JSON as JSON
+from flowrep.prospective.constant_recipe import JSONABLE as JSONABLE
 from flowrep.prospective.constant_recipe import ConstantRecipe as ConstantRecipe
 from flowrep.prospective.for_recipe import ForEachRecipe as ForEachRecipe
 from flowrep.prospective.helper_models import ConditionalCase as ConditionalCase

--- a/src/flowrep/api/tools.py
+++ b/src/flowrep/api/tools.py
@@ -13,6 +13,7 @@ from flowrep.parsers.atomic_parser import parse_atomic as parse_atomic
 from flowrep.parsers.dataclass_parser import dataclass as dataclass
 from flowrep.parsers.workflow_parser import parse_workflow as parse_workflow
 from flowrep.parsers.workflow_parser import workflow as workflow
+from flowrep.prospective.constant_recipe import is_jsonable as is_jsonable
 from flowrep.retrospective.datastructures import recipe2data as recipe2data
 from flowrep.retrospective.storage import LexicalBagBrowser as LexicalBagBrowser
 from flowrep.wfms import run_recipe as run_recipe

--- a/src/flowrep/prospective/constant_recipe.py
+++ b/src/flowrep/prospective/constant_recipe.py
@@ -8,9 +8,9 @@ from typing_extensions import TypeAliasType
 
 from flowrep import base_models
 
-JSON = TypeAliasType(
-    "JSON",
-    "dict[str, JSON] | list[JSON] | str | int | float | bool | None",
+JSONABLE = TypeAliasType(
+    "JSONABLE",
+    "dict[str, JSONABLE] | list[JSONABLE] | str | int | float | bool | None",
 )
 
 
@@ -73,7 +73,7 @@ class ConstantRecipe(base_models.NodeRecipe):
     outputs: base_models.Labels = pydantic.Field(
         default_factory=lambda: [ConstantRecipe.std_label]
     )
-    constant: JSON
+    constant: JSONABLE
 
     @pydantic.field_validator("constant", mode="before")
     @classmethod

--- a/src/flowrep/prospective/constant_recipe.py
+++ b/src/flowrep/prospective/constant_recipe.py
@@ -46,6 +46,15 @@ def _strict_json(value: Any) -> Any:
     )
 
 
+def is_jsonable(value: Any) -> bool:
+    """Whether *value* is JSON-serializable."""
+    try:
+        _strict_json(value)
+        return True
+    except ValueError:
+        return False
+
+
 class ConstantRecipe(base_models.NodeRecipe):
     """A source node emitting a fixed, JSON-serializable value.
 

--- a/tests/unit/prospective/test_constant_recipe.py
+++ b/tests/unit/prospective/test_constant_recipe.py
@@ -6,6 +6,12 @@ from flowrep import base_models
 from flowrep.prospective import constant_recipe, union_types
 
 
+class TestIsJsonable(unittest.TestCase):
+    def test_is_jsonable(self):
+        self.assertTrue(constant_recipe.is_jsonable([1, 2]))
+        self.assertFalse(constant_recipe.is_jsonable((1, 2)))
+
+
 class TestConstantRecipe(unittest.TestCase):
     def test_defaults_and_call(self):
         c = constant_recipe.ConstantRecipe(constant=0.5)


### PR DESCRIPTION
Renames the `JSON` type alias to `JSONABLE` and publicly exposes a little helper `is_jsonable` (since we can't `isinstance` against a `TypeAliasType`)