### PR TITLE
Remove unpacking mode

### DIFF
--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -292,19 +292,9 @@
     "lines_to_next_cell": 2
    },
    "source": [
-    "### 1.3 Output naming and `unpack_mode`\n",
+    "### 1.3 Function returns into output ports\n",
     "\n",
-    "How does flowrep know what to call the outputs? It depends on the **unpack mode**,\n",
-    "which controls how the function's return value is interpreted:\n",
-    "\n",
-    "| `UnpackMode` | Meaning | Output ports |\n",
-    "|---|---|---|\n",
-    "| `TUPLE` (default) | Unpack return as a tuple | One port per element |\n",
-    "| `NONE` | Treat return as a single value | Exactly one port |\n",
-    "\n",
-    "#### `TUPLE` mode (default)\n",
-    "\n",
-    "Output labels are scraped from `return` statement variable names:"
+    "How does flowrep know what to call the outputs? By default, they'll be scraped from the symbols returned in the parsed function:"
    ]
   },
   {
@@ -378,69 +368,57 @@
    "execution_count": 7
   },
   {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "You can override this by providing explicit labels to the decorator",
+   "id": "e9bab152b3f98e5d"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "@fr.atomic(\"stepped\")\n",
+    "def increment(x):\n",
+    "    return x + 1\n",
+    "\n",
+    "print(f\"Outputs: {increment.flowrep_recipe.outputs}\")\n",
+    "assert(increment.flowrep_recipe.outputs == [\"stepped\"])"
+   ],
+   "id": "d5a7b4f2477b326"
+  },
+  {
    "cell_type": "markdown",
    "id": "60c67935",
    "metadata": {},
    "source": [
-    "#### `NONE` mode\n",
+    "Sometimes, you might want to stop flowrep from breaking the returned values into different ports -- to actually have a port hold the entire tuple.\n",
     "\n",
-    "For functions where you want to keep the return as a single opaque value\n",
-    "(e.g. returning a tuple that shouldn't be unpacked):"
+    "One way to accomplish this is to provide a _single_ output label when the function itself has a tuple-like return value:"
    ]
   },
   {
    "cell_type": "code",
    "id": "467bd6b8",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.480271Z",
-     "start_time": "2026-07-21T19:23:17.442690Z"
-    }
-   },
+   "metadata": {},
    "source": [
-    "@fr.atomic(unpack_mode=fr.schemas.UnpackMode.NONE)\n",
+    "@fr.atomic(\"tuple_return\")\n",
     "def righthanded2lefthanded(x, y, z):\n",
     "    return (x, z, y)\n",
     "\n",
     "\n",
     "print(f\"Outputs: {righthanded2lefthanded.flowrep_recipe.outputs}\")\n",
-    "assert(righthanded2lefthanded.flowrep_recipe.outputs == [\"output_0\"])\n",
-    "print(f\"Unpack mode: {righthanded2lefthanded.flowrep_recipe.unpack_mode}\")\n",
-    "assert(str(righthanded2lefthanded.flowrep_recipe.unpack_mode) == \"none\")"
+    "assert(righthanded2lefthanded.flowrep_recipe.outputs == [\"tuple_return\"])"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outputs: ['output_0']\n",
-      "Unpack mode: none\n"
-     ]
-    }
-   ],
-   "execution_count": 8
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fad99e5f",
-   "metadata": {},
-   "source": [
-    "With `NONE`, you're limited to exactly one output port. Trying to declare multiple\n",
-    "outputs will fail at the model level — this is an internal consistency check, though\n",
-    "it doesn't validate anything about the actual function."
-   ]
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "1c301250",
    "metadata": {},
-   "source": [
-    "### 1.4 Annotated output labels\n",
-    "\n",
-    "For finer control, you can name outputs via `typing.Annotated` metadata on the\n",
-    "return type annotation, using either an `OutputMeta` instance or a plain dict\n",
-    "with a `\"label\"` key:"
-   ]
+   "source": "These labels take the highest priority, but if you happen to have annotated returns, flowrep will use any \"label\" term there before falling back to scraping the returned symbols themselves. These annotations won't control how many output ports are produced though -- the only way to force a single-output port is to provide a single output label."
   },
   {
    "cell_type": "code",
@@ -480,51 +458,6 @@
     }
    ],
    "execution_count": 9
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
-    "Annotation labels take precedence over AST-scraped variable names. Positions\n",
-    "without annotations fall back to the scraped name. You can also override information\n",
-    "in the function altogether and pass output label strings directly to the decorator:"
-   ],
-   "id": "95a09d3e500b1b87"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.665318Z",
-     "start_time": "2026-07-21T19:23:17.562403Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "@fr.atomic(\"my_magnitude\", \"my_angle\")\n",
-    "def norm2(\n",
-    "    x, y\n",
-    ") -> tuple[\n",
-    "    Annotated[float, {\"label\": \"magnitude\"}],\n",
-    "    Annotated[float, {\"label\": \"angle\"}],\n",
-    "]:\n",
-    "    import math\n",
-    "\n",
-    "    return math.hypot(x, y), math.atan2(y, x)\n",
-    "\n",
-    "print(f\"Outputs: {norm2.flowrep_recipe.outputs}\")\n",
-    "assert(norm2.flowrep_recipe.outputs == ['my_magnitude', 'my_angle'])"
-   ],
-   "id": "bebb33c6345c3ab9",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outputs: ['my_magnitude', 'my_angle']\n"
-     ]
-    }
-   ],
-   "execution_count": 10
   },
   {
    "cell_type": "markdown",
@@ -812,7 +745,6 @@
     "    ),\n",
     "    inputs=[\"start\", \"stop\", \"num\"],  # Hide retstep, endpoint, dtype, axis\n",
     "    outputs=[\"samples\"],\n",
-    "    unpack_mode=fr.schemas.UnpackMode.NONE,\n",
     ")\n",
     "print(f\"Inputs:  {linspace_node.inputs}\")\n",
     "print(f\"Outputs: {linspace_node.outputs}\")"
@@ -869,7 +801,6 @@
     "    ),\n",
     "    inputs=[\"start\", \"stop\", \"step\"],\n",
     "    outputs=[\"values\"],\n",
-    "    unpack_mode=fr.schemas.UnpackMode.NONE,\n",
     ")\n",
     "print(f\"Restricted kinds: {arange_node.reference.restricted_input_kinds}\")"
    ],
@@ -974,7 +905,6 @@
     "    ),\n",
     "    inputs=[\"this\", \"that\", \"the_other\"],\n",
     "    outputs=[\"as_a_dict\"],\n",
-    "    unpack_mode=fr.schemas.UnpackMode.NONE,\n",
     ")\n",
     "print(f\"Restricted kinds: {my_particular_dict_recipe.reference.restricted_input_kinds}\")"
    ],
@@ -1047,7 +977,6 @@
     "    ),\n",
     "    inputs=[\"a\", \"b\", \"offset\"],\n",
     "    outputs=[\"total\"],\n",
-    "    unpack_mode=fr.schemas.UnpackMode.TUPLE,\n",
     ")\n",
     "print(f\"Restricted kinds: {my_offset_sum.reference.restricted_input_kinds}\")"
    ],

--- a/notebooks/user-guide.ipynb
+++ b/notebooks/user-guide.ipynb
@@ -37,8 +37,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:16.980825Z",
-     "start_time": "2026-07-21T19:23:16.665367Z"
+     "end_time": "2026-07-21T21:51:23.767768Z",
+     "start_time": "2026-07-21T21:51:23.479375Z"
     }
    },
    "cell_type": "code",
@@ -53,7 +53,7 @@
     {
      "data": {
       "text/plain": [
-       "(<function flowrep.parsers.atomic_parser.parse_atomic(func: function | type, *output_labels: str, unpack_mode: flowrep.prospective.atomic_recipe.UnpackMode = <UnpackMode.TUPLE: 'tuple'>, version_scraping: dict[str, collections.abc.Callable[[str], str | None]] | None = None, forbid_main: bool = False, forbid_locals: bool = False, require_version: bool = False) -> flowrep.prospective.atomic_recipe.AtomicRecipe>,\n",
+       "(<function flowrep.parsers.atomic_parser.parse_atomic(func: function | type, *output_labels: str, version_scraping: dict[str, collections.abc.Callable[[str], str | None]] | None = None, forbid_main: bool = False, forbid_locals: bool = False, require_version: bool = False) -> flowrep.prospective.atomic_recipe.AtomicRecipe>,\n",
        " <function flowrep.parsers.atomic_parser.atomic(func=None, /, *output_labels, **kwargs)>,\n",
        " <function flowrep.parsers.workflow_parser.workflow(func=None, /, *output_labels: 'str', **kwargs)>,\n",
        " <function flowrep.parsers.dataclass_parser.dataclass(cls=None, /, *output_labels, **kwargs)>)"
@@ -101,8 +101,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.064585Z",
-     "start_time": "2026-07-21T19:23:16.984591Z"
+     "end_time": "2026-07-21T21:51:23.836617Z",
+     "start_time": "2026-07-21T21:51:23.782495Z"
     }
    },
    "cell_type": "code",
@@ -131,7 +131,7 @@
     {
      "data": {
       "text/plain": [
-       "AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>)"
+       "AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
       ]
      },
      "execution_count": 2,
@@ -163,8 +163,8 @@
    "id": "fbb2ac82",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.188596Z",
-     "start_time": "2026-07-21T19:23:17.137686Z"
+     "end_time": "2026-07-21T21:51:23.882735Z",
+     "start_time": "2026-07-21T21:51:23.849547Z"
     }
    },
    "source": [
@@ -180,7 +180,7 @@
     {
      "data": {
       "text/plain": [
-       "AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>)"
+       "AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
       ]
      },
      "execution_count": 3,
@@ -204,8 +204,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.263354Z",
-     "start_time": "2026-07-21T19:23:17.204398Z"
+     "end_time": "2026-07-21T21:51:23.918867Z",
+     "start_time": "2026-07-21T21:51:23.885779Z"
     }
    },
    "cell_type": "code",
@@ -240,8 +240,8 @@
    "id": "4ce6917d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.319682Z",
