### PR TITLE
Give a little shortcut on constant data

### DIFF
--- a/src/flowrep/retrospective/datastructures.py
+++ b/src/flowrep/retrospective/datastructures.py
@@ -173,6 +173,10 @@ class ConstantData(NodeData[constant_recipe.ConstantRecipe]):
             },
         )
 
+    @property
+    def value(self):
+        return self.output_ports[constant_recipe.ConstantRecipe.std_label].value
+
 
 @dataclasses.dataclass(frozen=False)
 class CompositeData(NodeData, Generic[RecipeType], abc.ABC):

--- a/tests/unit/test_retrospective_wfms.py
+++ b/tests/unit/test_retrospective_wfms.py
@@ -1499,6 +1499,14 @@ class TestWfMSConstants(unittest.TestCase):
         node = wfms.run_recipe(constant_recipe.ConstantRecipe(constant=7))
         self.assertEqual(node.output_ports["constant"].value, 7)
 
+    def test_shortcut(self):
+        recipe = constant_recipe.ConstantRecipe(constant=7)
+        data = datastructures.ConstantData.from_recipe(recipe)
+        self.assertEqual(
+            data.output_ports[constant_recipe.ConstantRecipe.std_label].value,
+            data.value,
+        )
+
     def test_end_to_end_kinetic_energy(self):
         recipe = workflow_parser.parse_workflow(_kinetic_energy)
         result = wfms.run_recipe(recipe, mass=2.0, velocity=3.0)


### PR DESCRIPTION
Just adding

```python
    @property
    def ConstantData.value(self):
        return self.output_ports[constant_recipe.ConstantRecipe.std_label].value
```

I'm not sure it's worth its very minimal weight yet, but there it is.