### PR TITLE
Remove `parse_workflow` from the module root

### DIFF
--- a/src/flowrep/__init__.py
+++ b/src/flowrep/__init__.py
@@ -9,7 +9,6 @@ import importlib.metadata
 from flowrep.api import atomic as atomic
 from flowrep.api import dataclass as dataclass
 from flowrep.api import parse_atomic as parse_atomic
-from flowrep.api import parse_workflow as parse_workflow
 from flowrep.api import schemas as schemas
 from flowrep.api import std as std
 from flowrep.api import tools as tools


### PR DESCRIPTION
It is still available via the api at `flowrep.tools.parse_workflow`

Closes #295 