-     "start_time": "2026-07-21T19:23:17.266132Z"
+     "end_time": "2026-07-21T21:51:23.973753Z",
+     "start_time": "2026-07-21T21:51:23.922083Z"
     }
    },
    "source": [
@@ -302,8 +302,8 @@
    "id": "cac0a1bd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.371439Z",
-     "start_time": "2026-07-21T19:23:17.323521Z"
+     "end_time": "2026-07-21T21:51:24.010920Z",
+     "start_time": "2026-07-21T21:51:23.977160Z"
     }
    },
    "source": [
@@ -343,8 +343,8 @@
    "id": "9f659bd7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.439250Z",
-     "start_time": "2026-07-21T19:23:17.388941Z"
+     "end_time": "2026-07-21T21:51:24.057186Z",
+     "start_time": "2026-07-21T21:51:24.025458Z"
     }
    },
    "source": [
@@ -374,10 +374,13 @@
    "id": "e9bab152b3f98e5d"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-21T21:51:24.129600Z",
+     "start_time": "2026-07-21T21:51:24.071851Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "@fr.atomic(\"stepped\")\n",
     "def increment(x):\n",
@@ -386,7 +389,17 @@
     "print(f\"Outputs: {increment.flowrep_recipe.outputs}\")\n",
     "assert(increment.flowrep_recipe.outputs == [\"stepped\"])"
    ],
-   "id": "d5a7b4f2477b326"
+   "id": "d5a7b4f2477b326",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outputs: ['stepped']\n"
+     ]
+    }
+   ],
+   "execution_count": 8
   },
   {
    "cell_type": "markdown",
@@ -401,7 +414,12 @@
   {
    "cell_type": "code",
    "id": "467bd6b8",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-07-21T21:51:24.163059Z",
+     "start_time": "2026-07-21T21:51:24.146302Z"
+    }
+   },
    "source": [
     "@fr.atomic(\"tuple_return\")\n",
     "def righthanded2lefthanded(x, y, z):\n",
@@ -411,8 +429,16 @@
     "print(f\"Outputs: {righthanded2lefthanded.flowrep_recipe.outputs}\")\n",
     "assert(righthanded2lefthanded.flowrep_recipe.outputs == [\"tuple_return\"])"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outputs: ['tuple_return']\n"
+     ]
+    }
+   ],
+   "execution_count": 9
   },
   {
    "cell_type": "markdown",
@@ -425,8 +451,8 @@
    "id": "0d46e437",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.546029Z",
-     "start_time": "2026-07-21T19:23:17.497114Z"
+     "end_time": "2026-07-21T21:51:24.202160Z",
+     "start_time": "2026-07-21T21:51:24.173678Z"
     }
    },
    "source": [
@@ -457,7 +483,7 @@
      ]
     }
    ],
-   "execution_count": 9
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",
@@ -479,8 +505,8 @@
    "id": "77276c40",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.727330Z",
-     "start_time": "2026-07-21T19:23:17.686169Z"
+     "end_time": "2026-07-21T21:51:24.225185Z",
+     "start_time": "2026-07-21T21:51:24.204422Z"
     }
    },
    "source": [
@@ -559,8 +585,8 @@
    "id": "b8f03ee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.777143Z",
-     "start_time": "2026-07-21T19:23:17.745260Z"
+     "end_time": "2026-07-21T21:51:24.267259Z",
+     "start_time": "2026-07-21T21:51:24.237111Z"
     }
    },
    "source": [
@@ -616,8 +642,8 @@
    "id": "66ac7ffa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.819751Z",
-     "start_time": "2026-07-21T19:23:17.792317Z"
+     "end_time": "2026-07-21T21:51:24.326074Z",
+     "start_time": "2026-07-21T21:51:24.270928Z"
     }
    },
    "source": [
@@ -663,8 +689,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.854354Z",
-     "start_time": "2026-07-21T19:23:17.830663Z"
+     "end_time": "2026-07-21T21:51:24.403098Z",
+     "start_time": "2026-07-21T21:51:24.362880Z"
     }
    },
    "cell_type": "code",
@@ -729,8 +755,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.874401Z",
-     "start_time": "2026-07-21T19:23:17.865510Z"
+     "end_time": "2026-07-21T21:51:24.425577Z",
+     "start_time": "2026-07-21T21:51:24.416066Z"
     }
    },
    "cell_type": "code",
@@ -784,8 +810,8 @@
    "id": "67cf6163",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.921210Z",
-     "start_time": "2026-07-21T19:23:17.888219Z"
+     "end_time": "2026-07-21T21:51:24.466967Z",
+     "start_time": "2026-07-21T21:51:24.437046Z"
     }
    },
    "source": [
@@ -846,8 +872,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.952176Z",
-     "start_time": "2026-07-21T19:23:17.923153Z"
+     "end_time": "2026-07-21T21:51:24.485208Z",
+     "start_time": "2026-07-21T21:51:24.468952Z"
     }
    },
    "cell_type": "code",
@@ -885,8 +911,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.972890Z",
-     "start_time": "2026-07-21T19:23:17.963581Z"
+     "end_time": "2026-07-21T21:51:24.512894Z",
+     "start_time": "2026-07-21T21:51:24.497371Z"
     }
    },
    "cell_type": "code",
@@ -923,8 +949,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:17.999784Z",
-     "start_time": "2026-07-21T19:23:17.983156Z"
+     "end_time": "2026-07-21T21:51:24.546717Z",
+     "start_time": "2026-07-21T21:51:24.525191Z"
     }
    },
    "cell_type": "code",
@@ -953,8 +979,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.048159Z",
-     "start_time": "2026-07-21T19:23:18.014630Z"
+     "end_time": "2026-07-21T21:51:24.589111Z",
+     "start_time": "2026-07-21T21:51:24.557278Z"
     }
    },
    "cell_type": "code",
@@ -995,8 +1021,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.143094Z",
-     "start_time": "2026-07-21T19:23:18.051014Z"
+     "end_time": "2026-07-21T21:51:24.643020Z",
+     "start_time": "2026-07-21T21:51:24.590907Z"
     }
    },
    "cell_type": "code",
@@ -1052,8 +1078,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.176663Z",
-     "start_time": "2026-07-21T19:23:18.144228Z"
+     "end_time": "2026-07-21T21:51:24.665520Z",
+     "start_time": "2026-07-21T21:51:24.644242Z"
     }
    },
    "cell_type": "code",
@@ -1096,7 +1122,7 @@
     {
      "data": {
       "text/plain": [
-       "WorkflowRecipe(type=<RecipeElementType.WORKFLOW: 'workflow'>, inputs=['x', 'slope', 'intercept'], outputs=['result'], description='y = slope * x + intercept', nodes={'multiply_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>), 'add_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}), unpack_mode=<UnpackMode.TUPLE: 'tuple'>)}, input_edges={TargetHandle(node='multiply_0', port='x'): InputSource(node=None, port='x'), TargetHandle(node='multiply_0', port='y'): InputSource(node=None, port='slope'), TargetHandle(node='add_0', port='b'): InputSource(node=None, port='intercept')}, edges={TargetHandle(node='add_0', port='a'): SourceHandle(node='multiply_0', port='product')}, output_edges={OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result')}, reference=PythonReference(info=VersionInfo(module='__main__', qualname='linear', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
+       "WorkflowRecipe(type=<RecipeElementType.WORKFLOW: 'workflow'>, inputs=['x', 'slope', 'intercept'], outputs=['result'], description='y = slope * x + intercept', nodes={'multiply_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['x', 'y'], outputs=['product'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='multiply', version=None), inputs_with_defaults=[], restricted_input_kinds={})), 'add_0': AtomicRecipe(type=<RecipeElementType.ATOMIC: 'atomic'>, inputs=['a', 'b'], outputs=['result'], description=None, reference=PythonReference(info=VersionInfo(module='__main__', qualname='add', version=None), inputs_with_defaults=[], restricted_input_kinds={}))}, input_edges={TargetHandle(node='multiply_0', port='x'): InputSource(node=None, port='x'), TargetHandle(node='multiply_0', port='y'): InputSource(node=None, port='slope'), TargetHandle(node='add_0', port='b'): InputSource(node=None, port='intercept')}, edges={TargetHandle(node='add_0', port='a'): SourceHandle(node='multiply_0', port='product')}, output_edges={OutputTarget(node=None, port='result'): SourceHandle(node='add_0', port='result')}, reference=PythonReference(info=VersionInfo(module='__main__', qualname='linear', version=None), inputs_with_defaults=[], restricted_input_kinds={}))"
       ]
      },
      "execution_count": 22,
@@ -1138,8 +1164,8 @@
    "id": "d39608c2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.201452Z",
-     "start_time": "2026-07-21T19:23:18.190596Z"
+     "end_time": "2026-07-21T21:51:24.691129Z",
+     "start_time": "2026-07-21T21:51:24.667850Z"
     }
    },
    "source": "linear.flowrep_recipe(x=3, slope=2, intercept=1)",
@@ -1189,8 +1215,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.244694Z",
-     "start_time": "2026-07-21T19:23:18.212036Z"
+     "end_time": "2026-07-21T21:51:24.719179Z",
+     "start_time": "2026-07-21T21:51:24.693439Z"
     }
    },
    "cell_type": "code",
@@ -1264,8 +1290,8 @@
    "id": "55716aa9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.276273Z",
-     "start_time": "2026-07-21T19:23:18.246604Z"
+     "end_time": "2026-07-21T21:51:24.760163Z",
+     "start_time": "2026-07-21T21:51:24.735163Z"
     }
    },
    "source": [
@@ -1320,8 +1346,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.294371Z",
-     "start_time": "2026-07-21T19:23:18.278128Z"
+     "end_time": "2026-07-21T21:51:24.797889Z",
+     "start_time": "2026-07-21T21:51:24.763111Z"
     }
    },
    "cell_type": "code",
@@ -1359,8 +1385,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.337087Z",
-     "start_time": "2026-07-21T19:23:18.308227Z"
+     "end_time": "2026-07-21T21:51:24.813300Z",
+     "start_time": "2026-07-21T21:51:24.798946Z"
     }
    },
    "cell_type": "code",
@@ -1393,8 +1419,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.361192Z",
-     "start_time": "2026-07-21T19:23:18.339140Z"
+     "end_time": "2026-07-21T21:51:24.892264Z",
+     "start_time": "2026-07-21T21:51:24.848788Z"
     }
    },
    "cell_type": "code",
@@ -1435,8 +1461,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.409858Z",
-     "start_time": "2026-07-21T19:23:18.376954Z"
+     "end_time": "2026-07-21T21:51:24.921325Z",
+     "start_time": "2026-07-21T21:51:24.895968Z"
     }
    },
    "cell_type": "code",
@@ -1485,8 +1511,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.424640Z",
-     "start_time": "2026-07-21T19:23:18.411765Z"
+     "end_time": "2026-07-21T21:51:24.938180Z",
+     "start_time": "2026-07-21T21:51:24.923500Z"
     }
    },
    "cell_type": "code",
@@ -1519,8 +1545,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.469790Z",
-     "start_time": "2026-07-21T19:23:18.438047Z"
+     "end_time": "2026-07-21T21:51:24.972647Z",
+     "start_time": "2026-07-21T21:51:24.951356Z"
     }
    },
    "cell_type": "code",
@@ -1565,8 +1591,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.500956Z",
-     "start_time": "2026-07-21T19:23:18.471872Z"
+     "end_time": "2026-07-21T21:51:25.000572Z",
+     "start_time": "2026-07-21T21:51:24.975014Z"
     }
    },
    "cell_type": "code",
@@ -1640,8 +1666,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.524417Z",
-     "start_time": "2026-07-21T19:23:18.511876Z"
+     "end_time": "2026-07-21T21:51:25.032638Z",
+     "start_time": "2026-07-21T21:51:25.002893Z"
     }
    },
    "cell_type": "code",
@@ -1670,8 +1696,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.554007Z",
-     "start_time": "2026-07-21T19:23:18.537437Z"
+     "end_time": "2026-07-21T21:51:25.061541Z",
+     "start_time": "2026-07-21T21:51:25.043833Z"
     }
    },
    "cell_type": "code",
@@ -1733,8 +1759,8 @@
    "id": "13f799b9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.598868Z",
-     "start_time": "2026-07-21T19:23:18.567466Z"
+     "end_time": "2026-07-21T21:51:25.089661Z",
+     "start_time": "2026-07-21T21:51:25.063740Z"
     }
    },
    "source": [
@@ -1777,8 +1803,7 @@
       "        },\n",
       "        \"inputs_with_defaults\": [],\n",
       "        \"restricted_input_kinds\": {}\n",
-      "      },\n",
-      "      \"unpack_mode\": \"tuple\"\n",
+      "      }\n",
       "    },\n",
       "    \"add_0\": {\n",
       "      \"type\": \"atomic\",\n",
@@ -1798,8 +1823,7 @@
       "        },\n",
       "        \"inputs_with_defaults\": [],\n",
       "        \"restricted_input_kinds\": {}\n",
-      "      },\n",
-      "      \"unpack_mode\": \"tuple\"\n",
+      "      }\n",
       "    }\n",
       "  },\n",
       "  \"input_edges\": {\n",
@@ -1848,8 +1872,8 @@
    "id": "e67cac8d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.673396Z",
-     "start_time": "2026-07-21T19:23:18.600356Z"
+     "end_time": "2026-07-21T21:51:25.116259Z",
+     "start_time": "2026-07-21T21:51:25.091800Z"
     }
    },
    "source": [
@@ -1904,8 +1928,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.709796Z",
-     "start_time": "2026-07-21T19:23:18.676600Z"
+     "end_time": "2026-07-21T21:51:25.144293Z",
+     "start_time": "2026-07-21T21:51:25.118452Z"
     }
    },
    "cell_type": "code",
@@ -2073,8 +2097,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.758345Z",
-     "start_time": "2026-07-21T19:23:18.729918Z"
+     "end_time": "2026-07-21T21:51:25.175417Z",
+     "start_time": "2026-07-21T21:51:25.146576Z"
     }
    },
    "cell_type": "code",
@@ -2149,8 +2173,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.786888Z",
-     "start_time": "2026-07-21T19:23:18.760424Z"
+     "end_time": "2026-07-21T21:51:25.218743Z",
+     "start_time": "2026-07-21T21:51:25.191380Z"
     }
    },
    "cell_type": "code",
@@ -2210,8 +2234,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.816550Z",
-     "start_time": "2026-07-21T19:23:18.790613Z"
+     "end_time": "2026-07-21T21:51:25.247174Z",
+     "start_time": "2026-07-21T21:51:25.221234Z"
     }
    },
    "cell_type": "code",
@@ -2256,8 +2280,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.845154Z",
-     "start_time": "2026-07-21T19:23:18.818718Z"
+     "end_time": "2026-07-21T21:51:25.273394Z",
+     "start_time": "2026-07-21T21:51:25.249446Z"
     }
    },
    "cell_type": "code",
@@ -2348,8 +2372,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.874120Z",
-     "start_time": "2026-07-21T19:23:18.848946Z"
+     "end_time": "2026-07-21T21:51:25.300690Z",
+     "start_time": "2026-07-21T21:51:25.275613Z"
     }
    },
    "cell_type": "code",
@@ -2448,8 +2472,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.908121Z",
-     "start_time": "2026-07-21T19:23:18.876777Z"
+     "end_time": "2026-07-21T21:51:25.335325Z",
+     "start_time": "2026-07-21T21:51:25.303083Z"
     }
    },
    "cell_type": "code",
@@ -2488,9 +2512,9 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_40411/3523357707.py\", line 16, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_46295/3523357707.py\", line 16, in <module>\n",
       "    conditional_availability(-1)\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_40411/3523357707.py\", line 9, in conditional_availability\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_46295/3523357707.py\", line 9, in conditional_availability\n",
       "    downstream = fr.std.identity(result)\n",
       "                                 ^^^^^^\n",
       "UnboundLocalError: cannot access local variable 'result' where it is not associated with a value\n"
@@ -2525,8 +2549,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.924541Z",
-     "start_time": "2026-07-21T19:23:18.910252Z"
+     "end_time": "2026-07-21T21:51:25.382571Z",
+     "start_time": "2026-07-21T21:51:25.336298Z"
     }
    },
    "cell_type": "code",
@@ -2578,8 +2602,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.962159Z",
-     "start_time": "2026-07-21T19:23:18.935814Z"
+     "end_time": "2026-07-21T21:51:25.433491Z",
+     "start_time": "2026-07-21T21:51:25.404969Z"
     }
    },
    "source": [
@@ -2624,8 +2648,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:18.990758Z",
-     "start_time": "2026-07-21T19:23:18.965143Z"
+     "end_time": "2026-07-21T21:51:25.464631Z",
+     "start_time": "2026-07-21T21:51:25.435352Z"
     }
    },
    "source": [
@@ -2701,8 +2725,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.018575Z",
-     "start_time": "2026-07-21T19:23:18.993172Z"
+     "end_time": "2026-07-21T21:51:25.492415Z",
+     "start_time": "2026-07-21T21:51:25.466920Z"
     }
    },
    "cell_type": "code",
@@ -2790,8 +2814,8 @@
    "id": "d76836d6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.048686Z",
-     "start_time": "2026-07-21T19:23:19.021268Z"
+     "end_time": "2026-07-21T21:51:25.524289Z",
+     "start_time": "2026-07-21T21:51:25.495690Z"
     }
    },
    "source": [
@@ -2818,8 +2842,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.076757Z",
-     "start_time": "2026-07-21T19:23:19.050799Z"
+     "end_time": "2026-07-21T21:51:25.564103Z",
+     "start_time": "2026-07-21T21:51:25.539359Z"
     }
    },
    "cell_type": "code",
@@ -2870,8 +2894,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.110696Z",
-     "start_time": "2026-07-21T19:23:19.079292Z"
+     "end_time": "2026-07-21T21:51:25.590666Z",
+     "start_time": "2026-07-21T21:51:25.566349Z"
     }
    },
    "cell_type": "code",
@@ -2894,16 +2918,16 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_40411/3041652459.py\", line 4, in <module>\n",
+      "  File \"/var/folders/nn/6kd6nhmj2rx7610kd9r_8h0m0000gn/T/ipykernel_46295/3041652459.py\", line 4, in <module>\n",
       "    @fr.atomic(forbid_main=True)\n",
       "     ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/parser_helpers.py\", line 64, in deferred\n",
       "    return wrap(f, labels)\n",
       "           ^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 73, in wrap\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 71, in wrap\n",
       "    f.flowrep_recipe = parse_atomic(f, *labels, **kwargs)\n",
       "                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 149, in parse_atomic\n",
+      "  File \"/Users/liamhuber/dev/pyiron/flowrep/src/flowrep/parsers/atomic_parser.py\", line 147, in parse_atomic\n",
       "    function_info = versions.VersionInfo.of(\n",
       "                    ^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/liamhuber/dev/pyiron/pyiron_snippets/pyiron_snippets/versions.py\", line 125, in of\n",
@@ -2954,8 +2978,8 @@
    "id": "3efa3180",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.192509Z",
-     "start_time": "2026-07-21T19:23:19.136158Z"
+     "end_time": "2026-07-21T21:51:25.616954Z",
+     "start_time": "2026-07-21T21:51:25.592962Z"
     }
    },
    "source": [
@@ -2993,8 +3017,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.223585Z",
-     "start_time": "2026-07-21T19:23:19.196050Z"
+     "end_time": "2026-07-21T21:51:25.645234Z",
+     "start_time": "2026-07-21T21:51:25.619153Z"
     }
    },
    "cell_type": "code",
@@ -3039,8 +3063,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.246898Z",
-     "start_time": "2026-07-21T19:23:19.225790Z"
+     "end_time": "2026-07-21T21:51:25.675143Z",
+     "start_time": "2026-07-21T21:51:25.647468Z"
     }
    },
    "cell_type": "code",
@@ -3066,8 +3090,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.274829Z",
-     "start_time": "2026-07-21T19:23:19.248698Z"
+     "end_time": "2026-07-21T21:51:25.700177Z",
+     "start_time": "2026-07-21T21:51:25.676895Z"
     }
    },
    "cell_type": "code",
@@ -3109,8 +3133,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.307377Z",
-     "start_time": "2026-07-21T19:23:19.276956Z"
+     "end_time": "2026-07-21T21:51:25.726592Z",
+     "start_time": "2026-07-21T21:51:25.702370Z"
     }
    },
    "cell_type": "code",
@@ -3151,8 +3175,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.354662Z",
-     "start_time": "2026-07-21T19:23:19.324810Z"
+     "end_time": "2026-07-21T21:51:25.753751Z",
+     "start_time": "2026-07-21T21:51:25.729660Z"
     }
    },
    "cell_type": "code",
@@ -3212,8 +3236,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.383223Z",
-     "start_time": "2026-07-21T19:23:19.357108Z"
+     "end_time": "2026-07-21T21:51:25.787163Z",
+     "start_time": "2026-07-21T21:51:25.756223Z"
     }
    },
    "cell_type": "code",
@@ -3282,8 +3306,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.422799Z",
-     "start_time": "2026-07-21T19:23:19.398423Z"
+     "end_time": "2026-07-21T21:51:25.814218Z",
+     "start_time": "2026-07-21T21:51:25.789715Z"
     }
    },
    "cell_type": "code",
@@ -3319,8 +3343,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.451831Z",
-     "start_time": "2026-07-21T19:23:19.425340Z"
+     "end_time": "2026-07-21T21:51:25.860939Z",
+     "start_time": "2026-07-21T21:51:25.816535Z"
     }
    },
    "cell_type": "code",
@@ -3384,8 +3408,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.484719Z",
-     "start_time": "2026-07-21T19:23:19.454264Z"
+     "end_time": "2026-07-21T21:51:25.917063Z",
+     "start_time": "2026-07-21T21:51:25.863708Z"
     }
    },
    "cell_type": "code",
@@ -3442,8 +3466,8 @@
    "id": "5ccd8c05",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.527434Z",
-     "start_time": "2026-07-21T19:23:19.500795Z"
+     "end_time": "2026-07-21T21:51:25.964625Z",
+     "start_time": "2026-07-21T21:51:25.919636Z"
     }
    },
    "source": [
@@ -3531,8 +3555,8 @@
    "id": "2370bd6b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.541762Z",
-     "start_time": "2026-07-21T19:23:19.529836Z"
+     "end_time": "2026-07-21T21:51:25.978416Z",
+     "start_time": "2026-07-21T21:51:25.966952Z"
     }
    },
    "source": [
@@ -3568,8 +3592,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.564769Z",
-     "start_time": "2026-07-21T19:23:19.552879Z"
+     "end_time": "2026-07-21T21:51:25.995299Z",
+     "start_time": "2026-07-21T21:51:25.978854Z"
     }
    },
    "cell_type": "code",
@@ -3581,8 +3605,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.593343Z",
-     "start_time": "2026-07-21T19:23:19.577010Z"
+     "end_time": "2026-07-21T21:51:26.031844Z",
+     "start_time": "2026-07-21T21:51:26.005677Z"
     }
    },
    "cell_type": "code",
@@ -3621,8 +3645,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.629Z",
-     "start_time": "2026-07-21T19:23:19.610976Z"
+     "end_time": "2026-07-21T21:51:26.056910Z",
+     "start_time": "2026-07-21T21:51:26.033987Z"
     }
    },
    "cell_type": "code",
@@ -3674,8 +3698,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.710276Z",
-     "start_time": "2026-07-21T19:23:19.630865Z"
+     "end_time": "2026-07-21T21:51:26.089621Z",
+     "start_time": "2026-07-21T21:51:26.059099Z"
     }
    },
    "cell_type": "code",
@@ -3704,8 +3728,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.743255Z",
-     "start_time": "2026-07-21T19:23:19.722550Z"
+     "end_time": "2026-07-21T21:51:26.114460Z",
+     "start_time": "2026-07-21T21:51:26.091968Z"
     }
    },
    "cell_type": "code",
@@ -3739,8 +3763,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.774118Z",
-     "start_time": "2026-07-21T19:23:19.745679Z"
+     "end_time": "2026-07-21T21:51:26.140250Z",
+     "start_time": "2026-07-21T21:51:26.116818Z"
     }
    },
    "cell_type": "code",
@@ -3779,8 +3803,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.803855Z",
-     "start_time": "2026-07-21T19:23:19.776509Z"
+     "end_time": "2026-07-21T21:51:26.171898Z",
+     "start_time": "2026-07-21T21:51:26.142488Z"
     }
    },
    "cell_type": "code",
@@ -3827,8 +3851,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.831637Z",
-     "start_time": "2026-07-21T19:23:19.806327Z"
+     "end_time": "2026-07-21T21:51:26.199455Z",
+     "start_time": "2026-07-21T21:51:26.182498Z"
     }
    },
    "cell_type": "code",
@@ -3852,8 +3876,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.867060Z",
-     "start_time": "2026-07-21T19:23:19.833861Z"
+     "end_time": "2026-07-21T21:51:26.226025Z",
+     "start_time": "2026-07-21T21:51:26.201552Z"
     }
    },
    "cell_type": "code",
@@ -3876,8 +3900,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.905837Z",
-     "start_time": "2026-07-21T19:23:19.869238Z"
+     "end_time": "2026-07-21T21:51:26.253404Z",
+     "start_time": "2026-07-21T21:51:26.229167Z"
     }
    },
    "cell_type": "code",
@@ -3920,8 +3944,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.934626Z",
-     "start_time": "2026-07-21T19:23:19.908107Z"
+     "end_time": "2026-07-21T21:51:26.279116Z",
+     "start_time": "2026-07-21T21:51:26.255984Z"
     }
    },
    "cell_type": "code",
@@ -3971,8 +3995,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.958912Z",
-     "start_time": "2026-07-21T19:23:19.936640Z"
+     "end_time": "2026-07-21T21:51:26.291303Z",
+     "start_time": "2026-07-21T21:51:26.281302Z"
     }
    },
    "cell_type": "code",
@@ -4006,8 +4030,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:19.990371Z",
-     "start_time": "2026-07-21T19:23:19.960531Z"
+     "end_time": "2026-07-21T21:51:26.327749Z",
+     "start_time": "2026-07-21T21:51:26.302108Z"
     }
    },
    "cell_type": "code",
@@ -4043,8 +4067,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:20.028089Z",
-     "start_time": "2026-07-21T19:23:20.002043Z"
+     "end_time": "2026-07-21T21:51:26.356972Z",
+     "start_time": "2026-07-21T21:51:26.330038Z"
     }
    },
    "cell_type": "code",
@@ -4092,8 +4116,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:20.053968Z",
-     "start_time": "2026-07-21T19:23:20.032037Z"
+     "end_time": "2026-07-21T21:51:26.379040Z",
+     "start_time": "2026-07-21T21:51:26.361168Z"
     }
    },
    "cell_type": "code",
@@ -4119,8 +4143,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:20.101713Z",
-     "start_time": "2026-07-21T19:23:20.068923Z"
+     "end_time": "2026-07-21T21:51:26.455849Z",
+     "start_time": "2026-07-21T21:51:26.380189Z"
     }
    },
    "cell_type": "code",
@@ -4154,8 +4178,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:20.124294Z",
-     "start_time": "2026-07-21T19:23:20.104094Z"
+     "end_time": "2026-07-21T21:51:26.500273Z",
+     "start_time": "2026-07-21T21:51:26.468913Z"
     }
    },
    "cell_type": "code",
@@ -4204,8 +4228,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:20.217568Z",
-     "start_time": "2026-07-21T19:23:20.126701Z"
+     "end_time": "2026-07-21T21:51:26.555899Z",
+     "start_time": "2026-07-21T21:51:26.502613Z"
     }
    },
    "cell_type": "code",
@@ -4268,8 +4292,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:20.614410Z",
-     "start_time": "2026-07-21T19:23:20.230022Z"
+     "end_time": "2026-07-21T21:51:26.967488Z",
+     "start_time": "2026-07-21T21:51:26.558200Z"
     }
    },
    "cell_type": "code",
@@ -4303,8 +4327,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:20.660307Z",
-     "start_time": "2026-07-21T19:23:20.618924Z"
+     "end_time": "2026-07-21T21:51:27.006299Z",
+     "start_time": "2026-07-21T21:51:26.972187Z"
     }
    },
    "cell_type": "code",
@@ -4394,8 +4418,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:21.027548Z",
-     "start_time": "2026-07-21T19:23:20.662868Z"
+     "end_time": "2026-07-21T21:51:27.366845Z",
+     "start_time": "2026-07-21T21:51:27.008550Z"
     }
    },
    "cell_type": "code",
@@ -4432,8 +4456,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:21.072052Z",
-     "start_time": "2026-07-21T19:23:21.032815Z"
+     "end_time": "2026-07-21T21:51:27.392958Z",
+     "start_time": "2026-07-21T21:51:27.371246Z"
     }
    },
    "cell_type": "code",
@@ -4473,8 +4497,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:21.139277Z",
-     "start_time": "2026-07-21T19:23:21.074705Z"
+     "end_time": "2026-07-21T21:51:27.478034Z",
+     "start_time": "2026-07-21T21:51:27.436653Z"
     }
    },
    "cell_type": "code",
@@ -4510,8 +4534,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T19:23:21.186655Z",
-     "start_time": "2026-07-21T19:23:21.142397Z"
+     "end_time": "2026-07-21T21:51:27.508887Z",
+     "start_time": "2026-07-21T21:51:27.480243Z"
     }
    },
    "cell_type": "code",
@@ -4529,7 +4553,7 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "b376a4e0e82f433193d3f57257892712"
+       "model_id": "2a5e28e39c3f4403a97bce945ee5c0d1"
       }
      },
      "execution_count": 86,

--- a/src/flowrep/api/schemas.py
+++ b/src/flowrep/api/schemas.py
@@ -22,7 +22,6 @@ from flowrep.edge_models import OutputTarget as OutputTarget
 from flowrep.edge_models import SourceHandle as SourceHandle
 from flowrep.edge_models import TargetHandle as TargetHandle
 from flowrep.prospective.atomic_recipe import AtomicRecipe as AtomicRecipe
-from flowrep.prospective.atomic_recipe import UnpackMode as UnpackMode
 from flowrep.prospective.constant_recipe import JSONABLE as JSONABLE
 from flowrep.prospective.constant_recipe import ConstantRecipe as ConstantRecipe
 from flowrep.prospective.for_recipe import ForEachRecipe as ForEachRecipe

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -27,7 +27,6 @@ def atomic(
     func: str | None = None,
     /,
     *output_labels: str,
-    unpack_mode: atomic_recipe.UnpackMode = atomic_recipe.UnpackMode.TUPLE,
     version_scraping: versions.VersionScrapingMap | None = None,
     forbid_main: bool = False,
     forbid_locals: bool = False,
@@ -47,11 +46,10 @@ def atomic(func=None, /, *output_labels, **kwargs):
     Args:
         func: The function to decorate. Passed positionally by Python when the
             decorator is used without parentheses.
-        *output_labels: Explicit names for the node's output ports. When provided,
-            their count must match the number of outputs inferred from the function
-            and the chosen ``unpack_mode``.
-        unpack_mode: How to convert the function's return value into output ports.
-            See :class:`~flowrep.models.nodes.atomic_recipe.UnpackMode`.
+        *output_labels: Explicit names for the node's output ports. When a single value
+            is provided, forces the node to have a single output port (i.e. tuple
+            returns are provided _as_ tuples); when multiple are provided,
+            their count must match the number of outputs inferred from the function.
         version_scraping: Optional mapping from top-level package names to callables
             that return a version string, for packages that don't expose
             ``__version__``. Forwarded to
@@ -109,7 +107,6 @@ def _ensure_recipe_attribute_free(cls: type, context: str) -> None:
 def parse_atomic(
     func: types.FunctionType | type,
     *output_labels: str,
-    unpack_mode: atomic_recipe.UnpackMode = atomic_recipe.UnpackMode.TUPLE,
     version_scraping: versions.VersionScrapingMap | None = None,
     forbid_main: bool = False,
     forbid_locals: bool = False,
@@ -125,10 +122,11 @@ def parse_atomic(
 
     Args:
         func: The function to represent as an atomic node.
-        *output_labels: Explicit output port names. When provided, their count must
-            match the number of outputs inferred from the function and the chosen
-            ``unpack_mode``.
-        unpack_mode: How to convert the function's return value into output ports.
+        *output_labels: Explicit output port names. When absent, output ports are
+         inferred from available returns; when a single label is provided, exactly
+         one output port will be produced regardless of return values (i.e. returning
+         tuple returns _as_ a tuple); when multiple labels are provided, their count
+         is compared against the count scraped from the function itself.
         version_scraping: Optional version-scraping overrides, forwarded to
             :meth:`~pyiron_snippets.versions.VersionInfo.of`.
         forbid_main: If ``True``, raise if the function's module is ``__main__``.
@@ -159,14 +157,14 @@ def parse_atomic(
     scraped_output_labels = (
         ["instance"]
         if isinstance(func, type)
-        else _get_output_labels(func, unpack_mode)
+        else _get_output_labels(func, output_labels)
     )
     if len(output_labels) > 0 and len(output_labels) != len(scraped_output_labels):
         raise ValueError(
-            "Explicitly provided output labels must match the function analysis and "
-            f"unpack_mode: expected {len(scraped_output_labels)} labels for "
-            f"unpack_mode='{unpack_mode}', got {len(output_labels)} labels "
-            f"{output_labels}; inferred labels were {scraped_output_labels}."
+            "Explicitly provided output labels must match the function analysis;"
+            f"{output_labels} were explicitly passed, but {len(scraped_output_labels)} "
+            f"return values were identified and given scraped labels "
+            f"{scraped_output_labels}."
         )
 
     return atomic_recipe.AtomicRecipe(
@@ -180,21 +178,25 @@ def parse_atomic(
             list(output_labels) if len(output_labels) > 0 else scraped_output_labels
         ),
         description=docstring,
-        unpack_mode=unpack_mode,
     )
 
 
 def _get_output_labels(
-    func: types.FunctionType, unpack_mode: atomic_recipe.UnpackMode
+    func: types.FunctionType, output_labels: tuple[str, ...]
 ) -> list[str]:
-    if unpack_mode == atomic_recipe.UnpackMode.NONE:
-        return _parse_return_label_without_unpacking(func)
-    elif unpack_mode == atomic_recipe.UnpackMode.TUPLE:
+    n_explicit = len(output_labels)
+    if n_explicit == 0:
         return _parse_tuple_return_labels(func)
-    raise TypeError(
-        f"Invalid unpack mode: {unpack_mode}. Possible values are "
-        f"{', '.join(atomic_recipe.UnpackMode.__members__.values())}"
-    )
+    elif len(output_labels) == 1:
+        return _parse_return_label_without_unpacking(func)
+    else:  # 0 or >1 labels provided
+        scraped = _parse_tuple_return_labels(func)
+        if len(scraped) != n_explicit:
+            raise ValueError(
+                f"Expected {n_explicit} output labels to match the explict labels {output_labels}, but scraped {len(scraped)}: "
+                f"{output_labels}"
+            )
+        return scraped
 
 
 def _parse_return_label_without_unpacking(func: types.FunctionType) -> list[str]:
@@ -238,7 +240,8 @@ def _parse_tuple_return_labels(func: types.FunctionType) -> list[str]:
     )
 
     # Override with annotation-based labels where available
-    annotated = label_helpers.get_annotated_output_labels(func)
+    annotated = label_helpers.get_annotated_output_labels(func, len(scraped) > 1)
+
     return label_helpers.merge_labels(
         first_choice=annotated,
         fallback=scraped,

--- a/src/flowrep/parsers/atomic_parser.py
+++ b/src/flowrep/parsers/atomic_parser.py
@@ -201,7 +201,7 @@ def _get_output_labels(
 
 def _parse_return_label_without_unpacking(func: types.FunctionType) -> list[str]:
     """
-    Get output label for UnpackMode.NONE.
+    Get output label without breaking apart return tuples.
 
     Looks for annotation on the return type itself (not tuple elements).
     For `-> Annotated[T, {"label": "x"}]` or `-> Annotated[tuple[...], {"label": "x"}]`

--- a/src/flowrep/parsers/dataclass_parser.py
+++ b/src/flowrep/parsers/dataclass_parser.py
@@ -103,7 +103,6 @@ def _bind_inverse_recipe(
                 "dataclass": base_models.RestrictedParamKind.POSITIONAL_ONLY
             },
         ),
-        unpack_mode=atomic_recipe.UnpackMode.TUPLE,
     )
     setattr(cls, INVERSE_RECIPE_ATTR, reverse_recipe)
     return cls

--- a/src/flowrep/parsers/label_helpers.py
+++ b/src/flowrep/parsers/label_helpers.py
@@ -63,12 +63,14 @@ def extract_label_from_annotated(hint: Any) -> str | None:
     return None
 
 
-def get_annotated_output_labels(func: FunctionType) -> list[str | None] | None:
+def get_annotated_output_labels(
+    func: FunctionType, decompose_annotations: bool = True
+) -> list[str | None] | None:
     """
     Extract output labels from return type annotation using Annotated.
 
-    For TUPLE unpacking - looks at tuple element annotations.
-    Unwraps outer Annotated wrapper if present to get to tuple elements.
+    Unwraps outer Annotated wrapper if present to get to tuple elements when set to
+    ``decompose_annotation``.
 
     Supports:
         - Single: `-> Annotated[T, {"label": "name"}]`
@@ -90,7 +92,7 @@ def get_annotated_output_labels(func: FunctionType) -> list[str | None] | None:
     # Unwrap outer Annotated to get to the actual type (for TUPLE mode,
     # we care about element annotations, not the tuple-level annotation)
     inner_type = return_hint
-    if get_origin(return_hint) is Annotated:
+    if get_origin(return_hint) is Annotated and decompose_annotations:
         inner_type = get_args(return_hint)[0]
 
     origin = get_origin(inner_type)

--- a/src/flowrep/parsers/workflow_parser.py
+++ b/src/flowrep/parsers/workflow_parser.py
@@ -525,7 +525,9 @@ class _WorkflowFunctionParser(WorkflowParser):
 
         returned_symbols = parser_helpers.resolve_symbols_to_strings(body.value)
 
-        annotated_returns = label_helpers.get_annotated_output_labels(func)
+        annotated_returns = label_helpers.get_annotated_output_labels(
+            func, len(returned_symbols) > 1
+        )
         scraped_labels = label_helpers.merge_labels(
             first_choice=annotated_returns,
             fallback=returned_symbols,

--- a/src/flowrep/prospective/atomic_recipe.py
+++ b/src/flowrep/prospective/atomic_recipe.py
@@ -1,24 +1,11 @@
 from __future__ import annotations
 
-from enum import StrEnum
 from typing import Literal
 
 import pydantic
 from pyiron_snippets import retrieve
 
 from flowrep import base_models
-
-
-class UnpackMode(StrEnum):
-    """
-    How to handle return values from running functions in atomic nodes.
-
-    - NONE: Return the output as a single value
-    - TUPLE: Split return into one port per tuple element
-    """
-
-    NONE = "none"
-    TUPLE = "tuple"
 
 
 class AtomicRecipe(base_models.NodeRecipe):
@@ -34,14 +21,13 @@ class AtomicRecipe(base_models.NodeRecipe):
         inspection.
     - As with all nodes, their IO should be available for retrospective inspection.
     - The conversion of function return values to node outputs is controlled via the
-        `unpack_mode` flag.
+        the number of output labels.
 
     Attributes:
         type: The node type -- always "atomic".
         inputs: The available input port names.
         outputs: The available output port names.
         reference: Info about the underlying python function.
-        unpack_mode: How to handle return values from running functions in atomic nodes.
 
     Properties:
         fully_qualified_name: The fully qualified name of the function to call, i.e.
@@ -52,7 +38,6 @@ class AtomicRecipe(base_models.NodeRecipe):
         default=base_models.RecipeElementType.ATOMIC, frozen=True
     )
     reference: base_models.PythonReference
-    unpack_mode: UnpackMode = UnpackMode.TUPLE
 
     @property
     def inputs_with_defaults(self) -> base_models.Labels:
@@ -61,16 +46,6 @@ class AtomicRecipe(base_models.NodeRecipe):
     @property
     def fully_qualified_name(self) -> str:
         return self.reference.info.fully_qualified_name
-
-    @pydantic.model_validator(mode="after")
-    def check_outputs_when_not_unpacking(self):
-        if self.unpack_mode == UnpackMode.NONE and len(self.outputs) > 1:
-            raise ValueError(
-                f"Outputs must have exactly one element when unpacking is disabled. "
-                f"Got {len(self.outputs)} outputs with "
-                f"unpack_mode={self.unpack_mode.value}"
-            )
-        return self
 
     def __call__(self, *args, **kwargs):
         func = retrieve.import_from_string(self.reference.info.fully_qualified_name)

--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -137,7 +137,6 @@ class AtomicData(NodeData[atomic_recipe.AtomicRecipe]):
             recipe.reference.info.fully_qualified_name,
             recipe.inputs,
             recipe.outputs,
-            recipe.unpack_mode,
             allow_variadic_inputs=allow_variadic_inputs,
         )
         return AtomicData(
@@ -250,7 +249,6 @@ def _parse_function(
     fully_qualified_name: str,
     inputs: list[str],
     outputs: list[str],
-    unpack_mode: atomic_recipe.UnpackMode = atomic_recipe.UnpackMode.TUPLE,
     allow_variadic_inputs: bool = True,
 ) -> tuple[
     types.FunctionType,
@@ -316,7 +314,7 @@ def _parse_function(
 
     # --- output ports ---
     return_annotation = hints.get("return", None)
-    if unpack_mode == atomic_recipe.UnpackMode.NONE:
+    if len(outputs) == 1:
         output_ports = _parse_return_without_unpacking(return_annotation, outputs)
     else:
         output_ports = _parse_return_tuple(return_annotation, outputs)
@@ -365,8 +363,8 @@ def _parse_return_tuple(
 
         if return_annotation is not None:
             unpacking_hint = (
-                f"To collect the entire tuple in a single port use "
-                f"{atomic_recipe.UnpackMode.NONE} unpacking mode."
+                "To collect the entire tuple in a single port use a single, explicit "
+                "output label."
             )
 
             if origin is not tuple:

--- a/src/flowrep/std.py
+++ b/src/flowrep/std.py
@@ -8,265 +8,264 @@ from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 from flowrep.parsers import atomic_parser
-from flowrep.prospective import atomic_recipe
 
 
-@atomic_parser.atomic("absolute", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("absolute")
 def abs(a, /):
     return operator.abs(a)
 
 
-@atomic_parser.atomic("added", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("added")
 def add(a, b, /):
     return operator.add(a, b)
 
 
-@atomic_parser.atomic("index", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("index")
 def index(a, /):
     return operator.index(a)
 
 
-@atomic_parser.atomic("inverted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("inverted")
 def inv(a, /):
     return operator.inv(a)
 
 
-@atomic_parser.atomic("inverted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("inverted")
 def invert(a, /):
     return operator.invert(a)
 
 
-@atomic_parser.atomic("negative", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("negative")
 def neg(a, /):
     return operator.neg(a)
 
 
-@atomic_parser.atomic("positive", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("positive")
 def pos(a, /):
     return operator.pos(a)
 
 
-@atomic_parser.atomic("negated", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("negated")
 def not_(a, /):
     return operator.not_(a)
 
 
-@atomic_parser.atomic("truth", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("truth")
 def truth(a, /):
     return operator.truth(a)
 
 
-@atomic_parser.atomic("length", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("length")
 def length_hint(obj, /):
     return operator.length_hint(obj)
 
 
-@atomic_parser.atomic("difference", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("difference")
 def sub(a, b, /):
     return operator.sub(a, b)
 
 
-@atomic_parser.atomic("difference", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("difference")
 def isub(a, b, /):
     return operator.isub(a, b)
 
 
-@atomic_parser.atomic("added", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("added")
 def iadd(a, b, /):
     return operator.iadd(a, b)
 
 
-@atomic_parser.atomic("product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("product")
 def mul(a, b, /):
     return operator.mul(a, b)
 
 
-@atomic_parser.atomic("product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("product")
 def imul(a, b, /):
     return operator.imul(a, b)
 
 
-@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("quotient")
 def floordiv(a, b, /):
     return operator.floordiv(a, b)
 
 
-@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("quotient")
 def ifloordiv(a, b, /):
     return operator.ifloordiv(a, b)
 
 
-@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("quotient")
 def truediv(a, b, /):
     return operator.truediv(a, b)
 
 
-@atomic_parser.atomic("quotient", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("quotient")
 def itruediv(a, b, /):
     return operator.itruediv(a, b)
 
 
-@atomic_parser.atomic("remainder", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("remainder")
 def mod(a, b, /):
     return operator.mod(a, b)
 
 
-@atomic_parser.atomic("remainder", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("remainder")
 def imod(a, b, /):
     return operator.imod(a, b)
 
 
-@atomic_parser.atomic("power", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("power")
 def pow(a, b, /):
     return operator.pow(a, b)
 
 
-@atomic_parser.atomic("power", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("power")
 def ipow(a, b, /):
     return operator.ipow(a, b)
 
 
-@atomic_parser.atomic("conjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("conjunction")
 def and_(a, b, /):
     return operator.and_(a, b)
 
 
-@atomic_parser.atomic("conjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("conjunction")
 def iand(a, b, /):
     return operator.iand(a, b)
 
 
-@atomic_parser.atomic("disjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("disjunction")
 def or_(a, b, /):
     return operator.or_(a, b)
 
 
-@atomic_parser.atomic("disjunction", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("disjunction")
 def ior(a, b, /):
     return operator.ior(a, b)
 
 
-@atomic_parser.atomic("exclusive_or", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("exclusive_or")
 def xor(a, b, /):
     return operator.xor(a, b)
 
 
-@atomic_parser.atomic("exclusive_or", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("exclusive_or")
 def ixor(a, b, /):
     return operator.ixor(a, b)
 
 
-@atomic_parser.atomic("left_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("left_shifted")
 def lshift(a, b, /):
     return operator.lshift(a, b)
 
 
-@atomic_parser.atomic("left_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("left_shifted")
 def ilshift(a, b, /):
     return operator.ilshift(a, b)
 
 
-@atomic_parser.atomic("right_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("right_shifted")
 def rshift(a, b, /):
     return operator.rshift(a, b)
 
 
-@atomic_parser.atomic("right_shifted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("right_shifted")
 def irshift(a, b, /):
     return operator.irshift(a, b)
 
 
-@atomic_parser.atomic("matrix_product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("matrix_product")
 def matmul(a, b, /):
     return operator.matmul(a, b)
 
 
-@atomic_parser.atomic("matrix_product", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("matrix_product")
 def imatmul(a, b, /):
     return operator.imatmul(a, b)
 
 
-@atomic_parser.atomic("equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("equal")
 def eq(a, b, /):
     return operator.eq(a, b)
 
 
-@atomic_parser.atomic("not_equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("not_equal")
 def ne(a, b, /):
     return operator.ne(a, b)
 
 
-@atomic_parser.atomic("less", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("less")
 def lt(a, b, /):
     return operator.lt(a, b)
 
 
-@atomic_parser.atomic("less_equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("less_equal")
 def le(a, b, /):
     return operator.le(a, b)
 
 
-@atomic_parser.atomic("greater", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("greater")
 def gt(a, b, /):
     return operator.gt(a, b)
 
 
-@atomic_parser.atomic("greater_equal", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("greater_equal")
 def ge(a, b, /):
     return operator.ge(a, b)
 
 
-@atomic_parser.atomic("identical", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("identical")
 def is_(a, b, /):
     return operator.is_(a, b)
 
 
-@atomic_parser.atomic("not_identical", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("not_identical")
 def is_not(a, b, /):
     return operator.is_not(a, b)
 
 
-@atomic_parser.atomic("contains", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("contains")
 def contains(a, b, /):
     return operator.contains(a, b)
 
 
-@atomic_parser.atomic("count", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("count")
 def countOf(a, b, /):
     return operator.countOf(a, b)
 
 
-@atomic_parser.atomic("index", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("index")
 def indexOf(a, b, /):
     return operator.indexOf(a, b)
 
 
-@atomic_parser.atomic("concatenated", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("concatenated")
 def concat(a, b, /):
     return operator.concat(a, b)
 
 
-@atomic_parser.atomic("concatenated", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("concatenated")
 def iconcat(a, b, /):
     return operator.iconcat(a, b)
 
 
-@atomic_parser.atomic("item", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("item")
 def getitem(a, b, /):
     return operator.getitem(a, b)
 
 
-@atomic_parser.atomic("set", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("set")
 def setitem(a, b, c, /):
     return operator.setitem(a, b, c)
 
 
-@atomic_parser.atomic("deleted", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("deleted")
 def delitem(a, b, /):
     return operator.delitem(a, b)
 
 
-@atomic_parser.atomic("result", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("result")
 def call(
     obj: Callable,
     /,
@@ -279,7 +278,7 @@ def call(
     return obj(*args_, **kwargs_)
 
 
-@atomic_parser.atomic("attr", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("attr")
 def get_attr(obj: object, name: str, /):
     """
     getattr doesn't have an inspectable signature until python 3.13, so provide a

--- a/src/flowrep/wfms.py
+++ b/src/flowrep/wfms.py
@@ -116,15 +116,11 @@ def _store_atomic_outputs(node: datastructures.AtomicData, result: Any) -> None:
     assert isinstance(recipe, atomic_recipe.AtomicRecipe)
     output_names = list(node.output_ports.keys())
 
-    if recipe.unpack_mode == atomic_recipe.UnpackMode.NONE:
+    if len(output_names) == 1:
         node.output_ports[output_names[0]].value = result
-
     else:
-        if len(output_names) == 1:
-            node.output_ports[output_names[0]].value = result
-        else:
-            for name, val in zip(output_names, result, strict=True):
-                node.output_ports[name].value = val
+        for name, val in zip(output_names, result, strict=True):
+            node.output_ports[name].value = val
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/parsers/test_atomic_parser.py
+++ b/tests/unit/parsers/test_atomic_parser.py
@@ -91,21 +91,6 @@ class TestAtomicDecorator(unittest.TestCase):
             simple_func.flowrep_recipe, atomic_parser.parse_atomic(simple_func)
         )
 
-    def test_atomic_with_unpack_mode(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.NONE)
-        def func_no_unpack(x):
-            return x
-
-        self.assertEqual(
-            func_no_unpack.flowrep_recipe.unpack_mode, atomic_recipe.UnpackMode.NONE
-        )
-        self.assertEqual(
-            func_no_unpack.flowrep_recipe,
-            atomic_parser.parse_atomic(
-                func_no_unpack, unpack_mode=atomic_recipe.UnpackMode.NONE
-            ),
-        )
-
     def test_atomic_preserves_function_behavior(self):
         @atomic_parser.atomic
         def add(a, b):
@@ -133,19 +118,16 @@ class TestParseAtomic(unittest.TestCase):
         self.assertEqual(node.outputs, ["x", "y"])
         self.assertTrue(node.fully_qualified_name.endswith("my_func"))
 
-    def test_unpack_mode_none(self):
+    def test_single_explicit_label_for_tuple_return(self):
         def single_output(x):
             return x * 2, x + 1
 
-        node = atomic_parser.parse_atomic(
-            single_output, unpack_mode=atomic_recipe.UnpackMode.NONE
-        )
+        node = atomic_parser.parse_atomic(single_output, "single_label")
         self.assertEqual(
             node.outputs,
-            ["output_0"],
+            ["single_label"],
             msg="Return tuple should be condensed to a single output port",
         )
-        self.assertEqual(node.unpack_mode, atomic_recipe.UnpackMode.NONE)
 
     def test_parse_atomic_captures_docstring(self):
         def has_docstring(a, b):
@@ -293,13 +275,12 @@ class TestAtomicWithOutputLabels(unittest.TestCase):
         self.assertEqual(func.flowrep_recipe.outputs, ["a", "b"])
         self.assertEqual(func.flowrep_recipe.inputs, ["x", "y"])
 
-    def test_atomic_with_output_labels_and_unpack_mode(self):
-        @atomic_parser.atomic("result", unpack_mode=atomic_recipe.UnpackMode.NONE)
+    def test_atomic_with_single_output_gets_single_port(self):
+        @atomic_parser.atomic("result")
         def func(x):
             return x, x + 1
 
         self.assertEqual(func.flowrep_recipe.outputs, ["result"])
-        self.assertEqual(func.flowrep_recipe.unpack_mode, atomic_recipe.UnpackMode.NONE)
 
     def test_atomic_no_args_infers_labels(self):
         @atomic_parser.atomic
@@ -318,8 +299,8 @@ class TestAtomicWithOutputLabels(unittest.TestCase):
 
         self.assertEqual(func.flowrep_recipe.outputs, ["a", "b"])
 
-    def test_atomic_only_unpack_mode_infers_labels(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.TUPLE)
+    def test_no_explicit_labels_infers_labels(self):
+        @atomic_parser.atomic
         def func():
             x = 1
             y = 2
@@ -327,14 +308,13 @@ class TestAtomicWithOutputLabels(unittest.TestCase):
 
         self.assertEqual(func.flowrep_recipe.outputs, ["x", "y"])
 
-    def test_atomic_wrong_number_of_labels_raises(self):
-        with self.assertRaises(ValueError) as ctx:
+    def test_single_label_overrides(self):
 
-            @atomic_parser.atomic("only_one")
-            def func():
-                return 1, 2
+        @atomic_parser.atomic("only_one")
+        def func():
+            return 1, 2
 
-        self.assertIn("expected 2 labels", str(ctx.exception))
+        self.assertEqual(func.flowrep_recipe.outputs, ["only_one"])
 
     def test_atomic_with_three_labels(self):
         @atomic_parser.atomic("first", "second", "third")
@@ -345,7 +325,7 @@ class TestAtomicWithOutputLabels(unittest.TestCase):
 
 
 class TestParseAtomicWithOutputLabels(unittest.TestCase):
-    def test_explicit_labels_override_inferred(self):
+    def test_explicit_labels_matching_count(self):
         def func():
             x = 1
             y = 2
@@ -354,13 +334,11 @@ class TestParseAtomicWithOutputLabels(unittest.TestCase):
         node = atomic_parser.parse_atomic(func, "custom_x", "custom_y")
         self.assertEqual(node.outputs, ["custom_x", "custom_y"])
 
-    def test_explicit_labels_with_unpack_none(self):
+    def test_explicit_labels_single_label(self):
         def func():
             return 1, 2
 
-        node = atomic_parser.parse_atomic(
-            func, "single", unpack_mode=atomic_recipe.UnpackMode.NONE
-        )
+        node = atomic_parser.parse_atomic(func, "single")
         self.assertEqual(node.outputs, ["single"])
 
     def test_explicit_labels_mismatch_raises(self):
@@ -370,7 +348,8 @@ class TestParseAtomicWithOutputLabels(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             atomic_parser.parse_atomic(func, "only", "two")
 
-        self.assertIn("expected 3 labels", str(ctx.exception))
+        self.assertIn("2 output labels to match the explict labels", str(ctx.exception))
+        self.assertIn("but scraped 3", str(ctx.exception))
 
     def test_no_explicit_labels_falls_back_to_inferred(self):
         def func():
@@ -417,7 +396,7 @@ class TestAtomicVariadicRejection(unittest.TestCase):
             return args
 
         with self.assertRaises(ValueError) as ctx:
-            atomic_parser.parse_atomic(func, unpack_mode=atomic_recipe.UnpackMode.NONE)
+            atomic_parser.parse_atomic(func)
         self.assertIn("Variadic parameter kinds are not supported", str(ctx.exception))
         self.assertIn("args", str(ctx.exception))
 
@@ -426,7 +405,7 @@ class TestAtomicVariadicRejection(unittest.TestCase):
             return kwargs
 
         with self.assertRaises(ValueError) as ctx:
-            atomic_parser.parse_atomic(func, unpack_mode=atomic_recipe.UnpackMode.NONE)
+            atomic_parser.parse_atomic(func)
         self.assertIn("Variadic parameter kinds are not supported", str(ctx.exception))
         self.assertIn("kwargs", str(ctx.exception))
 
@@ -435,7 +414,7 @@ class TestAtomicVariadicRejection(unittest.TestCase):
             return a
 
         with self.assertRaises(ValueError) as ctx:
-            atomic_parser.parse_atomic(func, unpack_mode=atomic_recipe.UnpackMode.NONE)
+            atomic_parser.parse_atomic(func)
         self.assertIn("Variadic parameter kinds are not supported", str(ctx.exception))
         self.assertIn("args", str(ctx.exception))
 
@@ -459,19 +438,40 @@ class TestAtomicVariadicRejection(unittest.TestCase):
 
 
 class TestGetOutputLabels(unittest.TestCase):
-    def test_unpack_mode_none(self):
-        def func():
-            return 42
+    @classmethod
+    def setUpClass(cls):
+        def func(x, y):
+            return x, 42
 
-        labels = atomic_parser._get_output_labels(func, atomic_recipe.UnpackMode.NONE)
-        self.assertEqual(labels, ["output_0"])
+        cls.func = staticmethod(func)
 
-    def test_invalid_unpack_mode(self):
-        def func():
-            pass
+    def test_without_provided_labels(self):
+        labels = atomic_parser._get_output_labels(self.func, [])
+        self.assertEqual(
+            labels,
+            ["x", "output_1"],
+            msg="Without labels, default to parsing each return value as a port",
+        )
 
-        with self.assertRaises(TypeError):
-            atomic_parser._get_output_labels(func, "invalid")
+    def test_with_single_provided_label(self):
+        labels = atomic_parser._get_output_labels(self.func, ["single_output"])
+        self.assertEqual(
+            labels,
+            ["output_0"],
+            msg="With a single explicit output, all scraped outputs should get lumped together into a single output (with the default name since we can't get a nice name for a tuple here)",
+        )
+
+    def test_matching_provided_labels(self):
+        labels = atomic_parser._get_output_labels(self.func, ["o1", "o2"])
+        self.assertEqual(
+            labels,
+            ["x", "output_1"],
+            msg="With multiple and matching explicit labels, the scraper should find a label for each return",
+        )
+
+    def test_mismatching_provided_labels(self):
+        with self.assertRaises(ValueError):
+            atomic_parser._get_output_labels(self.func, ["o1", "o2", "o3"])
 
 
 class TestParseTupleReturnLabels(unittest.TestCase):
@@ -776,21 +776,22 @@ class TestAtomicWithAnnotations(unittest.TestCase):
         self.assertEqual(func.flowrep_recipe.outputs, ["override1", "override2"])
 
     def test_unpack_none_uses_single_annotation(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.NONE)
+        @atomic_parser.atomic
         def func(x) -> Annotated[float, {"label": "single_result"}]:
             return x
 
         self.assertEqual(func.flowrep_recipe.outputs, ["single_result"])
 
-    def test_unpack_none_uses_tuple_level_annotation(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.NONE)
+    def test_singe_return_uses_tuple_level_annotation(self):
+        @atomic_parser.atomic
         def func(x) -> Annotated[tuple[float, str], {"label": "combined"}]:
-            return x, "y"
+            t = tuple(x, "y")
+            return t
 
         self.assertEqual(func.flowrep_recipe.outputs, ["combined"])
 
-    def test_unpack_none_ignores_element_annotations(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.NONE)
+    def test_forcing_single_output_ignores_element_annotations(self):
+        @atomic_parser.atomic("single_label")
         def func(
             x,
         ) -> tuple[
@@ -799,10 +800,10 @@ class TestAtomicWithAnnotations(unittest.TestCase):
         ]:
             return x, "y"
 
-        self.assertEqual(func.flowrep_recipe.outputs, ["output_0"])
+        self.assertEqual(func.flowrep_recipe.outputs, ["single_label"])
 
-    def test_unpack_none_tuple_with_both_annotations(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.NONE)
+    def test_annotation_label_overwhelmed_by_return_count(self):
+        @atomic_parser.atomic
         def func(
             x,
         ) -> Annotated[
@@ -814,10 +815,10 @@ class TestAtomicWithAnnotations(unittest.TestCase):
         ]:
             return x, "y"
 
-        self.assertEqual(func.flowrep_recipe.outputs, ["the_pair"])
+        self.assertEqual(func.flowrep_recipe.outputs, ["element_a", "element_b"])
 
-    def test_unpack_tuple_with_both_annotations(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.TUPLE)
+    def test_scraping_output_labels_from_nested_annotation(self):
+        @atomic_parser.atomic
         def func(
             x,
         ) -> Annotated[
@@ -830,13 +831,6 @@ class TestAtomicWithAnnotations(unittest.TestCase):
             return x, "y"
 
         self.assertEqual(func.flowrep_recipe.outputs, ["element_a", "element_b"])
-
-    def test_unpack_none_no_annotation_falls_back(self):
-        @atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.NONE)
-        def func(x):
-            return x
-
-        self.assertEqual(func.flowrep_recipe.outputs, ["output_0"])
 
     def test_annotation_with_extra_keys_for_other_packages(self):
         """Simulates semantikon-style annotations with extra metadata."""
@@ -989,9 +983,7 @@ class TestParseAtomicHasDefault(unittest.TestCase):
         def func():
             return 42
 
-        node = atomic_parser.parse_atomic(
-            func, unpack_mode=atomic_recipe.UnpackMode.NONE
-        )
+        node = atomic_parser.parse_atomic(func)
         self.assertEqual(node.reference.inputs_with_defaults, [])
 
     def test_decorator_preserves_inputs_with_defaults(self):

--- a/tests/unit/parsers/test_dataclass_parser.py
+++ b/tests/unit/parsers/test_dataclass_parser.py
@@ -131,7 +131,6 @@ class TestInverseRecipeStructure(unittest.TestCase):
         self.assertIsInstance(recipe, atomic_recipe.AtomicRecipe)
         self.assertEqual(recipe.inputs, ["dataclass"])
         self.assertEqual(recipe.outputs, ["foo", "bar"])
-        self.assertIs(recipe.unpack_mode, atomic_recipe.UnpackMode.TUPLE)
         self.assertEqual(
             recipe.reference.restricted_input_kinds,
             {"dataclass": base_models.RestrictedParamKind.POSITIONAL_ONLY},

--- a/tests/unit/parsers/test_for_parser.py
+++ b/tests/unit/parsers/test_for_parser.py
@@ -13,7 +13,6 @@ import unittest
 from flowrep import edge_models, std
 from flowrep.parsers import atomic_parser, for_parser, symbol_scope, workflow_parser
 from flowrep.prospective import (
-    atomic_recipe,
     for_recipe,
     if_recipe,
     try_recipe,
@@ -29,12 +28,12 @@ from flowrep_static import library
 # ---------------------------------------------------------------------------
 
 
-@atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("tuple_return")
 def pair(a, b):
     return a, b
 
 
-@atomic_parser.atomic(unpack_mode=atomic_recipe.UnpackMode.TUPLE)
+@atomic_parser.atomic
 def split(a, b):
     return a, b
 

--- a/tests/unit/parsers/test_symbol_scope.py
+++ b/tests/unit/parsers/test_symbol_scope.py
@@ -26,7 +26,6 @@ def _make_labeled_node(label: str, outputs: list[str]) -> helper_models.LabeledR
             ),
             inputs=["x"],
             outputs=outputs,
-            unpack_mode="tuple",
         ),
     )
 

--- a/tests/unit/parsers/test_workflow_parser.py
+++ b/tests/unit/parsers/test_workflow_parser.py
@@ -61,7 +61,7 @@ def annotated_operation(
     return x + y, x - y
 
 
-@atomic_parser.atomic("aggregate_result", unpack_mode=atomic_recipe.UnpackMode.NONE)
+@atomic_parser.atomic("aggregate_result")
 def tuple_operation(x: float, y: float) -> tuple[float, float]:
     return x + y, x - y
 

--- a/tests/unit/prospective/test_atomic_recipe.py
+++ b/tests/unit/prospective/test_atomic_recipe.py
@@ -67,90 +67,6 @@ class TestAtomicRecipeSource(unittest.TestCase):
         self.assertIsNone(node.reference.info.version)
 
 
-class TestAtomicRecipeUnpackMode(unittest.TestCase):
-    """Tests for unpack_mode validation."""
-
-    def test_default_unpack_mode_is_tuple(self):
-        node = atomic_recipe.AtomicRecipe(
-            reference=makers.make_reference(),
-            inputs=[],
-            outputs=["a", "b"],
-        )
-        self.assertEqual(node.unpack_mode, atomic_recipe.UnpackMode.TUPLE)
-
-    def test_tuple_mode_multiple_outputs(self):
-        node = atomic_recipe.AtomicRecipe(
-            reference=makers.make_reference(),
-            inputs=[],
-            outputs=["a", "b", "c"],
-            unpack_mode=atomic_recipe.UnpackMode.TUPLE,
-        )
-        self.assertEqual(len(node.outputs), 3)
-
-    def test_tuple_mode_zero_outputs(self):
-        node = atomic_recipe.AtomicRecipe(
-            reference=makers.make_reference(),
-            inputs=[],
-            outputs=[],
-            unpack_mode=atomic_recipe.UnpackMode.TUPLE,
-        )
-        self.assertEqual(len(node.outputs), 0)
-
-    def test_none_mode_single_output(self):
-        node = atomic_recipe.AtomicRecipe(
-            reference=makers.make_reference(),
-            inputs=[],
-            outputs=["result"],
-            unpack_mode=atomic_recipe.UnpackMode.NONE,
-        )
-        self.assertEqual(node.outputs, ["result"])
-
-    def test_none_mode_zero_outputs(self):
-        node = atomic_recipe.AtomicRecipe(
-            reference=makers.make_reference(),
-            inputs=[],
-            outputs=[],
-            unpack_mode=atomic_recipe.UnpackMode.NONE,
-        )
-        self.assertEqual(len(node.outputs), 0)
-
-    def test_none_mode_multiple_outputs_rejected(self):
-        with self.assertRaises(pydantic.ValidationError) as ctx:
-            atomic_recipe.AtomicRecipe(
-                reference=makers.make_reference(),
-                inputs=[],
-                outputs=["a", "b"],
-                unpack_mode=atomic_recipe.UnpackMode.NONE,
-            )
-        self.assertIn("exactly one element", str(ctx.exception))
-        self.assertIn(atomic_recipe.UnpackMode.NONE.value, str(ctx.exception))
-
-    def test_all_unpack_modes_accepted_as_string(self):
-        for mode in ["none", "tuple"]:
-            with self.subTest(mode=mode):
-                node = atomic_recipe.AtomicRecipe(
-                    reference=makers.make_reference(),
-                    inputs=[],
-                    outputs=["out"],
-                    unpack_mode=mode,
-                )
-                self.assertEqual(node.unpack_mode, mode)
-
-
-class TestUnpackModeEnum(unittest.TestCase):
-    """Tests for UnpackMode enum."""
-
-    def test_all_expected_values_exist(self):
-        expected = {"none", "tuple"}
-        actual = {e.value for e in atomic_recipe.UnpackMode}
-        self.assertEqual(expected, actual)
-
-    def test_is_str_enum(self):
-        for mode in atomic_recipe.UnpackMode:
-            self.assertIsInstance(mode, str)
-            self.assertEqual(mode, mode.value)
-
-
 class TestAtomicRecipeSerialization(unittest.TestCase):
     """Tests for serialization roundtrips."""
 
@@ -165,19 +81,6 @@ class TestAtomicRecipeSerialization(unittest.TestCase):
                 data = original.model_dump(mode=mode)
                 restored = atomic_recipe.AtomicRecipe.model_validate(data)
                 self.assertEqual(original, restored)
-
-    def test_roundtrip_with_unpack_mode(self):
-        for mode in atomic_recipe.UnpackMode:
-            with self.subTest(mode=mode):
-                original = atomic_recipe.AtomicRecipe(
-                    reference=makers.make_reference(),
-                    inputs=[],
-                    outputs=["out"],
-                    unpack_mode=mode,
-                )
-                data = original.model_dump(mode="json")
-                restored = atomic_recipe.AtomicRecipe.model_validate(data)
-                self.assertEqual(original.unpack_mode, restored.unpack_mode)
 
     def test_roundtrip_with_version(self):
         original = atomic_recipe.AtomicRecipe(
@@ -198,7 +101,6 @@ class TestAtomicRecipeSerialization(unittest.TestCase):
             reference=makers.make_reference("pkg.mod", "func", "2.0.0"),
             inputs=["x", "y"],
             outputs=["z"],
-            unpack_mode=atomic_recipe.UnpackMode.NONE,
         )
         data = node.model_dump(mode="json")
         self.assertEqual(data["type"], "atomic")
@@ -212,7 +114,6 @@ class TestAtomicRecipeSerialization(unittest.TestCase):
         )
         self.assertEqual(data["inputs"], ["x", "y"])
         self.assertEqual(data["outputs"], ["z"])
-        self.assertEqual(data["unpack_mode"], "none")
 
     def test_json_structure_version_null_when_absent(self):
         node = atomic_recipe.AtomicRecipe(

--- a/tests/unit/prospective/test_union_types.py
+++ b/tests/unit/prospective/test_union_types.py
@@ -138,7 +138,6 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                         qualname="check",
                                         inputs_with_defaults=["x"],
                                     ),
-                                    "unpack_mode": "tuple",
                                 },
                             },
                             "body": {
@@ -148,7 +147,6 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "inputs": ["x"],
                                     "outputs": ["y"],
                                     "reference": reference_dict(qualname="handle"),
-                                    "unpack_mode": "tuple",
                                 },
                             },
                             "condition_output": None,
@@ -178,7 +176,6 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                         qualname="check",
                                         inputs_with_defaults=["x"],
                                     ),
-                                    "unpack_mode": "tuple",
                                 },
                             },
                             "body": {
@@ -188,7 +185,6 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "inputs": ["x"],
                                     "outputs": ["y"],
                                     "reference": reference_dict(qualname="hanlde"),
-                                    "unpack_mode": "tuple",
                                 },
                             },
                             "condition_output": None,
@@ -203,7 +199,6 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             "inputs": ["x"],
                             "outputs": ["y"],
                             "reference": reference_dict(qualname="handle"),
-                            "unpack_mode": "tuple",
                         },
                     },
                 },
@@ -222,7 +217,6 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                             "inputs": ["x"],
                             "outputs": ["y"],
                             "reference": reference_dict(qualname="try_func"),
-                            "unpack_mode": "tuple",
                         },
                     },
                     "exception_cases": [
@@ -237,7 +231,6 @@ class TestDiscriminatedUnionRoundtrip(unittest.TestCase):
                                     "reference": reference_dict(
                                         qualname="handle_error"
                                     ),
-                                    "unpack_mode": "tuple",
                                 },
                             },
                         }

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -484,7 +484,6 @@ def _variadic_recipe(func, inputs, outputs=("result",)):
         reference=base_models.PythonReference(info=versions.VersionInfo.of(func)),
         inputs=list(inputs),
         outputs=list(outputs),
-        unpack_mode=atomic_recipe.UnpackMode.NONE,
     )
 
 
@@ -570,7 +569,6 @@ class TestAtomicFromRecipe(unittest.TestCase):
             inputs=["a", "b"],
             outputs=["result"],
             reference=library.divmod_func.flowrep_recipe.reference,
-            unpack_mode=atomic_recipe.UnpackMode.NONE,
         )
         node = datastructures.AtomicData.from_recipe(recipe)
         origin = get_origin(node.output_ports["result"].annotation)
@@ -580,7 +578,6 @@ class TestAtomicFromRecipe(unittest.TestCase):
         recipe = atomic_parser.parse_atomic(
             takes_positional_only,
             "dc",
-            unpack_mode=atomic_recipe.UnpackMode.NONE,
         )
         node = datastructures.AtomicData.from_recipe(recipe)
         self.assertIs(node.output_ports["dc"].annotation, SumClass)
@@ -886,7 +883,6 @@ class TestRunAtomic(unittest.TestCase):
             inputs=["a", "b"],
             outputs=["result"],
             reference=library.divmod_func.flowrep_recipe.reference,
-            unpack_mode=atomic_recipe.UnpackMode.NONE,
         )
         node = wfms.run_recipe(recipe, a=1, b=2)
         self.assertEqual(node.output_ports["result"].value, (0, 1))


### PR DESCRIPTION
This is API breaking, since it removes `flowrep.schemas.UnpackingMode`, removes the `unpacking_mode` field from existing serialized recipes, and removes `unpacking_mode` from the signature of some public-facing `parse_atomic` and `atomic` functions.

With `.DATACLASS` removed, the remaining `.NONE` and `.TUPLE` modes are redundant with whether the recipe specifies one or more `outputs`. This is just trimming the waste.

Closes #298 